### PR TITLE
Preparing the IBM format for QASM 2.0 API (it still works with 1.1 API)

### DIFF
--- a/projectq/backends/_ibm/_ibm.py
+++ b/projectq/backends/_ibm/_ibm.py
@@ -67,7 +67,7 @@ class IBMBackend(BasicEngine):
 		if use_hardware:
 			self._device = 'real'
 		else:
-			self._device = 'sim_trivial'
+			self._device = 'sim_trivial_2'
 		self._num_runs = num_runs
 		self._verbose = verbose
 		self._user = user
@@ -166,6 +166,7 @@ class IBMBackend(BasicEngine):
 					gate['position'] = j
 					try:
 						gate['name'] = cmd.gate
+						gate['qasm'] = cmd.gate
 						if not cmd.ctrl is None:
 							gate['to'] = cmd.ctrl
 							cnot_qubit_id = i
@@ -209,8 +210,10 @@ class IBMBackend(BasicEngine):
 				for j in range(len(lines[i]['gates'])):
 					try:
 						name = lines[i]['gates'][j]['name']
+						qasm = lines[i]['gates'][j]['qasm']
 						gates += '{"position":' + str(j)
 						gates += ',"name":"' + name + '"'
+						gates += ',"qasm":"' + qasm + '"'
 						if name == "cx":
 							gates += ',"to":' + str(lines[i]['gates'][j]['to'])
 						gates += '},'

--- a/projectq/backends/_ibm/_ibm_http_client.py
+++ b/projectq/backends/_ibm/_ibm_http_client.py
@@ -27,7 +27,7 @@ class DeviceOfflineError(Exception):
 	pass
 
 
-def send(json_qasm, name, device='sim_trivial', user=None, password=None,
+def send(json_qasm, name, device='sim_trivial_2', user=None, password=None,
          shots=1, verbose=False):
 	"""
 	Sends json QASM through the IBM API and runs the quantum circuit represented
@@ -36,7 +36,7 @@ def send(json_qasm, name, device='sim_trivial', user=None, password=None,
 	Args:
 		json_qasm: JSON QASM representation of the circuit to run.
 		name (str): Name of the experiment.
-		device (str): 'sim_trivial' or 'real' to run on simulator or on the real
+		device (str): 'sim_trivial_2' or 'real' to run on simulator or on the real
 			chip, respectively.
 		user (str): IBM quantum experience user.
 		password (str): IBM quantum experience user password.

--- a/projectq/backends/_ibm/_ibm_test.py
+++ b/projectq/backends/_ibm/_ibm_test.py
@@ -71,7 +71,7 @@ def test_ibm_backend_functional_test(monkeypatch):
                                             toffoli2cnotandtgate,
                                             entangle,
                                             qft2crandhadamard)
-	correct_info = '{"playground":[{"line":0,"name":"q","gates":[{"position":0,"name":"h"},{"position":3,"name":"h"},{"position":4,"name":"measure"}]},{"line":1,"name":"q","gates":[{"position":0,"name":"h"},{"position":2,"name":"h"},{"position":3,"name":"measure"}]},{"line":2,"name":"q","gates":[{"position":1,"name":"cx","to":1},{"position":2,"name":"cx","to":0},{"position":3,"name":"h"},{"position":4,"name":"measure"}]},{"line":3,"name":"q","gates":[]},{"line":4,"name":"q","gates":[]}],"numberColumns":40,"numberLines":5,"numberGates":200,"hasMeasures":true,"topology":"250e969c6b9e68aa2a045ffbceb3ac33"}'
+	correct_info = '{"playground":[{"line":0,"name":"q","gates":[{"position":0,"name":"h","qasm":"h"},{"position":3,"name":"h","qasm":"h"},{"position":4,"name":"measure","qasm":"measure"}]},{"line":1,"name":"q","gates":[{"position":0,"name":"h","qasm":"h"},{"position":2,"name":"h","qasm":"h"},{"position":3,"name":"measure","qasm":"measure"}]},{"line":2,"name":"q","gates":[{"position":1,"name":"cx","qasm":"cx","to":1},{"position":2,"name":"cx","qasm":"cx","to":0},{"position":3,"name":"h","qasm":"h"},{"position":4,"name":"measure","qasm":"measure"}]},{"line":3,"name":"q","gates":[]},{"line":4,"name":"q","gates":[]}],"numberColumns":40,"numberLines":5,"numberGates":200,"hasMeasures":true,"topology":"250e969c6b9e68aa2a045ffbceb3ac33"}'
 	# patch send 
 	def mock_send(*args, **kwargs):
 		assert args[0] == correct_info


### PR DESCRIPTION
These changes would allow you to keep using the IBM connector when the QASM 2.0 API is deployed (coming soon).

It will still work with the current version of the API.