### PR TITLE
Convert .py indentation from tabs to spaces and remove trailing spaces

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -294,7 +294,7 @@ latex_documents = [
 #
 # latex_appendices = []
 
-# It false, will not define \strong, \code, 	itleref, \crossref ... but only
+# It false, will not define \strong, \code,     itleref, \crossref ... but only
 # \sphinxstrong, ..., \sphinxtitleref, ... To help avoid clash with user added
 # packages.
 #

--- a/examples/grover.py
+++ b/examples/grover.py
@@ -6,75 +6,75 @@ from projectq.meta import Loop, Compute, Uncompute, Control
 
 
 def run_grover(eng, n, oracle):
-	"""
-	Runs Grover's algorithm on n qubit using the provided quantum oracle.
-	
-	Args:
-		eng (MainEngine): Main compiler engine to run Grover on.
-		n (int): Number of bits in the solution.
-		oracle (function): Function accepting the engine, an n-qubit register, and
-			an output qubit which is flipped by the oracle for the correct bit-
-			string.
-	
-	Returns:
-		solution (list<int>): Solution bit-string.
-	"""
-	x = eng.allocate_qureg(n)
-	
-	# start in uniform superposition
-	All(H) | x
-	
-	# number of iterations we have to run:
-	num_it = int(math.pi/4.*math.sqrt(1 << n))
-	
-	# prepare the oracle output qubit (the one that is flipped to indicate the
-	# solution. start in state 1/sqrt(2) * (|0> - |1>) s.t. a bit-flip turns
-	# into a (-1)-phase.
-	oracle_out = eng.allocate_qubit()
-	X | oracle_out
-	H | oracle_out
-	
-	# run num_it iterations
-	with Loop(eng, num_it):
-		# oracle adds a (-1)-phase to the solution
-		oracle(eng, x, oracle_out)
-			
-		# reflection across uniform superposition
-		with Compute(eng):
-			All(H) | x
-			All(X) | x
-			
-		with Control(eng, x[0:-1]):
-			Z | x[-1]
-		
-		Uncompute(eng)
-	
-	Measure | x
-	Measure | oracle_out
-	
-	eng.flush()
-	# return result
-	return [int(qubit) for qubit in x]
+    """
+    Runs Grover's algorithm on n qubit using the provided quantum oracle.
+
+    Args:
+        eng (MainEngine): Main compiler engine to run Grover on.
+        n (int): Number of bits in the solution.
+        oracle (function): Function accepting the engine, an n-qubit register, and
+            an output qubit which is flipped by the oracle for the correct bit-
+            string.
+
+    Returns:
+        solution (list<int>): Solution bit-string.
+    """
+    x = eng.allocate_qureg(n)
+
+    # start in uniform superposition
+    All(H) | x
+
+    # number of iterations we have to run:
+    num_it = int(math.pi/4.*math.sqrt(1 << n))
+
+    # prepare the oracle output qubit (the one that is flipped to indicate the
+    # solution. start in state 1/sqrt(2) * (|0> - |1>) s.t. a bit-flip turns
+    # into a (-1)-phase.
+    oracle_out = eng.allocate_qubit()
+    X | oracle_out
+    H | oracle_out
+
+    # run num_it iterations
+    with Loop(eng, num_it):
+        # oracle adds a (-1)-phase to the solution
+        oracle(eng, x, oracle_out)
+
+        # reflection across uniform superposition
+        with Compute(eng):
+            All(H) | x
+            All(X) | x
+
+        with Control(eng, x[0:-1]):
+            Z | x[-1]
+
+        Uncompute(eng)
+
+    Measure | x
+    Measure | oracle_out
+
+    eng.flush()
+    # return result
+    return [int(qubit) for qubit in x]
 
 
 def alternating_bits_oracle(eng, qubits, output):
-	"""
-	Marks the solution string 1,0,1,0,...,0,1 by flipping the output qubit,
-	conditioned on qubits being equal to the alternating bit-string.
-	
-	Args:
-		eng (MainEngine): Main compiler engine the algorithm is being run on.
-		qubits (Qureg): n-qubit quantum register Grover search is run on.
-		output (Qubit): Output qubit to flip in order to indicate the solution.
-	"""
-	with Compute(eng):
-		All(X) | qubits[1::2]
-	with Control(eng, qubits):
-		X | output
-	Uncompute(eng)
+    """
+    Marks the solution string 1,0,1,0,...,0,1 by flipping the output qubit,
+    conditioned on qubits being equal to the alternating bit-string.
+
+    Args:
+        eng (MainEngine): Main compiler engine the algorithm is being run on.
+        qubits (Qureg): n-qubit quantum register Grover search is run on.
+        output (Qubit): Output qubit to flip in order to indicate the solution.
+    """
+    with Compute(eng):
+        All(X) | qubits[1::2]
+    with Control(eng, qubits):
+        X | output
+    Uncompute(eng)
 
 
 if __name__ == "__main__":
-	eng = MainEngine()  # use default compiler engine
-	# run Grover search to find a 7-bit solution
-	print(run_grover(eng, 7, alternating_bits_oracle))
+    eng = MainEngine()  # use default compiler engine
+    # run Grover search to find a 7-bit solution
+    print(run_grover(eng, 7, alternating_bits_oracle))

--- a/examples/ibm.py
+++ b/examples/ibm.py
@@ -4,39 +4,39 @@ from projectq import MainEngine
 
 
 def run_entangle(eng, num_qubits=5):
-	"""
-	Runs an entangling operation on the provided compiler engine.
-	
-	Args:
-		eng (MainEngine): Main compiler engine to use.
-		num_qubits (int): Number of qubits to entangle.
-	
-	Returns:
-		measurement (list<int>): List of measurement outcomes.
-	"""
-	# allocate the quantum register to entangle
-	qureg = eng.allocate_qureg(num_qubits)
-	
-	# entangle the qureg
-	Entangle | qureg
-	
-	# measure; should be all-0 or all-1
-	Measure | qureg
-	
-	# run the circuit
-	eng.flush()
-	
-	# access the probabilities via the back-end:
-	results = eng.backend.get_probabilities(qureg)
-	for state in results:
-		print("Measured {} with p = {}.".format(state, results[state]))
-	
-	# return one (random) measurement outcome.
-	return [int(q) for q in qureg]
+    """
+    Runs an entangling operation on the provided compiler engine.
+
+    Args:
+        eng (MainEngine): Main compiler engine to use.
+        num_qubits (int): Number of qubits to entangle.
+
+    Returns:
+        measurement (list<int>): List of measurement outcomes.
+    """
+    # allocate the quantum register to entangle
+    qureg = eng.allocate_qureg(num_qubits)
+
+    # entangle the qureg
+    Entangle | qureg
+
+    # measure; should be all-0 or all-1
+    Measure | qureg
+
+    # run the circuit
+    eng.flush()
+
+    # access the probabilities via the back-end:
+    results = eng.backend.get_probabilities(qureg)
+    for state in results:
+        print("Measured {} with p = {}.".format(state, results[state]))
+
+    # return one (random) measurement outcome.
+    return [int(q) for q in qureg]
 
 
 if __name__ == "__main__":
-	# create main compiler engine for the IBM back-end
-	eng = MainEngine(IBMBackend(use_hardware=True, num_runs=1024, verbose=False))
-	# run the circuit and print the result
-	print(run_entangle(eng))
+    # create main compiler engine for the IBM back-end
+    eng = MainEngine(IBMBackend(use_hardware=True, num_runs=1024, verbose=False))
+    # run the circuit and print the result
+    print(run_entangle(eng))

--- a/examples/shor.py
+++ b/examples/shor.py
@@ -27,119 +27,119 @@ from projectq.backends import Simulator, ResourceCounter
 
 
 def run_shor(eng, N, a, verbose=False):
-	"""
-	Runs the quantum subroutine of Shor's algorithm for factoring.
-	
-	Args:
-		eng (MainEngine): Main compiler engine to use.
-		N (int): Number to factor.
-		a (int): Relative prime to use as a base for a^x mod N.
-		verbose (bool): If True, display intermediate measurement results.
-	
-	Returns:
-		r (float): Potential period of a.
-	"""
-	n = int(math.ceil(math.log(N, 2)))
+    """
+    Runs the quantum subroutine of Shor's algorithm for factoring.
 
-	x = eng.allocate_qureg(n)
+    Args:
+        eng (MainEngine): Main compiler engine to use.
+        N (int): Number to factor.
+        a (int): Relative prime to use as a base for a^x mod N.
+        verbose (bool): If True, display intermediate measurement results.
 
-	X | x[0]
+    Returns:
+        r (float): Potential period of a.
+    """
+    n = int(math.ceil(math.log(N, 2)))
 
-	measurements = [0] * (2 * n)  # will hold the 2n measurement results
-	
-	ctrl_qubit = eng.allocate_qubit()
-	
-	for k in range(2 * n):
-		current_a = pow(a, 1 << (2 * n - 1 - k), N)
-		# one iteration of 1-qubit QPE
-		H | ctrl_qubit
-		with Control(eng, ctrl_qubit):
-			MultiplyByConstantModN(current_a, N) | x
-	
-		# perform inverse QFT --> Rotations conditioned on previous outcomes
-		for i in range(k):
-			if measurements[i]:
-				R(-math.pi/(1 << (k - i))) | ctrl_qubit
-		H | ctrl_qubit
-	
-		# and measure
-		Measure | ctrl_qubit
-		eng.flush()
-		measurements[k] = int(ctrl_qubit)
-		if measurements[k]:
-			X | ctrl_qubit
-		
-		if verbose:
-			print("\033[95m{}\033[0m".format(measurements[k]), end="")
-			sys.stdout.flush()
-	
-	Measure | x
-	# turn the measured values into a number in [0,1)
-	y = sum([(measurements[2 * n - 1 - i]*1. / (1 << (i + 1)))
-	         for i in range(2 * n)])
-	
-	# continued fraction expansion to get denominator (the period?)
-	r = Fraction(y).limit_denominator(N-1).denominator
-	
-	# return the (potential) period
-	return r
+    x = eng.allocate_qureg(n)
+
+    X | x[0]
+
+    measurements = [0] * (2 * n)  # will hold the 2n measurement results
+
+    ctrl_qubit = eng.allocate_qubit()
+
+    for k in range(2 * n):
+        current_a = pow(a, 1 << (2 * n - 1 - k), N)
+        # one iteration of 1-qubit QPE
+        H | ctrl_qubit
+        with Control(eng, ctrl_qubit):
+            MultiplyByConstantModN(current_a, N) | x
+
+        # perform inverse QFT --> Rotations conditioned on previous outcomes
+        for i in range(k):
+            if measurements[i]:
+                R(-math.pi/(1 << (k - i))) | ctrl_qubit
+        H | ctrl_qubit
+
+        # and measure
+        Measure | ctrl_qubit
+        eng.flush()
+        measurements[k] = int(ctrl_qubit)
+        if measurements[k]:
+            X | ctrl_qubit
+
+        if verbose:
+            print("\033[95m{}\033[0m".format(measurements[k]), end="")
+            sys.stdout.flush()
+
+    Measure | x
+    # turn the measured values into a number in [0,1)
+    y = sum([(measurements[2 * n - 1 - i]*1. / (1 << (i + 1)))
+             for i in range(2 * n)])
+
+    # continued fraction expansion to get denominator (the period?)
+    r = Fraction(y).limit_denominator(N-1).denominator
+
+    # return the (potential) period
+    return r
 
 
 # Filter function, which defines the gate set for the first optimization
 # (don't decompose QFTs and iQFTs to make cancellation easier)
 def high_level_gates(eng, cmd):
-	g = cmd.gate
-	if g == QFT or get_inverse(g) == QFT or g == Swap:
-		return True
-	if isinstance(g, BasicMathGate):
-		return False
-		if isinstance(g, AddConstant):
-			return True
-		elif isinstance(g, AddConstantModN):
-			return True
-		return False
-	return eng.next_engine.is_available(cmd)
+    g = cmd.gate
+    if g == QFT or get_inverse(g) == QFT or g == Swap:
+        return True
+    if isinstance(g, BasicMathGate):
+        return False
+        if isinstance(g, AddConstant):
+            return True
+        elif isinstance(g, AddConstantModN):
+            return True
+        return False
+    return eng.next_engine.is_available(cmd)
 
 
 if __name__ == "__main__":
-	# build compilation engine list
-	resource_counter = ResourceCounter()
-	compilerengines = [AutoReplacer(), InstructionFilter(high_level_gates),
-	                   TagRemover(), LocalOptimizer(3), AutoReplacer(),
-	                   TagRemover(), LocalOptimizer(3), resource_counter]
-	
-	# make the compiler and run the circuit on the simulator backend
-	eng = MainEngine(Simulator(), compilerengines)
-	
-	# print welcome message and ask the user for the number to factor
-	print("\n\t\033[37mprojectq\033[0m\n\t--------\n\tImplementation of Shor"
-	      "\'s algorithm.", end="")
-	N = int(input('\n\tNumber to factor: '))
-	print("\n\tFactoring N = {}: \033[0m".format(N), end="")
-	
-	# choose a base at random:
-	a = int(random.random()*N)
-	if not gcd(a, N) == 1:
-		print("\n\n\t\033[92mOoops, we were lucky: Chose non relative prime by "
-		      "accident :)")
-		print("\tFactor: {}\033[0m".format(gcd(a, N)))
-	else:
-		# run the quantum subroutine
-		r = run_shor(eng, N, a, True)
-	
-		# try to determine the factors
-		if r % 2 != 0:
-			r *= 2
-		apowrhalf = pow(a, r>>1, N)
-		f1 = gcd(apowrhalf+1, N)
-		f2 = gcd(apowrhalf-1, N)
-		if ((not f1 * f2 == N) and f1 * f2 > 1
-		    and int(1. * N / (f1 * f2)) * f1 * f2 == N):
-			f1, f2 = f1*f2, int(N/(f1*f2))
-		if f1 * f2 == N and f1 > 1 and f2 > 1:
-			print("\n\n\t\033[92mFactors found :-) : {} * {} = {}\033[0m"
-			       .format(f1, f2, N))
-		else:
-			print("\n\n\t\033[91mBad luck: Found {} and {}\033[0m".format(f1, f2))
-		
-		print(resource_counter)  # print resource usage
+    # build compilation engine list
+    resource_counter = ResourceCounter()
+    compilerengines = [AutoReplacer(), InstructionFilter(high_level_gates),
+                       TagRemover(), LocalOptimizer(3), AutoReplacer(),
+                       TagRemover(), LocalOptimizer(3), resource_counter]
+
+    # make the compiler and run the circuit on the simulator backend
+    eng = MainEngine(Simulator(), compilerengines)
+
+    # print welcome message and ask the user for the number to factor
+    print("\n\t\033[37mprojectq\033[0m\n\t--------\n\tImplementation of Shor"
+          "\'s algorithm.", end="")
+    N = int(input('\n\tNumber to factor: '))
+    print("\n\tFactoring N = {}: \033[0m".format(N), end="")
+
+    # choose a base at random:
+    a = int(random.random()*N)
+    if not gcd(a, N) == 1:
+        print("\n\n\t\033[92mOoops, we were lucky: Chose non relative prime by "
+              "accident :)")
+        print("\tFactor: {}\033[0m".format(gcd(a, N)))
+    else:
+        # run the quantum subroutine
+        r = run_shor(eng, N, a, True)
+
+        # try to determine the factors
+        if r % 2 != 0:
+            r *= 2
+        apowrhalf = pow(a, r>>1, N)
+        f1 = gcd(apowrhalf+1, N)
+        f2 = gcd(apowrhalf-1, N)
+        if ((not f1 * f2 == N) and f1 * f2 > 1
+            and int(1. * N / (f1 * f2)) * f1 * f2 == N):
+            f1, f2 = f1*f2, int(N/(f1*f2))
+        if f1 * f2 == N and f1 > 1 and f2 > 1:
+            print("\n\n\t\033[92mFactors found :-) : {} * {} = {}\033[0m"
+                   .format(f1, f2, N))
+        else:
+            print("\n\n\t\033[91mBad luck: Found {} and {}\033[0m".format(f1, f2))
+
+        print(resource_counter)  # print resource usage

--- a/examples/teleport.py
+++ b/examples/teleport.py
@@ -5,96 +5,96 @@ from projectq.meta import Dagger, Control
 
 
 def create_bell_pair(eng):
-	"""
-	Returns a Bell-pair (two qubits in state :math:`|A\rangle \otimes |B\rangle
-	 = \frac 1{\sqrt 2} \left( |0\rangle\otimes|0\rangle + |1\rangle\otimes|1
-	\rangle \right)`).
-	
-	Args:
-		eng (MainEngine): MainEngine from which to allocate the qubits.
-	
-	Returns:
-		bell_pair (tuple<Qubits>): The Bell-pair.
-	"""
-	b1 = eng.allocate_qubit()
-	b2 = eng.allocate_qubit()
-	
-	H | b1
-	CNOT | (b1, b2)
-	
-	return b1, b2
+    """
+    Returns a Bell-pair (two qubits in state :math:`|A\rangle \otimes |B\rangle
+     = \frac 1{\sqrt 2} \left( |0\rangle\otimes|0\rangle + |1\rangle\otimes|1
+    \rangle \right)`).
+
+    Args:
+        eng (MainEngine): MainEngine from which to allocate the qubits.
+
+    Returns:
+        bell_pair (tuple<Qubits>): The Bell-pair.
+    """
+    b1 = eng.allocate_qubit()
+    b2 = eng.allocate_qubit()
+
+    H | b1
+    CNOT | (b1, b2)
+
+    return b1, b2
 
 
 def run_teleport(eng, state_creation_function, verbose=False):
-	"""
-	Runs quantum teleportation on the provided main compiler engine.
-	
-	Creates a state from |0> using the state_creation_function, teleports this
-	state to Bob who then tries to uncompute his qubit using the inverse of the
-	state_creation_function. If successful, deleting the qubit won't raise an
-	error in the underlying Simulator back-end (else it will).
-	
-	Args:
-		eng (MainEngine): Main compiler engine to run the circuit on.
-		state_creation_function (function): Function which accepts the main
-			engine and a qubit in state |0>, which it then transforms to the state
-			that Alice would like to send to Bob.
-		verbose (bool): If True, info messages will be printed.
-	
-	"""
-	# make a Bell-pair
-	b1, b2 = create_bell_pair(eng)
-	
-	# Alice creates a nice state to send
-	psi = eng.allocate_qubit()
-	if verbose:
-		print("Alice is creating her state from scratch, i.e., |0>.")
-	state_creation_function(eng, psi)
+    """
+    Runs quantum teleportation on the provided main compiler engine.
 
-	# entangle it with Alice's b1
-	CNOT | (psi, b1)
-	if verbose:
-		print("Alice entangled her qubit with her share of the Bell-pair.")
+    Creates a state from |0> using the state_creation_function, teleports this
+    state to Bob who then tries to uncompute his qubit using the inverse of the
+    state_creation_function. If successful, deleting the qubit won't raise an
+    error in the underlying Simulator back-end (else it will).
 
-	# measure two values (once in Hadamard basis) and send the bits to Bob
-	H | psi
-	Measure | (psi, b1)
-	message_to_bob = [int(psi), int(b1)]
-	if verbose:
-		print("Alice is sending the message {} to Bob.".format(message_to_bob))
+    Args:
+        eng (MainEngine): Main compiler engine to run the circuit on.
+        state_creation_function (function): Function which accepts the main
+            engine and a qubit in state |0>, which it then transforms to the state
+            that Alice would like to send to Bob.
+        verbose (bool): If True, info messages will be printed.
 
-	# Bob may have to apply up to two operation depending on the message sent
-	# by Alice:
-	with Control(eng, b1):
-		X | b2
-	with Control(eng, psi):
-		Z | b2
+    """
+    # make a Bell-pair
+    b1, b2 = create_bell_pair(eng)
 
-	# try to uncompute the psi state
-	if verbose:
-		print("Bob is trying to uncompute the state.")
-	with Dagger(eng):
-		state_creation_function(eng, b2)
-	
-	# check whether the uncompute was successful. The simulator only allows to
-	# delete qubits which are in a computational basis state.
-	del b2
-	eng.flush()
-	
-	if verbose:
-		print("Bob successfully arrived at |0>")
+    # Alice creates a nice state to send
+    psi = eng.allocate_qubit()
+    if verbose:
+        print("Alice is creating her state from scratch, i.e., |0>.")
+    state_creation_function(eng, psi)
+
+    # entangle it with Alice's b1
+    CNOT | (psi, b1)
+    if verbose:
+        print("Alice entangled her qubit with her share of the Bell-pair.")
+
+    # measure two values (once in Hadamard basis) and send the bits to Bob
+    H | psi
+    Measure | (psi, b1)
+    message_to_bob = [int(psi), int(b1)]
+    if verbose:
+        print("Alice is sending the message {} to Bob.".format(message_to_bob))
+
+    # Bob may have to apply up to two operation depending on the message sent
+    # by Alice:
+    with Control(eng, b1):
+        X | b2
+    with Control(eng, psi):
+        Z | b2
+
+    # try to uncompute the psi state
+    if verbose:
+        print("Bob is trying to uncompute the state.")
+    with Dagger(eng):
+        state_creation_function(eng, b2)
+
+    # check whether the uncompute was successful. The simulator only allows to
+    # delete qubits which are in a computational basis state.
+    del b2
+    eng.flush()
+
+    if verbose:
+        print("Bob successfully arrived at |0>")
 
 
 if __name__ == "__main__":
-	# create a main compiler engine with a simulator backend:
-	eng = MainEngine()
-	
-	# define our state-creation routine, which transforms a |0> to the state
-	# we would like to send. Bob can then try to uncompute it and, if he arrives
-	# back at |0>, we know that the teleportation worked.
-	def create_state(eng, qb):
-		H | qb
-		Rz(1.21) | qb
-	
-	# run the teleport and then, let Bob try to uncompute his qubit:
-	run_teleport(eng, create_state, verbose=True)
+    # create a main compiler engine with a simulator backend:
+    eng = MainEngine()
+
+    # define our state-creation routine, which transforms a |0> to the state
+    # we would like to send. Bob can then try to uncompute it and, if he arrives
+    # back at |0>, we know that the teleportation worked.
+    def create_state(eng, qb):
+        H | qb
+        Rz(1.21) | qb
+
+    # run the teleport and then, let Bob try to uncompute his qubit:
+    run_teleport(eng, create_state, verbose=True)

--- a/examples/teleport_circuit.py
+++ b/examples/teleport_circuit.py
@@ -5,18 +5,18 @@ from projectq.backends import CircuitDrawer
 import teleport
 
 if __name__ == "__main__":
-	# create a main compiler engine with a simulator backend:
-	drawing_engine = CircuitDrawer()
-	locations = {0: 1, 1: 2, 2: 0}
-	drawing_engine.set_qubit_locations(locations)
-	eng = MainEngine(drawing_engine)
-	
-	# we just want to draw the teleportation circuit
-	def create_state(eng, qb):
-		pass
-	
-	# run the teleport and then, let Bob try to uncompute his qubit:
-	teleport.run_teleport(eng, create_state, verbose=False)
-	
-	# print latex code to draw the circuit:
-	print(drawing_engine.get_latex())
+    # create a main compiler engine with a simulator backend:
+    drawing_engine = CircuitDrawer()
+    locations = {0: 1, 1: 2, 2: 0}
+    drawing_engine.set_qubit_locations(locations)
+    eng = MainEngine(drawing_engine)
+
+    # we just want to draw the teleportation circuit
+    def create_state(eng, qb):
+        pass
+
+    # run the teleport and then, let Bob try to uncompute his qubit:
+    teleport.run_teleport(eng, create_state, verbose=False)
+
+    # print latex code to draw the circuit:
+    print(drawing_engine.get_latex())

--- a/projectq/__init__.py
+++ b/projectq/__init__.py
@@ -14,14 +14,14 @@
 ProjectQ - An open source software framework for quantum computing
 
 Get started:
-	Simply import the main compiler engine (from projectq import MainEngine)
-	together with your setup of choice (e.g., import projectq.setups.default)
-	and start coding!
-	
-	For examples, see the example folder, which features implementation of
-	a quantum random number generator, entanglement demonstration (simulation
-	or run on the IBM backend), Teleportation, Grover search, and
-	Shor's algorithm for factoring.
+    Simply import the main compiler engine (from projectq import MainEngine)
+    together with your setup of choice (e.g., import projectq.setups.default)
+    and start coding!
+
+    For examples, see the example folder, which features implementation of
+    a quantum random number generator, entanglement demonstration (simulation
+    or run on the IBM backend), Teleportation, Grover search, and
+    Shor's algorithm for factoring.
 """
 
 from ._version import __version__

--- a/projectq/backends/_circuits/_drawer.py
+++ b/projectq/backends/_circuits/_drawer.py
@@ -24,259 +24,259 @@ from projectq.meta import get_control_count
 from projectq.backends._circuits import to_latex
 
 class CircuitItem(object):
-	def __init__(self, gate, lines, ctrl_lines):
-		"""
-		Initialize a circuit item.
-		
-		Args:
-			gate: Gate object.
-			lines (list<int>): Circuit lines the gate acts on.
-			ctrl_lines (list<int>): Circuit lines which control the gate.
-		"""
-		self.gate = gate
-		self.lines = lines
-		self.ctrl_lines = ctrl_lines
-		self.id = -1
-	
-	def __eq__(self, other):
-		return (self.gate == other.gate and self.lines == other.lines
-		        and self.ctrl_lines == other.ctrl_lines) and self.id == other.id
-	
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __init__(self, gate, lines, ctrl_lines):
+        """
+        Initialize a circuit item.
+
+        Args:
+            gate: Gate object.
+            lines (list<int>): Circuit lines the gate acts on.
+            ctrl_lines (list<int>): Circuit lines which control the gate.
+        """
+        self.gate = gate
+        self.lines = lines
+        self.ctrl_lines = ctrl_lines
+        self.id = -1
+
+    def __eq__(self, other):
+        return (self.gate == other.gate and self.lines == other.lines
+                and self.ctrl_lines == other.ctrl_lines) and self.id == other.id
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class CircuitDrawer(BasicEngine):
-	"""
-	CircuitDrawer is a compiler engine which generates TikZ code for drawing
-	quantum circuits.
-	
-	The circuit can be modified by editing the settings.json file which is
-	generated upon first execution. This includes adjusting the gate width,
-	height, shadowing, line thickness, and many more options.
-	
-	After initializing the CircuitDrawer, it can also be given the mapping from
-	qubit IDs to wire location (via the :meth:`set_qubit_locations` function):
-	
-	.. code-block:: python
-	
-		circuit_backend = CircuitDrawer()
-		circuit_backend.set_qubit_locations({0: 1, 1: 0}) # swaps lines 0 and 1
-		eng = MainEngine(circuit_backend)
-		
-		... # run quantum algorithm on this main engine
-		
-		print(circuit_backend.get_latex()) # prints LaTeX code
-	
-	To see the qubit IDs in the generated circuit, simply set the `draw_id`
-	option in the settings.json file under "gates":"AllocateQubitGate" to True:
-	
-	.. code-block:: python
-		
-		"gates": {
-			"AllocateQubitGate": {
-				"draw_id": True,
-				"height": 0.15,
-				"width": 0.2,
-				"pre_offset": 0.1,
-				"offset": 0.1
-			},
-			...
-	
-	The settings.json file has the following structure:
-	
-	.. code-block:: python
-		
-		{
-			"control": { # settings for control "circle"
-					"shadow": false,
-					"size": 0.1
-			},
-			"gate_shadow": true, # enable/disable shadows for all gates
-			"gates": {
-					"GateClassString": {
-						GATE_PROPERTIES
-					}
-					"GateClassString2": {
-						...
-			},
-			"lines": { # settings for qubit lines
-					"double_classical": true, # draw double-lines for classical bits
-					"double_lines_sep": 0.04, # gap between the two lines for double lines
-					"init_quantum": true, # start out with quantum bits
-					"style": "very thin" # line style
-			}
-		}
-	
-	All gates (except for the ones requiring special treatment) support the
-	following properties:
-	
-	.. code-block:: python
-		
-		"GateClassString": {
-			"height": GATE_HEIGHT,
-			"width": GATE_WIDTH
-			"pre_offset": OFFSET_BEFORE_PLACEMENT,
-			"offset": OFFSET_AFTER_PLACEMENT,
-		},
-  
-	"""
-	def __init__(self, accept_input=False, default_measure=0):
-		"""
-		Initialize a circuit drawing engine.
-		
-		The TikZ code generator uses a settings file (settings.json), which can
-		be altered by the user. It contains gate widths, heights, offsets, etc.
-		
-		Args:
-			accept_input (bool): If accept_input is true, the printer queries the
-				user to input measurement results if the CircuitDrawer is the last
-				engine. Otherwise, all measurements yield the result default_measure
-				(0 or 1).
-			default_measure (bool): Default value to use as measurement results if
-				accept_input is False and there is no underlying backend to register
-				real measurement results.
-		"""
-		BasicEngine.__init__(self)
-		self._accept_input = accept_input
-		self._default_measure = default_measure
-		self._qubit_lines = dict()
-		self._free_lines = []
-		self._map = dict()
+    """
+    CircuitDrawer is a compiler engine which generates TikZ code for drawing
+    quantum circuits.
 
-	def is_available(self, cmd):
-		"""
-		Specialized implementation of is_available: Returns True if the
-		CircuitDrawer is the last engine (since it can print any command).
-		
-		Args:
-			cmd (Command): Command of which to check availability (all Commands can
-				be printed).
-		Returns:
-			availability (bool): True, unless the next engine cannot handle the
-			Command (if there is a next engine).
-		"""
-		try:
-			return BasicEngine.is_available(self, cmd)
-		except LastEngineException:
-			return True
-	
-	def set_qubit_locations(self, id_to_loc):
-		"""
-		Sets the qubit lines to use for the qubits explicitly.
-		
-		To figure out the qubit IDs, simply use the setting `draw_id` in the
-		settings file. It is located in "gates":"AllocateQubitGate".
-		If draw_id is True, the qubit IDs are drawn in red.
-		
-		Args:
-			id_to_loc (dict): Dictionary mapping qubit ids to qubit line numbers.
-		
-		Raises:
-			RuntimeError: If the mapping has already begun (this function needs be
-				called before any gates have been received).
-		"""
-		if len(self._map) > 0:
-			raise RuntimeError("set_qubit_locations() has to be called before "
-			                   "applying gates!")
-		
-		for k in range(min(id_to_loc),max(id_to_loc)+1):
-			if not k in id_to_loc:
-				raise RuntimeError("set_qubit_locations(): Invalid id_to_loc mapping"
-				                   "provided. All ids in the provided range of qubit "
-				                   "ids have to be mapped somewhere.")
-		self._map = id_to_loc
-	
-	def _print_cmd(self, cmd):
-		"""
-		Add the command cmd to the circuit diagram, taking care of potential
-		measurements as specified in the __init__ function.
-		
-		Queries the user for measurement input if a measurement command arrives
-		if accept_input was set to True. Otherwise, it uses the default_measure
-		parameter to register the measurement outcome.
-		
-		Args:
-			cmd (Command): Command to add to the circuit diagram.
-		"""
-		if cmd.gate == Allocate:
-			qubit_id = cmd.qubits[0][0].id
-			if not qubit_id in self._map:
-				self._map[qubit_id] = qubit_id
-			self._qubit_lines[qubit_id] = []
-		
-		if cmd.gate == Deallocate:
-			qubit_id = cmd.qubits[0][0].id
-			self._free_lines.append(qubit_id)
-		
-		if self.is_last_engine and cmd.gate == Measure:
-			assert(get_control_count(cmd) == 0)
-			for qureg in cmd.qubits:
-				for qubit in qureg:
-					if self._accept_input:
-						m = None
-						while m != '0' and m != '1' and m != 1 and m != 0:
-							prompt = ("Input measurement result (0 or 1) for qubit "
-							          + str(qubit) + ": ")
-							m = input(prompt)
-					else:
-						m = self._default_measure
-					m = int(m)
-					self.main_engine.set_measurement_result(qubit, m)
-					
-		all_lines = [qb.id for qr in cmd.all_qubits for qb in qr]
-		
-		gate = cmd.gate
-		lines = [qb.id for qr in cmd.qubits for qb in qr]
-		ctrl_lines = [qb.id for qb in cmd.control_qubits]
-		item = CircuitItem(gate, lines, ctrl_lines)
-		for l in all_lines:
-			self._qubit_lines[l].append(item)
-	
-	def get_latex(self):
-		"""
-		Return the latex document string representing the circuit.
-		
-		Simply write this string into a tex-file or, alternatively, pipe the
-		output directly to, e.g., pdflatex:
-		
-		.. code-block:: bash
-	
-			python3 my_circuit.py | pdflatex
-		
-		where my_circuit.py calls this function and prints it to the terminal.
-		"""
-		qubit_lines = dict()
-		
-		for line in range(len(self._qubit_lines)):
-			new_line = self._map[line]
-			qubit_lines[new_line] = []
-			for cmd in self._qubit_lines[line]:
-				lines = [self._map[qb_id] for qb_id in cmd.lines]
-				ctrl_lines = [self._map[qb_id] for qb_id in cmd.ctrl_lines]
-				gate = cmd.gate
-				new_cmd = CircuitItem(gate, lines, ctrl_lines)
-				if gate == Allocate:
-					new_cmd.id = cmd.lines[0]
-				qubit_lines[new_line].append(new_cmd)
-		
-		circuit = []
-		for lines in qubit_lines:
-			circuit.append(qubit_lines[lines])
-		return to_latex(qubit_lines)
-	
-	def receive(self, command_list):
-		"""
-		Receive a list of commands from the previous engine, print the commands,
-		and then send them on to the next engine.
-		
-		Args:
-			command_list (list<Command>): List of Commands to print (and potentially
-				send on to the next engine).
-		"""
-		for cmd in command_list:
-			if not cmd.gate == FlushGate():
-				self._print_cmd(cmd)
-			# (try to) send on
-			if not self.is_last_engine:
-				self.send([cmd])
+    The circuit can be modified by editing the settings.json file which is
+    generated upon first execution. This includes adjusting the gate width,
+    height, shadowing, line thickness, and many more options.
+
+    After initializing the CircuitDrawer, it can also be given the mapping from
+    qubit IDs to wire location (via the :meth:`set_qubit_locations` function):
+
+    .. code-block:: python
+
+        circuit_backend = CircuitDrawer()
+        circuit_backend.set_qubit_locations({0: 1, 1: 0}) # swaps lines 0 and 1
+        eng = MainEngine(circuit_backend)
+
+        ... # run quantum algorithm on this main engine
+
+        print(circuit_backend.get_latex()) # prints LaTeX code
+
+    To see the qubit IDs in the generated circuit, simply set the `draw_id`
+    option in the settings.json file under "gates":"AllocateQubitGate" to True:
+
+    .. code-block:: python
+
+        "gates": {
+            "AllocateQubitGate": {
+                "draw_id": True,
+                "height": 0.15,
+                "width": 0.2,
+                "pre_offset": 0.1,
+                "offset": 0.1
+            },
+            ...
+
+    The settings.json file has the following structure:
+
+    .. code-block:: python
+
+        {
+            "control": { # settings for control "circle"
+                    "shadow": false,
+                    "size": 0.1
+            },
+            "gate_shadow": true, # enable/disable shadows for all gates
+            "gates": {
+                    "GateClassString": {
+                        GATE_PROPERTIES
+                    }
+                    "GateClassString2": {
+                        ...
+            },
+            "lines": { # settings for qubit lines
+                    "double_classical": true, # draw double-lines for classical bits
+                    "double_lines_sep": 0.04, # gap between the two lines for double lines
+                    "init_quantum": true, # start out with quantum bits
+                    "style": "very thin" # line style
+            }
+        }
+
+    All gates (except for the ones requiring special treatment) support the
+    following properties:
+
+    .. code-block:: python
+
+        "GateClassString": {
+            "height": GATE_HEIGHT,
+            "width": GATE_WIDTH
+            "pre_offset": OFFSET_BEFORE_PLACEMENT,
+            "offset": OFFSET_AFTER_PLACEMENT,
+        },
+
+    """
+    def __init__(self, accept_input=False, default_measure=0):
+        """
+        Initialize a circuit drawing engine.
+
+        The TikZ code generator uses a settings file (settings.json), which can
+        be altered by the user. It contains gate widths, heights, offsets, etc.
+
+        Args:
+            accept_input (bool): If accept_input is true, the printer queries the
+                user to input measurement results if the CircuitDrawer is the last
+                engine. Otherwise, all measurements yield the result default_measure
+                (0 or 1).
+            default_measure (bool): Default value to use as measurement results if
+                accept_input is False and there is no underlying backend to register
+                real measurement results.
+        """
+        BasicEngine.__init__(self)
+        self._accept_input = accept_input
+        self._default_measure = default_measure
+        self._qubit_lines = dict()
+        self._free_lines = []
+        self._map = dict()
+
+    def is_available(self, cmd):
+        """
+        Specialized implementation of is_available: Returns True if the
+        CircuitDrawer is the last engine (since it can print any command).
+
+        Args:
+            cmd (Command): Command of which to check availability (all Commands can
+                be printed).
+        Returns:
+            availability (bool): True, unless the next engine cannot handle the
+            Command (if there is a next engine).
+        """
+        try:
+            return BasicEngine.is_available(self, cmd)
+        except LastEngineException:
+            return True
+
+    def set_qubit_locations(self, id_to_loc):
+        """
+        Sets the qubit lines to use for the qubits explicitly.
+
+        To figure out the qubit IDs, simply use the setting `draw_id` in the
+        settings file. It is located in "gates":"AllocateQubitGate".
+        If draw_id is True, the qubit IDs are drawn in red.
+
+        Args:
+            id_to_loc (dict): Dictionary mapping qubit ids to qubit line numbers.
+
+        Raises:
+            RuntimeError: If the mapping has already begun (this function needs be
+                called before any gates have been received).
+        """
+        if len(self._map) > 0:
+            raise RuntimeError("set_qubit_locations() has to be called before "
+                               "applying gates!")
+
+        for k in range(min(id_to_loc),max(id_to_loc)+1):
+            if not k in id_to_loc:
+                raise RuntimeError("set_qubit_locations(): Invalid id_to_loc mapping"
+                                   "provided. All ids in the provided range of qubit "
+                                   "ids have to be mapped somewhere.")
+        self._map = id_to_loc
+
+    def _print_cmd(self, cmd):
+        """
+        Add the command cmd to the circuit diagram, taking care of potential
+        measurements as specified in the __init__ function.
+
+        Queries the user for measurement input if a measurement command arrives
+        if accept_input was set to True. Otherwise, it uses the default_measure
+        parameter to register the measurement outcome.
+
+        Args:
+            cmd (Command): Command to add to the circuit diagram.
+        """
+        if cmd.gate == Allocate:
+            qubit_id = cmd.qubits[0][0].id
+            if not qubit_id in self._map:
+                self._map[qubit_id] = qubit_id
+            self._qubit_lines[qubit_id] = []
+
+        if cmd.gate == Deallocate:
+            qubit_id = cmd.qubits[0][0].id
+            self._free_lines.append(qubit_id)
+
+        if self.is_last_engine and cmd.gate == Measure:
+            assert(get_control_count(cmd) == 0)
+            for qureg in cmd.qubits:
+                for qubit in qureg:
+                    if self._accept_input:
+                        m = None
+                        while m != '0' and m != '1' and m != 1 and m != 0:
+                            prompt = ("Input measurement result (0 or 1) for qubit "
+                                      + str(qubit) + ": ")
+                            m = input(prompt)
+                    else:
+                        m = self._default_measure
+                    m = int(m)
+                    self.main_engine.set_measurement_result(qubit, m)
+
+        all_lines = [qb.id for qr in cmd.all_qubits for qb in qr]
+
+        gate = cmd.gate
+        lines = [qb.id for qr in cmd.qubits for qb in qr]
+        ctrl_lines = [qb.id for qb in cmd.control_qubits]
+        item = CircuitItem(gate, lines, ctrl_lines)
+        for l in all_lines:
+            self._qubit_lines[l].append(item)
+
+    def get_latex(self):
+        """
+        Return the latex document string representing the circuit.
+
+        Simply write this string into a tex-file or, alternatively, pipe the
+        output directly to, e.g., pdflatex:
+
+        .. code-block:: bash
+
+            python3 my_circuit.py | pdflatex
+
+        where my_circuit.py calls this function and prints it to the terminal.
+        """
+        qubit_lines = dict()
+
+        for line in range(len(self._qubit_lines)):
+            new_line = self._map[line]
+            qubit_lines[new_line] = []
+            for cmd in self._qubit_lines[line]:
+                lines = [self._map[qb_id] for qb_id in cmd.lines]
+                ctrl_lines = [self._map[qb_id] for qb_id in cmd.ctrl_lines]
+                gate = cmd.gate
+                new_cmd = CircuitItem(gate, lines, ctrl_lines)
+                if gate == Allocate:
+                    new_cmd.id = cmd.lines[0]
+                qubit_lines[new_line].append(new_cmd)
+
+        circuit = []
+        for lines in qubit_lines:
+            circuit.append(qubit_lines[lines])
+        return to_latex(qubit_lines)
+
+    def receive(self, command_list):
+        """
+        Receive a list of commands from the previous engine, print the commands,
+        and then send them on to the next engine.
+
+        Args:
+            command_list (list<Command>): List of Commands to print (and potentially
+                send on to the next engine).
+        """
+        for cmd in command_list:
+            if not cmd.gate == FlushGate():
+                self._print_cmd(cmd)
+            # (try to) send on
+            if not self.is_last_engine:
+                self.send([cmd])

--- a/projectq/backends/_circuits/_drawer_test.py
+++ b/projectq/backends/_circuits/_drawer_test.py
@@ -29,133 +29,133 @@ from projectq.backends._circuits._drawer import CircuitItem, CircuitDrawer
 
 
 def test_drawer_getlatex():
-	old_latex = _drawer.to_latex
-	_drawer.to_latex = lambda x: x
-	
-	drawer = CircuitDrawer()
-	drawer.set_qubit_locations({0: 1, 1: 0})
-	
-	drawer2 = CircuitDrawer()
-	
-	eng = MainEngine(drawer, [drawer2])
-	qureg = eng.allocate_qureg(2)
-	H | qureg[1]
-	H | qureg[0]
-	X | qureg[0]
-	CNOT | (qureg[0], qureg[1])
-	
-	lines = drawer2.get_latex()
-	assert len(lines) == 2
-	assert len(lines[0]) == 4
-	assert len(lines[1]) == 3
-	
-	# check if it was sent on correctly:
-	lines = drawer.get_latex()
-	assert len(lines) == 2
-	assert len(lines[0]) == 3
-	assert len(lines[1]) == 4
-	
-	_drawer.to_latex = old_latex
+    old_latex = _drawer.to_latex
+    _drawer.to_latex = lambda x: x
+
+    drawer = CircuitDrawer()
+    drawer.set_qubit_locations({0: 1, 1: 0})
+
+    drawer2 = CircuitDrawer()
+
+    eng = MainEngine(drawer, [drawer2])
+    qureg = eng.allocate_qureg(2)
+    H | qureg[1]
+    H | qureg[0]
+    X | qureg[0]
+    CNOT | (qureg[0], qureg[1])
+
+    lines = drawer2.get_latex()
+    assert len(lines) == 2
+    assert len(lines[0]) == 4
+    assert len(lines[1]) == 3
+
+    # check if it was sent on correctly:
+    lines = drawer.get_latex()
+    assert len(lines) == 2
+    assert len(lines[0]) == 3
+    assert len(lines[1]) == 4
+
+    _drawer.to_latex = old_latex
 
 
 def test_drawer_measurement():
-	drawer = CircuitDrawer(default_measure=0)
-	eng = MainEngine(drawer, [])
-	qubit = eng.allocate_qubit()
-	Measure | qubit
-	assert int(qubit) == 0
-	
-	drawer = CircuitDrawer(default_measure=1)
-	eng = MainEngine(drawer, [])
-	qubit = eng.allocate_qubit()
-	Measure | qubit
-	assert int(qubit) == 1
-	
-	drawer = CircuitDrawer(accept_input=True)
-	eng = MainEngine(drawer, [])
-	qubit = eng.allocate_qubit()
-	
-	old_input = _drawer.input
-	
-	_drawer.input = lambda x: '1'
-	Measure | qubit
-	assert int(qubit) == 1
-	_drawer.input = old_input
+    drawer = CircuitDrawer(default_measure=0)
+    eng = MainEngine(drawer, [])
+    qubit = eng.allocate_qubit()
+    Measure | qubit
+    assert int(qubit) == 0
+
+    drawer = CircuitDrawer(default_measure=1)
+    eng = MainEngine(drawer, [])
+    qubit = eng.allocate_qubit()
+    Measure | qubit
+    assert int(qubit) == 1
+
+    drawer = CircuitDrawer(accept_input=True)
+    eng = MainEngine(drawer, [])
+    qubit = eng.allocate_qubit()
+
+    old_input = _drawer.input
+
+    _drawer.input = lambda x: '1'
+    Measure | qubit
+    assert int(qubit) == 1
+    _drawer.input = old_input
 
 
 def test_drawer_qubitmapping():
-	drawer = CircuitDrawer()
-	# mapping should still work (no gate has been applied yet)
-	valid_mappings = [{0: 1, 1:0}, {2: 1, 1: 2}]
-	for valid_mapping in valid_mappings:
-		drawer.set_qubit_locations(valid_mapping)
-		drawer = CircuitDrawer()
-	
-	# invalid mapping should raise an error:
-	invalid_mappings = [{3: 1, 0: 2}, {0: 1, 2: 1}]
-	for invalid_mapping in invalid_mappings:
-		with pytest.raises(RuntimeError):
-			drawer.set_qubit_locations(invalid_mapping)
-			drawer = CircuitDrawer()
-	
-	eng = MainEngine(drawer, [])
-	qubit = eng.allocate_qubit()
-	# mapping has begun --> can't assign it anymore
-	with pytest.raises(RuntimeError):
-		drawer.set_qubit_locations({0: 1, 1: 0})
+    drawer = CircuitDrawer()
+    # mapping should still work (no gate has been applied yet)
+    valid_mappings = [{0: 1, 1:0}, {2: 1, 1: 2}]
+    for valid_mapping in valid_mappings:
+        drawer.set_qubit_locations(valid_mapping)
+        drawer = CircuitDrawer()
+
+    # invalid mapping should raise an error:
+    invalid_mappings = [{3: 1, 0: 2}, {0: 1, 2: 1}]
+    for invalid_mapping in invalid_mappings:
+        with pytest.raises(RuntimeError):
+            drawer.set_qubit_locations(invalid_mapping)
+            drawer = CircuitDrawer()
+
+    eng = MainEngine(drawer, [])
+    qubit = eng.allocate_qubit()
+    # mapping has begun --> can't assign it anymore
+    with pytest.raises(RuntimeError):
+        drawer.set_qubit_locations({0: 1, 1: 0})
 
 
 class MockEngine(object):
-	def is_available(self, cmd):
-		self.cmd = cmd
-		self.called = True
-		return False
+    def is_available(self, cmd):
+        self.cmd = cmd
+        self.called = True
+        return False
 
 
 def test_drawer_isavailable():
-	drawer = CircuitDrawer()
-	drawer.is_last_engine = True
-	
-	assert drawer.is_available(None)
-	assert drawer.is_available("Everything")
-	
-	mock_engine = MockEngine()
-	mock_engine.called = False
-	drawer.is_last_engine = False
-	drawer.next_engine = mock_engine
-	
-	assert not drawer.is_available(None)
-	assert mock_engine.called
-	assert mock_engine.cmd is None
+    drawer = CircuitDrawer()
+    drawer.is_last_engine = True
+
+    assert drawer.is_available(None)
+    assert drawer.is_available("Everything")
+
+    mock_engine = MockEngine()
+    mock_engine.called = False
+    drawer.is_last_engine = False
+    drawer.next_engine = mock_engine
+
+    assert not drawer.is_available(None)
+    assert mock_engine.called
+    assert mock_engine.cmd is None
 
 
 def test_drawer_circuititem():
-	circuit_item = CircuitItem(1, 2, 3)
-	assert circuit_item.gate == 1
-	assert circuit_item.lines == 2
-	assert circuit_item.ctrl_lines == 3
-	assert circuit_item.id == -1
-	
-	circuit_item2 = CircuitItem(1, 2, 2)
-	assert not circuit_item2 == circuit_item
-	assert circuit_item2 != circuit_item
-	
-	circuit_item2.ctrl_lines = 3
-	assert circuit_item2 == circuit_item
-	assert not circuit_item2 != circuit_item
-	
-	circuit_item2.gate = 2
-	assert not circuit_item2 == circuit_item
-	assert circuit_item2 != circuit_item
-	
-	circuit_item2.gate = 1
-	assert circuit_item2 == circuit_item
-	assert not circuit_item2 != circuit_item
-	
-	circuit_item2.lines = 1
-	assert not circuit_item2 == circuit_item
-	assert circuit_item2 != circuit_item
-	
-	circuit_item2.lines = 2
-	assert circuit_item2 == circuit_item
-	assert not circuit_item2 != circuit_item
+    circuit_item = CircuitItem(1, 2, 3)
+    assert circuit_item.gate == 1
+    assert circuit_item.lines == 2
+    assert circuit_item.ctrl_lines == 3
+    assert circuit_item.id == -1
+
+    circuit_item2 = CircuitItem(1, 2, 2)
+    assert not circuit_item2 == circuit_item
+    assert circuit_item2 != circuit_item
+
+    circuit_item2.ctrl_lines = 3
+    assert circuit_item2 == circuit_item
+    assert not circuit_item2 != circuit_item
+
+    circuit_item2.gate = 2
+    assert not circuit_item2 == circuit_item
+    assert circuit_item2 != circuit_item
+
+    circuit_item2.gate = 1
+    assert circuit_item2 == circuit_item
+    assert not circuit_item2 != circuit_item
+
+    circuit_item2.lines = 1
+    assert not circuit_item2 == circuit_item
+    assert circuit_item2 != circuit_item
+
+    circuit_item2.lines = 2
+    assert circuit_item2 == circuit_item
+    assert not circuit_item2 != circuit_item

--- a/projectq/backends/_circuits/_to_latex.py
+++ b/projectq/backends/_circuits/_to_latex.py
@@ -15,553 +15,553 @@ from projectq.ops import Measure, Allocate, Deallocate, X, Z
 
 
 def to_latex(circuit):
-	"""
-	Translates a given circuit to a TikZ picture in a Latex document.
-	
-	It uses a json-configuration file which (if it does not exist) is created
-	automatically upon running this function for the first time. The config file
-	can be used to determine custom gate sizes, offsets, etc.
-	
-	New gate options can be added under settings['gates'], using the gate class
-	name string as a key. Every gate can have its own width, height, pre-offset
-	and offset.
-	
-	Example:
-		.. code-block:: python
-		
-			settings['gates']['HGate'] = {'width': .5, 'offset': .15}
-	
-	The default settings can be acquired using the get_default_settings()
-	function, and written using write_settings().
-	
-	Args:
-		circuit (list<list<CircuitItem>>): Each qubit line is a list of
-			CircuitItem objects, i.e., in circuit[line].
-			
-	Returns:
-		tex_doc_str (string): Latex document string which can be compiled using,
-			e.g., pdflatex.
-	"""
-	try:
-		FileNotFoundError
-	except NameError:
-		FileNotFoundError = IOError  # for Python2 compatibility
-	
-	try:
-		with open('settings.json') as settings_file:
-			settings = json.load(settings_file)
-	except FileNotFoundError:
-		settings = write_settings(get_default_settings())
-	
-	text = _header(settings)
-	text += _body(circuit, settings)
-	text += _footer(settings)
-	return text
+    """
+    Translates a given circuit to a TikZ picture in a Latex document.
+
+    It uses a json-configuration file which (if it does not exist) is created
+    automatically upon running this function for the first time. The config file
+    can be used to determine custom gate sizes, offsets, etc.
+
+    New gate options can be added under settings['gates'], using the gate class
+    name string as a key. Every gate can have its own width, height, pre-offset
+    and offset.
+
+    Example:
+        .. code-block:: python
+
+            settings['gates']['HGate'] = {'width': .5, 'offset': .15}
+
+    The default settings can be acquired using the get_default_settings()
+    function, and written using write_settings().
+
+    Args:
+        circuit (list<list<CircuitItem>>): Each qubit line is a list of
+            CircuitItem objects, i.e., in circuit[line].
+
+    Returns:
+        tex_doc_str (string): Latex document string which can be compiled using,
+            e.g., pdflatex.
+    """
+    try:
+        FileNotFoundError
+    except NameError:
+        FileNotFoundError = IOError  # for Python2 compatibility
+
+    try:
+        with open('settings.json') as settings_file:
+            settings = json.load(settings_file)
+    except FileNotFoundError:
+        settings = write_settings(get_default_settings())
+
+    text = _header(settings)
+    text += _body(circuit, settings)
+    text += _footer(settings)
+    return text
 
 
 def write_settings(settings):
-	"""
-	Write all settings to a json-file.
-	
-	Args:
-		settings (dict): Settings dict to write.
-	"""
-	with open('settings.json', 'w') as settings_file:
-		json.dump(settings, settings_file, sort_keys=True, indent=4)
-	return settings
+    """
+    Write all settings to a json-file.
+
+    Args:
+        settings (dict): Settings dict to write.
+    """
+    with open('settings.json', 'w') as settings_file:
+        json.dump(settings, settings_file, sort_keys=True, indent=4)
+    return settings
 
 
 def get_default_settings():
-	"""
-	Return the default settings for the circuit drawing function to_latex().
-	
-	Returns:
-		settings (dict): Default circuit settings
-	"""
-	settings = dict()
-	settings['gate_shadow'] = True
-	settings['lines'] = ({'style': 'very thin', 'double_classical': True,
-	                      'init_quantum': True, 'double_lines_sep': .04})
-	settings['gates'] = ({'HGate': {'width': .5, 'offset': .3,
-	                                'pre_offset': .1},
-	                      'XGate': {'width': .35, 'height': .35, 'offset': .1},
-	                      'Rx': {'width': 1., 'height': .8, 'pre_offset': .2,
-	                             'offset': .3},
-	                      'Ry': {'width': 1., 'height': .8, 'pre_offset': .2,
-	                             'offset': .3},
-	                      'Rz': {'width': 1., 'height': .8, 'pre_offset': .2,
-	                             'offset': .3},
-	                      'EntangleGate': {'width': 1.8, 'offset': .2,
-	                                       'pre_offset': .2},
-	                      'DeallocateQubitGate': {'height': .15, 'offset': .2,
-	                                              'width': .2,
-	                                              'pre_offset': .1},
-	                      'AllocateQubitGate': {'height': .15, 'width': .2,
-	                                            'offset': .1, 'pre_offset': .1,
-	                                            'draw_id': False},
-	                      'MeasureGate': {'width': 0.75, 'offset': .2,
-	                                      'height': .5, 'pre_offset': .2}
-	                     })
-	settings['control'] = {'size': .1, 'shadow': False}
-	return settings
+    """
+    Return the default settings for the circuit drawing function to_latex().
+
+    Returns:
+        settings (dict): Default circuit settings
+    """
+    settings = dict()
+    settings['gate_shadow'] = True
+    settings['lines'] = ({'style': 'very thin', 'double_classical': True,
+                          'init_quantum': True, 'double_lines_sep': .04})
+    settings['gates'] = ({'HGate': {'width': .5, 'offset': .3,
+                                    'pre_offset': .1},
+                          'XGate': {'width': .35, 'height': .35, 'offset': .1},
+                          'Rx': {'width': 1., 'height': .8, 'pre_offset': .2,
+                                 'offset': .3},
+                          'Ry': {'width': 1., 'height': .8, 'pre_offset': .2,
+                                 'offset': .3},
+                          'Rz': {'width': 1., 'height': .8, 'pre_offset': .2,
+                                 'offset': .3},
+                          'EntangleGate': {'width': 1.8, 'offset': .2,
+                                           'pre_offset': .2},
+                          'DeallocateQubitGate': {'height': .15, 'offset': .2,
+                                                  'width': .2,
+                                                  'pre_offset': .1},
+                          'AllocateQubitGate': {'height': .15, 'width': .2,
+                                                'offset': .1, 'pre_offset': .1,
+                                                'draw_id': False},
+                          'MeasureGate': {'width': 0.75, 'offset': .2,
+                                          'height': .5, 'pre_offset': .2}
+                         })
+    settings['control'] = {'size': .1, 'shadow': False}
+    return settings
 
 
 def _header(settings):
-	"""
-	Writes the Latex header using the settings file.
-	
-	The header includes all packages and defines all tikz styles.
-	
-	Returns:
-		header (string): Header of the Latex document.
-	"""
-	packages = ("\\documentclass{standalone}\n\\usepackage[margin=1in]"
-	            "{geometry}\n\\usepackage[hang,small,bf]{caption}\n"
-	            "\\usepackage{tikz}\n"
-	            "\\usepackage{braket}\n\\usetikzlibrary{backgrounds,shadows."
-	            "blur,fit,decorations.pathreplacing,shapes}\n\n")
-	           
-	init = ("\\begin{document}\n"
-	        "\\begin{tikzpicture}[scale=0.8, transform shape]\n\n")
-	
-	gate_style = ("\\tikzstyle{basicshadow}=[blur shadow={shadow blur steps=8,"
-	              " shadow xshift=0.7pt, shadow yshift=-0.7pt, shadow scale="
-	              "1.02}]")
-	
-	if not (settings['gate_shadow'] or settings['control']['shadow']):
-		gate_style = ""
-	
-	gate_style += "\\tikzstyle{basic}=[draw,fill=white,"
-	if settings['gate_shadow']:
-		gate_style += "basicshadow"
-	gate_style += "]\n"
-	
-	gate_style += ("\\tikzstyle{operator}=[basic,minimum size=1.5em]\n"
-	               "\\tikzstyle{phase}=[fill=black,shape=circle," +
-	               "minimum size={}".format(settings['control']['size'])
-	               + "cm,inner sep=0pt,outer sep=0pt,draw=black"
-	              )
-	if settings['control']['shadow']:
-		gate_style += ",basicshadow"
-	gate_style += ("]\n\\tikzstyle{none}=[inner sep=0pt,outer sep=-.5pt,"
-	               "minimum height=0.5cm+1pt]\n"
-	              "\\tikzstyle{measure}=[operator,inner sep=0pt,minimum "
-	              + "height={}cm, minimum width={}cm]\n".format(
-	              settings['gates']['MeasureGate']['height'],
-	              settings['gates']['MeasureGate']['width']) +
-	              "\\tikzstyle{xstyle}=[circle,basic,minimum height=")
-	x_gate_radius = min(settings['gates']['XGate']['height'],
-	                    settings['gates']['XGate']['width'])
-	gate_style += ("{x_rad}cm,minimum width={x_rad}cm,inner sep=0pt,{linestyle}"
-	               "]\n"
-	              ).format(x_rad=x_gate_radius,
-	                       linestyle=settings['lines']['style'])
-	
-	edge_style = "\\tikzstyle{edgestyle}=[" + settings['lines']['style'] + "]\n"
-	
-	return packages + init + gate_style + edge_style
+    """
+    Writes the Latex header using the settings file.
+
+    The header includes all packages and defines all tikz styles.
+
+    Returns:
+        header (string): Header of the Latex document.
+    """
+    packages = ("\\documentclass{standalone}\n\\usepackage[margin=1in]"
+                "{geometry}\n\\usepackage[hang,small,bf]{caption}\n"
+                "\\usepackage{tikz}\n"
+                "\\usepackage{braket}\n\\usetikzlibrary{backgrounds,shadows."
+                "blur,fit,decorations.pathreplacing,shapes}\n\n")
+
+    init = ("\\begin{document}\n"
+            "\\begin{tikzpicture}[scale=0.8, transform shape]\n\n")
+
+    gate_style = ("\\tikzstyle{basicshadow}=[blur shadow={shadow blur steps=8,"
+                  " shadow xshift=0.7pt, shadow yshift=-0.7pt, shadow scale="
+                  "1.02}]")
+
+    if not (settings['gate_shadow'] or settings['control']['shadow']):
+        gate_style = ""
+
+    gate_style += "\\tikzstyle{basic}=[draw,fill=white,"
+    if settings['gate_shadow']:
+        gate_style += "basicshadow"
+    gate_style += "]\n"
+
+    gate_style += ("\\tikzstyle{operator}=[basic,minimum size=1.5em]\n"
+                   "\\tikzstyle{phase}=[fill=black,shape=circle," +
+                   "minimum size={}".format(settings['control']['size'])
+                   + "cm,inner sep=0pt,outer sep=0pt,draw=black"
+                  )
+    if settings['control']['shadow']:
+        gate_style += ",basicshadow"
+    gate_style += ("]\n\\tikzstyle{none}=[inner sep=0pt,outer sep=-.5pt,"
+                   "minimum height=0.5cm+1pt]\n"
+                  "\\tikzstyle{measure}=[operator,inner sep=0pt,minimum "
+                  + "height={}cm, minimum width={}cm]\n".format(
+                  settings['gates']['MeasureGate']['height'],
+                  settings['gates']['MeasureGate']['width']) +
+                  "\\tikzstyle{xstyle}=[circle,basic,minimum height=")
+    x_gate_radius = min(settings['gates']['XGate']['height'],
+                        settings['gates']['XGate']['width'])
+    gate_style += ("{x_rad}cm,minimum width={x_rad}cm,inner sep=0pt,{linestyle}"
+                   "]\n"
+                  ).format(x_rad=x_gate_radius,
+                           linestyle=settings['lines']['style'])
+
+    edge_style = "\\tikzstyle{edgestyle}=[" + settings['lines']['style'] + "]\n"
+
+    return packages + init + gate_style + edge_style
 
 
 def _body(circuit, settings):
-	"""
-	Return the body of the Latex document, including the entire circuit in
-	TikZ format.
-	
-	Args:
-		circuit (list<list<CircuitItem>>): Circuit to draw.
-		
-	Returns:
-		tex_str (string): Latex string to draw the entire circuit.
-	"""
-	code = []
-	
-	conv = _Circ2Tikz(settings, len(circuit))
-	for line in range(len(circuit)):
-		code.append(conv.to_tikz(line, circuit))
-	
-	return "".join(code)
+    """
+    Return the body of the Latex document, including the entire circuit in
+    TikZ format.
+
+    Args:
+        circuit (list<list<CircuitItem>>): Circuit to draw.
+
+    Returns:
+        tex_str (string): Latex string to draw the entire circuit.
+    """
+    code = []
+
+    conv = _Circ2Tikz(settings, len(circuit))
+    for line in range(len(circuit)):
+        code.append(conv.to_tikz(line, circuit))
+
+    return "".join(code)
 
 
 def _footer(settings):
-	"""
-	Return the footer of the Latex document.
-	
-	Returns:
-		tex_footer_str (string): Latex document footer.
-	"""
-	return "\n\n\end{tikzpicture}\n\end{document}"
+    """
+    Return the footer of the Latex document.
+
+    Returns:
+        tex_footer_str (string): Latex document footer.
+    """
+    return "\n\n\end{tikzpicture}\n\end{document}"
 
 
 class _Circ2Tikz(object):
-	"""
-	The Circ2Tikz class takes a circuit (list of lists of CircuitItem objects)
-	and turns them into Latex/TikZ code.
-	
-	It uses the settings dictionary for gate offsets, sizes, spacing, ...
-	"""
-	def __init__(self, settings, num_lines):
-		"""
-		Initialize a circuit to latex converter object.
-		
-		Args:
-			settings (dict): Dictionary of settings to use for the TikZ image.
-			num_lines (int): Number of qubit lines to use for the entire circuit.
-		"""
-		self.settings = settings
-		self.pos = [0.] * num_lines
-		self.op_count = [0] * num_lines
-		self.is_quantum = [settings['lines']['init_quantum']] * num_lines
-	
-	def to_tikz(self, line, circuit, end=None):
-		"""
-		Generate the TikZ code for one line of the circuit up to a certain gate.
-		
-		It modifies the circuit to include only the gates which have not been
-		drawn. It automatically switches to other lines if the gates on those
-		lines have to be drawn earlier.
-		
-		Args:
-			line (int): Line to generate the TikZ code for.
-			circuit (list<list<CircuitItem>>): The circuit to draw.
-			end (int): Gate index to stop at (for recursion).
-			
-		Returns:
-			tikz_code (string): TikZ code representing the current qubit line and,
-				if it was necessary to draw other lines, those lines as well.
-		"""
-		if end is None:
-			end = len(circuit[line])
-		
-		tikz_code = []
-		
-		cmds = circuit[line]
-		for i in range(0, end):
-			gate = cmds[i].gate
-			lines = cmds[i].lines
-			ctrl_lines = cmds[i].ctrl_lines
-			
-			all_lines = lines + ctrl_lines
-			all_lines.remove(line)  # remove current line
-			for l in all_lines:
-				gate_idx = 0
-				while not (circuit[l][gate_idx] == cmds[i]):
-					gate_idx += 1
-				
-				tikz_code.append(self.to_tikz(l, circuit, gate_idx))
-				# we are taking care of gate 0 (the current one)
-				circuit[l] = circuit[l][1:]
-			
-			all_lines = lines + ctrl_lines
-			pos = max([self.pos[l] for l in range(min(all_lines),max(all_lines)+1)])
-			for l in range(min(all_lines),max(all_lines)+1):
-				self.pos[l] = pos + self._gate_pre_offset(gate)
-			
-			connections = ""
-			for l in all_lines:
-				connections += self._line(self.op_count[l] - 1, self.op_count[l], line=l)
-			add_str = ""
-			if gate == X:
-				# draw NOT-gate with controls
-				add_str = self._x_gate(lines, ctrl_lines)
-				if (not self.is_quantum[lines[0]] and
-				    sum([self.is_quantum[i] for i in ctrl_lines]) > 0):
-				    self.is_quantum[lines[0]] = True
-			elif gate == Measure:
-				# draw measurement gate
-				for l in lines:
-					op = self._op(l)
-					width = self._gate_width(Measure)
-					height = self._gate_height(Measure)
-					shift0 = .07 * height
-					shift1 = .36 * height
-					shift2 = .1 * width
-					add_str += ("\n\\node[measure,edgestyle] ({op}) at ({pos},-{line})"
-					            " {{}};\n\\draw[edgestyle] ([yshift=-{shift1}cm,xshift="
-					            "{shift2}cm]{op}.west) to [out=60,in=180] ([yshift="
-					            "{shift0}cm]{op}.center) to [out=0, in=120] ([yshift=-"
-					            "{shift1}cm,xshift=-{shift2}cm]{op}.east);\n"
-					            "\\draw[edgestyle] ([yshift=-{shift1}cm]{op}.center) to"
-					            " ([yshift=-{shift2}cm,xshift=-{shift1}cm]{op}.north "
-					            "east);"
-					           ).format(op=op, pos=self.pos[l], line=l, shift0=shift0,
-					                    shift1=shift1, shift2=shift2)
-					self.op_count[l] += 1
-					self.pos[l] += self._gate_width(gate) + self._gate_offset(gate)
-					self.is_quantum[l] = False
-			elif gate == Allocate:
-				# draw 'begin line'
-				add_str = "\n\\node[none] ({}) at ({},-{}) {{$\Ket{{0}}{}$}};"
-				id_str = ""
-				if self.settings['gates']['AllocateQubitGate']['draw_id']:
-					id_str = "^{{\\textcolor{{red}}{{{}}}}}".format(cmds[i].id)
-				add_str = add_str.format(self._op(line), self.pos[line], line, id_str)
-				self.op_count[line] += 1
-				self.pos[line] += self._gate_offset(gate) + self._gate_width(gate)
-				self.is_quantum[line] = self.settings['lines']['init_quantum']
-			elif gate == Deallocate:
-				# draw 'end of line'
-				op = self._op(line)
-				add_str = "\n\\node[none] ({}) at ({},-{}) {{}};"
-				add_str = add_str.format(op, self.pos[line], line)
-				yshift = str(self._gate_height(gate)) + "cm]"
-				add_str += ("\n\\draw ([yshift={yshift}{op}.center) edge [edgestyle] "
-				            "([yshift=-{yshift}{op}.center);").format(op=op,
-				                                                      yshift=yshift)
-				self.op_count[line] += 1
-				self.pos[line] += self._gate_width(gate) + self._gate_offset(gate)
-			else:
-				add_str = self._regular_gate(gate, lines, ctrl_lines)
-				for l in lines:
-					self.is_quantum[l] = True
-			
-			tikz_code.append(add_str)
-			if not gate == Allocate:
-				tikz_code.append(connections)
+    """
+    The Circ2Tikz class takes a circuit (list of lists of CircuitItem objects)
+    and turns them into Latex/TikZ code.
 
-		circuit[line] = circuit[line][end:]
-		return "".join(tikz_code)
-	
-	def _gate_name(self, gate):
-		"""
-		Return the string representation of the gate.
-		
-		Tries to use gate.tex_str and, if that is not available, uses str(gate)
-		instead.
-		
-		Args:
-			gate: Gate object of which to get the name / latex representation.
-		
-		Returns:
-			gate_name (string): Latex gate name.
-		"""
-		try:
-			name = gate.tex_str()
-		except AttributeError:
-			name = str(gate)
-		return name
-	
-	def _x_gate(self, lines, ctrl_lines):
-		"""
-		Return the TikZ code for a NOT-gate.
-		
-		Args:
-			lines (list<int>): List of length 1 denoting the target qubit of the
-				NOT / X gate.
-			ctrl_lines (list<int>): List of qubit lines which act as controls.
-		
-		"""
-		assert(len(lines) == 1)  # NOT gate only acts on 1 qubit
-		line = lines[0]
-		delta_pos = self._gate_offset(X)
-		gate_width = self._gate_width(X)
-		op = self._op(line)
-		gate_str = ("\n\\node[xstyle] ({op}) at ({pos},-{line}) {{}};\n\\draw"
-		            "[edgestyle] ({op}.north)--({op}.south);\n\\draw[edgestyle] "
-		            "({op}.west)--({op}.east);").format(op=op, line=line,
-		                                                pos=self.pos[line])
-		
-		if len(ctrl_lines) > 0:
-			for ctrl in ctrl_lines:
-				gate_str += self._phase(ctrl, self.pos[line])
-				gate_str += self._line(ctrl, line)
-		
-		all_lines = ctrl_lines + [line]
-		new_pos = self.pos[line] + delta_pos + gate_width
-		for i in all_lines:
-			self.op_count[i] += 1
-		for i in range(min(all_lines), max(all_lines)+1):
-			self.pos[i] = new_pos
-		return gate_str
-	
-	def _gate_width(self, gate):
-		"""
-		Return the gate width, using the settings (if available).
-		
-		Returns:
-			gate_width (float): Width of the gate.
-				(settings['gates'][gate_class_name]['width'])
-		"""
-		try:
-			gate_width = self.settings['gates'][gate.__class__.__name__]['width']
-		except KeyError:
-			gate_width = .5
-		return gate_width
-	
-	def _gate_pre_offset(self, gate):
-		"""
-		Return the offset to use before placing this gate.
-		
-		Returns:
-			gate_pre_offset (float): Offset to use before the gate.
-				(settings['gates'][gate_class_name]['pre_offset'])
-		"""
-		try:
-			delta_pos = self.settings['gates'][gate.__class__.__name__]['pre_offset']
-		except KeyError:
-			delta_pos = self._gate_offset(gate)
-		return delta_pos
-		
-	def _gate_offset(self, gate):
-		"""
-		Return the offset to use after placing this gate and, if no pre_offset
-		is defined, the same offset is used in front of the gate.
-		
-		Returns:
-			gate_offset (float): Offset.
-				(settings['gates'][gate_class_name]['offset'])
-		"""
-		try:
-			delta_pos = self.settings['gates'][gate.__class__.__name__]['offset']
-		except KeyError:
-			delta_pos = .2
-		return delta_pos
-	
-	def _gate_height(self, gate):
-		"""
-		Return the height to use for this gate.
-		
-		Returns:
-			gate_height (float): Height of the gate.
-				(settings['gates'][gate_class_name]['height'])
-		"""
-		try:
-			height = self.settings['gates'][gate.__class__.__name__]['height']
-		except KeyError:
-			height = .5
-		return height
-		
-	def _phase(self, line, pos):
-		"""
-		Places a phase / control circle on a qubit line at a given position.
-		
-		Args:
-			line (int): Qubit line at which to place the circle.
-			pos (float): Position at which to place the circle.
-			
-		Returns:
-			tex_str (string): Latex string representing a control circle at the
-				given position.
-		"""
-		return "\n\\node[phase] ({}) at ({},-{}) {{}};".format(self._op(line),
-																													 pos, line)
-	
-	def _op(self, line, op=None, offset=0):
-		"""
-		Returns the gate name for placing a gate on a line.
-		
-		Args:
-			line (int): Line number.
-			op (int): Operation number or, by default, uses the current op count.
-		
-		Returns:
-			op_str (string): Gate name.
-		"""
-		if op is None:
-			op = self.op_count[line]
-		return "line{}_gate{}".format(line, op + offset)
-	
-	def _line(self, p1, p2, double=False, line=None):
-		"""
-		Connects p1 and p2, where p1 and p2 are either to qubit line indices, in
-		which case the two most recent gates are connected, or two gate indices,
-		in which case line denotes the line number and the two gates are connected
-		on the given line.
-		
-		Args:
-			p1 (int): Index of the first object to connect.
-			p2 (int): Index of the second object to connect.
-			double (bool): Draws double lines if True.
-			line (int or None): Line index - if provided, p1 and p2 are gate
-				indices.
-		
-		Returns:
-			tex_str (string): Latex code to draw this / these line(s).
-		"""
-		dbl_classical = self.settings['lines']['double_classical']
-		
-		if line is None:
-			quantum = not dbl_classical or self.is_quantum[p1]
-			op1, op2 = self._op(p1), self._op(p2)
-			loc1, loc2 = 'north', 'south'
-			shift = "xshift={}cm"
-		else:
-			quantum = not dbl_classical or self.is_quantum[line]
-			op1, op2 = self._op(line, p1), self._op(line, p2)
-			loc1, loc2 = 'west', 'east'
-			shift = "yshift={}cm"
-		
-		if quantum:
-			return "\n\\draw ({}) edge[edgestyle] ({});".format(op1, op2)
-		else:
-			if p2 > p1:
-				loc1, loc2 = loc2, loc1
-			edge_str = "\n\\draw ([{shift}]{op1}.{loc1}) edge[edgestyle] ([{shift}]{op2}.{loc2});"
-			shift1 = shift.format(self.settings['lines']['double_lines_sep'] / 2.)
-			shift2 = shift.format(-self.settings['lines']['double_lines_sep'] / 2.)
-			edges_str = edge_str.format(shift=shift1, op1=op1, op2=op2, loc1=loc1, loc2=loc2)
-			edges_str += edge_str.format(shift=shift2, op1=op1, op2=op2, loc1=loc1, loc2=loc2)
-			return edges_str
-	
-	def _regular_gate(self, gate, lines, ctrl_lines):
-		"""
-		Draw a regular gate.
-		
-		Args:
-			gate: Gate to draw.
-			lines (list<int>): Lines the gate acts on.
-			ctrl_lines (list<int>): Control lines.
-		
-		Returns:
-			tex_str (string): Latex string drawing a regular gate at the given
-				location
-		"""
-		imax = max(lines)
-		imin = min(lines)
-		
-		delta_pos = self._gate_offset(gate)
-		gate_width = self._gate_width(gate)
-		gate_height = self._gate_height(gate)
-		
-		name = self._gate_name(gate)
-		
-		lines = list(range(imin, imax+1))
-		
-		tex_str = ""
-		pos = self.pos[lines[0]]
-		
-		node_str = "\n\\node[none] ({}) at ({},-{}) {{}};"
-		for l in lines:
-			node1 = node_str.format(self._op(l), pos, l)
-			node2 = ("\n\\node[none,minimum height={}cm,outer sep=0] ({}) at ({},-{"
-			        "}) {{}};").format(gate_height, self._op(l, offset=1), pos +
-			                         gate_width/2., l)
-			node3 = node_str.format(self._op(l, offset=2),
+    It uses the settings dictionary for gate offsets, sizes, spacing, ...
+    """
+    def __init__(self, settings, num_lines):
+        """
+        Initialize a circuit to latex converter object.
+
+        Args:
+            settings (dict): Dictionary of settings to use for the TikZ image.
+            num_lines (int): Number of qubit lines to use for the entire circuit.
+        """
+        self.settings = settings
+        self.pos = [0.] * num_lines
+        self.op_count = [0] * num_lines
+        self.is_quantum = [settings['lines']['init_quantum']] * num_lines
+
+    def to_tikz(self, line, circuit, end=None):
+        """
+        Generate the TikZ code for one line of the circuit up to a certain gate.
+
+        It modifies the circuit to include only the gates which have not been
+        drawn. It automatically switches to other lines if the gates on those
+        lines have to be drawn earlier.
+
+        Args:
+            line (int): Line to generate the TikZ code for.
+            circuit (list<list<CircuitItem>>): The circuit to draw.
+            end (int): Gate index to stop at (for recursion).
+
+        Returns:
+            tikz_code (string): TikZ code representing the current qubit line and,
+                if it was necessary to draw other lines, those lines as well.
+        """
+        if end is None:
+            end = len(circuit[line])
+
+        tikz_code = []
+
+        cmds = circuit[line]
+        for i in range(0, end):
+            gate = cmds[i].gate
+            lines = cmds[i].lines
+            ctrl_lines = cmds[i].ctrl_lines
+
+            all_lines = lines + ctrl_lines
+            all_lines.remove(line)  # remove current line
+            for l in all_lines:
+                gate_idx = 0
+                while not (circuit[l][gate_idx] == cmds[i]):
+                    gate_idx += 1
+
+                tikz_code.append(self.to_tikz(l, circuit, gate_idx))
+                # we are taking care of gate 0 (the current one)
+                circuit[l] = circuit[l][1:]
+
+            all_lines = lines + ctrl_lines
+            pos = max([self.pos[l] for l in range(min(all_lines),max(all_lines)+1)])
+            for l in range(min(all_lines),max(all_lines)+1):
+                self.pos[l] = pos + self._gate_pre_offset(gate)
+
+            connections = ""
+            for l in all_lines:
+                connections += self._line(self.op_count[l] - 1, self.op_count[l], line=l)
+            add_str = ""
+            if gate == X:
+                # draw NOT-gate with controls
+                add_str = self._x_gate(lines, ctrl_lines)
+                if (not self.is_quantum[lines[0]] and
+                    sum([self.is_quantum[i] for i in ctrl_lines]) > 0):
+                    self.is_quantum[lines[0]] = True
+            elif gate == Measure:
+                # draw measurement gate
+                for l in lines:
+                    op = self._op(l)
+                    width = self._gate_width(Measure)
+                    height = self._gate_height(Measure)
+                    shift0 = .07 * height
+                    shift1 = .36 * height
+                    shift2 = .1 * width
+                    add_str += ("\n\\node[measure,edgestyle] ({op}) at ({pos},-{line})"
+                                " {{}};\n\\draw[edgestyle] ([yshift=-{shift1}cm,xshift="
+                                "{shift2}cm]{op}.west) to [out=60,in=180] ([yshift="
+                                "{shift0}cm]{op}.center) to [out=0, in=120] ([yshift=-"
+                                "{shift1}cm,xshift=-{shift2}cm]{op}.east);\n"
+                                "\\draw[edgestyle] ([yshift=-{shift1}cm]{op}.center) to"
+                                " ([yshift=-{shift2}cm,xshift=-{shift1}cm]{op}.north "
+                                "east);"
+                               ).format(op=op, pos=self.pos[l], line=l, shift0=shift0,
+                                        shift1=shift1, shift2=shift2)
+                    self.op_count[l] += 1
+                    self.pos[l] += self._gate_width(gate) + self._gate_offset(gate)
+                    self.is_quantum[l] = False
+            elif gate == Allocate:
+                # draw 'begin line'
+                add_str = "\n\\node[none] ({}) at ({},-{}) {{$\Ket{{0}}{}$}};"
+                id_str = ""
+                if self.settings['gates']['AllocateQubitGate']['draw_id']:
+                    id_str = "^{{\\textcolor{{red}}{{{}}}}}".format(cmds[i].id)
+                add_str = add_str.format(self._op(line), self.pos[line], line, id_str)
+                self.op_count[line] += 1
+                self.pos[line] += self._gate_offset(gate) + self._gate_width(gate)
+                self.is_quantum[line] = self.settings['lines']['init_quantum']
+            elif gate == Deallocate:
+                # draw 'end of line'
+                op = self._op(line)
+                add_str = "\n\\node[none] ({}) at ({},-{}) {{}};"
+                add_str = add_str.format(op, self.pos[line], line)
+                yshift = str(self._gate_height(gate)) + "cm]"
+                add_str += ("\n\\draw ([yshift={yshift}{op}.center) edge [edgestyle] "
+                            "([yshift=-{yshift}{op}.center);").format(op=op,
+                                                                      yshift=yshift)
+                self.op_count[line] += 1
+                self.pos[line] += self._gate_width(gate) + self._gate_offset(gate)
+            else:
+                add_str = self._regular_gate(gate, lines, ctrl_lines)
+                for l in lines:
+                    self.is_quantum[l] = True
+
+            tikz_code.append(add_str)
+            if not gate == Allocate:
+                tikz_code.append(connections)
+
+        circuit[line] = circuit[line][end:]
+        return "".join(tikz_code)
+
+    def _gate_name(self, gate):
+        """
+        Return the string representation of the gate.
+
+        Tries to use gate.tex_str and, if that is not available, uses str(gate)
+        instead.
+
+        Args:
+            gate: Gate object of which to get the name / latex representation.
+
+        Returns:
+            gate_name (string): Latex gate name.
+        """
+        try:
+            name = gate.tex_str()
+        except AttributeError:
+            name = str(gate)
+        return name
+
+    def _x_gate(self, lines, ctrl_lines):
+        """
+        Return the TikZ code for a NOT-gate.
+
+        Args:
+            lines (list<int>): List of length 1 denoting the target qubit of the
+                NOT / X gate.
+            ctrl_lines (list<int>): List of qubit lines which act as controls.
+
+        """
+        assert(len(lines) == 1)  # NOT gate only acts on 1 qubit
+        line = lines[0]
+        delta_pos = self._gate_offset(X)
+        gate_width = self._gate_width(X)
+        op = self._op(line)
+        gate_str = ("\n\\node[xstyle] ({op}) at ({pos},-{line}) {{}};\n\\draw"
+                    "[edgestyle] ({op}.north)--({op}.south);\n\\draw[edgestyle] "
+                    "({op}.west)--({op}.east);").format(op=op, line=line,
+                                                        pos=self.pos[line])
+
+        if len(ctrl_lines) > 0:
+            for ctrl in ctrl_lines:
+                gate_str += self._phase(ctrl, self.pos[line])
+                gate_str += self._line(ctrl, line)
+
+        all_lines = ctrl_lines + [line]
+        new_pos = self.pos[line] + delta_pos + gate_width
+        for i in all_lines:
+            self.op_count[i] += 1
+        for i in range(min(all_lines), max(all_lines)+1):
+            self.pos[i] = new_pos
+        return gate_str
+
+    def _gate_width(self, gate):
+        """
+        Return the gate width, using the settings (if available).
+
+        Returns:
+            gate_width (float): Width of the gate.
+                (settings['gates'][gate_class_name]['width'])
+        """
+        try:
+            gate_width = self.settings['gates'][gate.__class__.__name__]['width']
+        except KeyError:
+            gate_width = .5
+        return gate_width
+
+    def _gate_pre_offset(self, gate):
+        """
+        Return the offset to use before placing this gate.
+
+        Returns:
+            gate_pre_offset (float): Offset to use before the gate.
+                (settings['gates'][gate_class_name]['pre_offset'])
+        """
+        try:
+            delta_pos = self.settings['gates'][gate.__class__.__name__]['pre_offset']
+        except KeyError:
+            delta_pos = self._gate_offset(gate)
+        return delta_pos
+
+    def _gate_offset(self, gate):
+        """
+        Return the offset to use after placing this gate and, if no pre_offset
+        is defined, the same offset is used in front of the gate.
+
+        Returns:
+            gate_offset (float): Offset.
+                (settings['gates'][gate_class_name]['offset'])
+        """
+        try:
+            delta_pos = self.settings['gates'][gate.__class__.__name__]['offset']
+        except KeyError:
+            delta_pos = .2
+        return delta_pos
+
+    def _gate_height(self, gate):
+        """
+        Return the height to use for this gate.
+
+        Returns:
+            gate_height (float): Height of the gate.
+                (settings['gates'][gate_class_name]['height'])
+        """
+        try:
+            height = self.settings['gates'][gate.__class__.__name__]['height']
+        except KeyError:
+            height = .5
+        return height
+
+    def _phase(self, line, pos):
+        """
+        Places a phase / control circle on a qubit line at a given position.
+
+        Args:
+            line (int): Qubit line at which to place the circle.
+            pos (float): Position at which to place the circle.
+
+        Returns:
+            tex_str (string): Latex string representing a control circle at the
+                given position.
+        """
+        return "\n\\node[phase] ({}) at ({},-{}) {{}};".format(self._op(line),
+                                                                                                                     pos, line)
+
+    def _op(self, line, op=None, offset=0):
+        """
+        Returns the gate name for placing a gate on a line.
+
+        Args:
+            line (int): Line number.
+            op (int): Operation number or, by default, uses the current op count.
+
+        Returns:
+            op_str (string): Gate name.
+        """
+        if op is None:
+            op = self.op_count[line]
+        return "line{}_gate{}".format(line, op + offset)
+
+    def _line(self, p1, p2, double=False, line=None):
+        """
+        Connects p1 and p2, where p1 and p2 are either to qubit line indices, in
+        which case the two most recent gates are connected, or two gate indices,
+        in which case line denotes the line number and the two gates are connected
+        on the given line.
+
+        Args:
+            p1 (int): Index of the first object to connect.
+            p2 (int): Index of the second object to connect.
+            double (bool): Draws double lines if True.
+            line (int or None): Line index - if provided, p1 and p2 are gate
+                indices.
+
+        Returns:
+            tex_str (string): Latex code to draw this / these line(s).
+        """
+        dbl_classical = self.settings['lines']['double_classical']
+
+        if line is None:
+            quantum = not dbl_classical or self.is_quantum[p1]
+            op1, op2 = self._op(p1), self._op(p2)
+            loc1, loc2 = 'north', 'south'
+            shift = "xshift={}cm"
+        else:
+            quantum = not dbl_classical or self.is_quantum[line]
+            op1, op2 = self._op(line, p1), self._op(line, p2)
+            loc1, loc2 = 'west', 'east'
+            shift = "yshift={}cm"
+
+        if quantum:
+            return "\n\\draw ({}) edge[edgestyle] ({});".format(op1, op2)
+        else:
+            if p2 > p1:
+                loc1, loc2 = loc2, loc1
+            edge_str = "\n\\draw ([{shift}]{op1}.{loc1}) edge[edgestyle] ([{shift}]{op2}.{loc2});"
+            shift1 = shift.format(self.settings['lines']['double_lines_sep'] / 2.)
+            shift2 = shift.format(-self.settings['lines']['double_lines_sep'] / 2.)
+            edges_str = edge_str.format(shift=shift1, op1=op1, op2=op2, loc1=loc1, loc2=loc2)
+            edges_str += edge_str.format(shift=shift2, op1=op1, op2=op2, loc1=loc1, loc2=loc2)
+            return edges_str
+
+    def _regular_gate(self, gate, lines, ctrl_lines):
+        """
+        Draw a regular gate.
+
+        Args:
+            gate: Gate to draw.
+            lines (list<int>): Lines the gate acts on.
+            ctrl_lines (list<int>): Control lines.
+
+        Returns:
+            tex_str (string): Latex string drawing a regular gate at the given
+                location
+        """
+        imax = max(lines)
+        imin = min(lines)
+
+        delta_pos = self._gate_offset(gate)
+        gate_width = self._gate_width(gate)
+        gate_height = self._gate_height(gate)
+
+        name = self._gate_name(gate)
+
+        lines = list(range(imin, imax+1))
+
+        tex_str = ""
+        pos = self.pos[lines[0]]
+
+        node_str = "\n\\node[none] ({}) at ({},-{}) {{}};"
+        for l in lines:
+            node1 = node_str.format(self._op(l), pos, l)
+            node2 = ("\n\\node[none,minimum height={}cm,outer sep=0] ({}) at ({},-{"
+                    "}) {{}};").format(gate_height, self._op(l, offset=1), pos +
+                                     gate_width/2., l)
+            node3 = node_str.format(self._op(l, offset=2),
                               pos + gate_width, l)
-			tex_str += node1 + node2 + node3
-		
-		tex_str += ("\n\\draw[operator,edgestyle,outer sep={width}cm] ([yshift="
-		            "{half_height}cm]{op1}) rectangle ([yshift=-{half_height}cm]"
-		            "{op2}) node[pos=.5] {{{name}}};").format(width=gate_width,
-		            op1=self._op(imin), op2=self._op(imax, offset=2), half_height=
-		            .5 * gate_height, name=name)
-		
-		for l in lines:
-			self.pos[l] = pos + gate_width/2.
-			self.op_count[l] += 1
-			
-		for ctrl in ctrl_lines:
-			if not ctrl in lines:
-				tex_str += self._phase(ctrl, pos + gate_width/2.)
-				connect_to = imax
-				if abs(connect_to - ctrl) > abs(imin - ctrl):
-					connect_to = imin
-				tex_str += self._line(ctrl, connect_to)
-				self.pos[ctrl] = pos + delta_pos + gate_width
-				self.op_count[ctrl] += 1
-		
-		for l in lines:
-			self.op_count[l] += 2
-		
-		for l in range(min(ctrl_lines + lines), max(ctrl_lines + lines)+1):
-			self.pos[l] = pos + delta_pos + gate_width
-		return tex_str
+            tex_str += node1 + node2 + node3
+
+        tex_str += ("\n\\draw[operator,edgestyle,outer sep={width}cm] ([yshift="
+                    "{half_height}cm]{op1}) rectangle ([yshift=-{half_height}cm]"
+                    "{op2}) node[pos=.5] {{{name}}};").format(width=gate_width,
+                    op1=self._op(imin), op2=self._op(imax, offset=2), half_height=
+                    .5 * gate_height, name=name)
+
+        for l in lines:
+            self.pos[l] = pos + gate_width/2.
+            self.op_count[l] += 1
+
+        for ctrl in ctrl_lines:
+            if not ctrl in lines:
+                tex_str += self._phase(ctrl, pos + gate_width/2.)
+                connect_to = imax
+                if abs(connect_to - ctrl) > abs(imin - ctrl):
+                    connect_to = imin
+                tex_str += self._line(ctrl, connect_to)
+                self.pos[ctrl] = pos + delta_pos + gate_width
+                self.op_count[ctrl] += 1
+
+        for l in lines:
+            self.op_count[l] += 2
+
+        for l in range(min(ctrl_lines + lines), max(ctrl_lines + lines)+1):
+            self.pos[l] = pos + delta_pos + gate_width
+        return tex_str

--- a/projectq/backends/_circuits/_to_latex_test.py
+++ b/projectq/backends/_circuits/_to_latex_test.py
@@ -31,184 +31,184 @@ import projectq.backends._circuits._to_latex as _to_latex
 import projectq.backends._circuits._drawer as _drawer
 
 def test_tolatex():
-	old_header = _to_latex._header
-	old_body = _to_latex._body
-	old_footer = _to_latex._footer
-	
-	_to_latex._header = lambda x: "H"
-	_to_latex._body = lambda x, y: x
-	_to_latex._footer = lambda x: "F"
-	
-	latex = _to_latex.to_latex("B")
-	assert latex == "HBF"
-	
-	_to_latex._header = old_header
-	_to_latex._body = old_body
-	_to_latex._footer = old_footer
+    old_header = _to_latex._header
+    old_body = _to_latex._body
+    old_footer = _to_latex._footer
+
+    _to_latex._header = lambda x: "H"
+    _to_latex._body = lambda x, y: x
+    _to_latex._footer = lambda x: "F"
+
+    latex = _to_latex.to_latex("B")
+    assert latex == "HBF"
+
+    _to_latex._header = old_header
+    _to_latex._body = old_body
+    _to_latex._footer = old_footer
 
 
 def test_default_settings():
-	settings = _to_latex.get_default_settings()
-	assert isinstance(settings, dict)
-	assert 'gate_shadow' in settings
-	assert 'lines' in settings
-	assert 'gates' in settings
-	assert 'control' in settings
+    settings = _to_latex.get_default_settings()
+    assert isinstance(settings, dict)
+    assert 'gate_shadow' in settings
+    assert 'lines' in settings
+    assert 'gates' in settings
+    assert 'control' in settings
 
 
 def test_header():
-	settings = {'gate_shadow': False, 'control': {'shadow': False, 'size': 0},
-	            'gates': {'MeasureGate': {'height': 0, 'width': 0},
-	                      'XGate': {'height': 1, 'width': .5}
-	                      },
-	            'lines': {'style': 'my_style'}}
-	header = _to_latex._header(settings)
-	
-	assert 'minimum' in header
-	assert not 'basicshadow' in header
-	assert 'minimum height=0.5' in header
-	assert not 'minimum height=1cm' in header
-	assert 'minimum height=0cm' in header
-	
-	settings['control']['shadow'] = True
-	settings['gates']['XGate']['width'] = 1
-	header = _to_latex._header(settings)
-	
-	assert 'minimum' in header
-	assert 'basicshadow' in header
-	assert 'minimum height=1cm' in header
-	assert 'minimum height=0cm' in header
-	
-	settings['control']['shadow'] = True
-	settings['gate_shadow'] = True
-	header = _to_latex._header(settings)
-	
-	assert 'minimum' in header
-	assert 'white,basicshadow' in header
-	assert 'minimum height=1cm' in header
-	assert 'minimum height=0cm' in header
+    settings = {'gate_shadow': False, 'control': {'shadow': False, 'size': 0},
+                'gates': {'MeasureGate': {'height': 0, 'width': 0},
+                          'XGate': {'height': 1, 'width': .5}
+                          },
+                'lines': {'style': 'my_style'}}
+    header = _to_latex._header(settings)
+
+    assert 'minimum' in header
+    assert not 'basicshadow' in header
+    assert 'minimum height=0.5' in header
+    assert not 'minimum height=1cm' in header
+    assert 'minimum height=0cm' in header
+
+    settings['control']['shadow'] = True
+    settings['gates']['XGate']['width'] = 1
+    header = _to_latex._header(settings)
+
+    assert 'minimum' in header
+    assert 'basicshadow' in header
+    assert 'minimum height=1cm' in header
+    assert 'minimum height=0cm' in header
+
+    settings['control']['shadow'] = True
+    settings['gate_shadow'] = True
+    header = _to_latex._header(settings)
+
+    assert 'minimum' in header
+    assert 'white,basicshadow' in header
+    assert 'minimum height=1cm' in header
+    assert 'minimum height=0cm' in header
 
 
 def test_body():
-	drawer = _drawer.CircuitDrawer()
-	eng = MainEngine(drawer, [])
-	old_tolatex = _drawer.to_latex
-	_drawer.to_latex = lambda x : x
-	
-	qubit1 = eng.allocate_qubit()
-	qubit2 = eng.allocate_qubit()
-	
-	H | qubit1
-	H | qubit2
-	CNOT | (qubit1, qubit2)
-	X | qubit2
-	Measure | qubit2
-	CNOT | (qubit2, qubit1)
-	Z | qubit2
-	
-	del qubit1
-	eng.flush()
-	
-	circuit_lines = drawer.get_latex()
-	_drawer.to_latex = old_tolatex
-	
-	settings = _to_latex.get_default_settings()
-	settings['gates']['AllocateQubitGate']['draw_id']=True
-	code = _to_latex._body(circuit_lines, settings)
-	
-	assert code.count("{{{}}}".format(str(H))) == 2 # 2 hadamard gates
-	assert code.count("{$\Ket{0}") == 2 # two qubits allocated
-	assert code.count("xstyle") == 3 # 1 cnot, 1 not gate
-	assert code.count("measure") == 1 # 1 measurement
-	assert code.count("{{{}}}".format(str(Z))) == 1 # 1 Z gate
-	assert code.count("{red}") == 2
+    drawer = _drawer.CircuitDrawer()
+    eng = MainEngine(drawer, [])
+    old_tolatex = _drawer.to_latex
+    _drawer.to_latex = lambda x : x
+
+    qubit1 = eng.allocate_qubit()
+    qubit2 = eng.allocate_qubit()
+
+    H | qubit1
+    H | qubit2
+    CNOT | (qubit1, qubit2)
+    X | qubit2
+    Measure | qubit2
+    CNOT | (qubit2, qubit1)
+    Z | qubit2
+
+    del qubit1
+    eng.flush()
+
+    circuit_lines = drawer.get_latex()
+    _drawer.to_latex = old_tolatex
+
+    settings = _to_latex.get_default_settings()
+    settings['gates']['AllocateQubitGate']['draw_id']=True
+    code = _to_latex._body(circuit_lines, settings)
+
+    assert code.count("{{{}}}".format(str(H))) == 2 # 2 hadamard gates
+    assert code.count("{$\Ket{0}") == 2 # two qubits allocated
+    assert code.count("xstyle") == 3 # 1 cnot, 1 not gate
+    assert code.count("measure") == 1 # 1 measurement
+    assert code.count("{{{}}}".format(str(Z))) == 1 # 1 Z gate
+    assert code.count("{red}") == 2
 
 
 def test_qubit_lines_classicalvsquantum1():
-	drawer = _drawer.CircuitDrawer()
-	eng = MainEngine(drawer, [])
-	old_tolatex = _drawer.to_latex
-	_drawer.to_latex = lambda x : x
-	
-	qubit1 = eng.allocate_qubit()
-	
-	H | qubit1
-	Measure | qubit1
-	X | qubit1
-	
-	circuit_lines = drawer.get_latex()
-	_drawer.to_latex = old_tolatex
-	
-	settings = _to_latex.get_default_settings()
-	code = _to_latex._body(circuit_lines, settings)
+    drawer = _drawer.CircuitDrawer()
+    eng = MainEngine(drawer, [])
+    old_tolatex = _drawer.to_latex
+    _drawer.to_latex = lambda x : x
 
-	assert code.count("edge[") == 4
+    qubit1 = eng.allocate_qubit()
+
+    H | qubit1
+    Measure | qubit1
+    X | qubit1
+
+    circuit_lines = drawer.get_latex()
+    _drawer.to_latex = old_tolatex
+
+    settings = _to_latex.get_default_settings()
+    code = _to_latex._body(circuit_lines, settings)
+
+    assert code.count("edge[") == 4
 
 
 def test_qubit_lines_classicalvsquantum2():
-	drawer = _drawer.CircuitDrawer()
-	eng = MainEngine(drawer, [])
-	
-	controls = eng.allocate_qureg(3)
-	action = eng.allocate_qubit()
-	
-	with Control(eng, controls):
-		H | action
-	
-	code = drawer.get_latex()
-	assert code.count("{{{}}}".format(str(H))) == 1 # 1 Hadamard
-	assert code.count("{$") == 4 # four allocate gates
-	assert code.count("node[phase]") == 3 # 3 controls
+    drawer = _drawer.CircuitDrawer()
+    eng = MainEngine(drawer, [])
+
+    controls = eng.allocate_qureg(3)
+    action = eng.allocate_qubit()
+
+    with Control(eng, controls):
+        H | action
+
+    code = drawer.get_latex()
+    assert code.count("{{{}}}".format(str(H))) == 1 # 1 Hadamard
+    assert code.count("{$") == 4 # four allocate gates
+    assert code.count("node[phase]") == 3 # 3 controls
 
 
 def test_qubit_lines_classicalvsquantum3():
-	drawer = _drawer.CircuitDrawer()
-	eng = MainEngine(drawer, [])
-	
-	control0 = eng.allocate_qureg(2)
-	action1 = eng.allocate_qubit()
-	control1 = eng.allocate_qureg(2)
-	action2 = eng.allocate_qubit()
-	control2 = eng.allocate_qubit()
-	
-	with Control(eng, control0 + control1 + control2):
-		H | (action1, action2)
-	
-	code = drawer.get_latex()
-	assert code.count("{{{}}}".format(str(H))) == 1 # 1 Hadamard
-	assert code.count("{$") == 7 # 8 allocate gates
-	assert code.count("node[phase]") == 3 # 1 control 
-	# (other controls are within the gate -> are not drawn)
-	assert code.count("edge[") == 10 # 7 qubit lines + 3 from controls to gate
+    drawer = _drawer.CircuitDrawer()
+    eng = MainEngine(drawer, [])
+
+    control0 = eng.allocate_qureg(2)
+    action1 = eng.allocate_qubit()
+    control1 = eng.allocate_qureg(2)
+    action2 = eng.allocate_qubit()
+    control2 = eng.allocate_qubit()
+
+    with Control(eng, control0 + control1 + control2):
+        H | (action1, action2)
+
+    code = drawer.get_latex()
+    assert code.count("{{{}}}".format(str(H))) == 1 # 1 Hadamard
+    assert code.count("{$") == 7 # 8 allocate gates
+    assert code.count("node[phase]") == 3 # 1 control
+    # (other controls are within the gate -> are not drawn)
+    assert code.count("edge[") == 10 # 7 qubit lines + 3 from controls to gate
 
 
 def test_quantum_lines_cnot():
-	drawer = _drawer.CircuitDrawer()
-	eng = MainEngine(drawer, [])
-	
-	qubit1 = eng.allocate_qubit()
-	qubit2 = eng.allocate_qubit()
-	
-	Measure | qubit1
-	Measure | qubit2
-	
-	CNOT | (qubit2, qubit1)
-	
-	del qubit1, qubit2
-	code = drawer.get_latex()
-	assert code.count("edge[") == 12 # all lines are classical
-	
-	drawer = _drawer.CircuitDrawer()
-	eng = MainEngine(drawer, [])
-	
-	qubit1 = eng.allocate_qubit()
-	qubit2 = eng.allocate_qubit()
-	
-	Measure | qubit1 # qubit1 is classical
-	
-	CNOT | (qubit2, qubit1) # now it is quantum
-	
-	del qubit1, qubit2
-	code = drawer.get_latex()
-	assert code.count("edge[") == 7 # all lines are quantum
-	
+    drawer = _drawer.CircuitDrawer()
+    eng = MainEngine(drawer, [])
+
+    qubit1 = eng.allocate_qubit()
+    qubit2 = eng.allocate_qubit()
+
+    Measure | qubit1
+    Measure | qubit2
+
+    CNOT | (qubit2, qubit1)
+
+    del qubit1, qubit2
+    code = drawer.get_latex()
+    assert code.count("edge[") == 12 # all lines are classical
+
+    drawer = _drawer.CircuitDrawer()
+    eng = MainEngine(drawer, [])
+
+    qubit1 = eng.allocate_qubit()
+    qubit2 = eng.allocate_qubit()
+
+    Measure | qubit1 # qubit1 is classical
+
+    CNOT | (qubit2, qubit1) # now it is quantum
+
+    del qubit1, qubit2
+    code = drawer.get_latex()
+    assert code.count("edge[") == 7 # all lines are quantum
+

--- a/projectq/backends/_ibm/_ibm.py
+++ b/projectq/backends/_ibm/_ibm.py
@@ -33,311 +33,311 @@ from ._ibm_http_client import send
 
 
 class _IBMGateCommand:
-	"""
-	IBM gate command wrapper: Stores gate, qubit, and control qubit (for cx
-	gates only).
-	"""
-	def __init__(self, gate_str, qubit_id, ctrl_id=None):
-		self.gate = gate_str
-		self.qubit = qubit_id
-		self.ctrl = ctrl_id
+    """
+    IBM gate command wrapper: Stores gate, qubit, and control qubit (for cx
+    gates only).
+    """
+    def __init__(self, gate_str, qubit_id, ctrl_id=None):
+        self.gate = gate_str
+        self.qubit = qubit_id
+        self.ctrl = ctrl_id
 
 
 class IBMBackend(BasicEngine):
-	"""
-	The IBM Backend class, which stores the circuit, transforms it to JSON QASM,
-	and sends the circuit through the IBM API.
-	"""
-	def __init__(self, use_hardware=False, num_runs=1024, verbose=False,
-	             user=None, password=None):
-		"""
-		Initialize the Backend object.
-		
-		Args:
-			use_hardware (bool): If True, the code is run on the IBM quantum chip
-				(instead of using the IBM simulator)
-			num_runs (int): Number of runs to collect statistics. (default is 1024)
-			verbose (bool): If True, statistics are printed, in addition to the
-				measurement result being registered (at the end of the circuit).
-			user (string): IBM Quantum Experience user name
-			password (string): IBM Quantum Experience password
-		"""
-		BasicEngine.__init__(self)
-		self._reset()
-		if use_hardware:
-			self._device = 'real'
-		else:
-			self._device = 'sim_trivial_2'
-		self._num_runs = num_runs
-		self._verbose = verbose
-		self._user = user
-		self._password = password
-		self._mapping = dict()
-		self._inverse_mapping = dict()
-		self._mapped_qubits = 0
-		self._probabilities = dict()
-		
-	def is_available(self, cmd):
-		"""
-		Return true if the command can be executed.
-		
-		The IBM quantum chip can do X, Y, Z, T, Tdag, S, Sdag, and CX / CNOT.
-		
-		Args:
-			cmd (Command): Command for which to check availability
-		"""
-		g = cmd.gate
-		if g == NOT and get_control_count(cmd) <= 1:
-			return True
-		if get_control_count(cmd) == 0:
-			if (g == T or g == Tdag or g == S or g == Sdag or g == H or g == Y
-			   or g == Z):
-				return True
-		if g == Measure or g == Allocate or g == Deallocate:
-			return True
-		return False
-		
-	def _reset(self):
-		""" Reset all temporary variables (after flush gate). """
-		self._num_cols = 40  # number of gates / columns in the circuit
-		self._num_qubits = 5  # number of lines
-		self._cmds = []
-		for _ in range(self._num_qubits):
-			self._cmds.append([""] * self._num_cols)
-		self._positions = [0] * self._num_qubits
-		self._mapped_qubits = 0
-		
-	def _store(self, cmd):
-		"""
-		Temporarily store the command cmd.
-		
-		Translates the command and stores it in a local variable (self._cmds).
-		
-		Args:
-			cmd: Command to store
-		"""
-		gate = cmd.gate
-		if gate == Allocate or gate == Deallocate:
-			return
-		
-		if self._mapped_qubits == 0:
-			self._mapping = dict()
-			self._inverse_mapping = dict()
-			self._probabilities = dict()
-		
-		for qr in cmd.qubits:
-			for qb in qr:
-				if not qb.id in self._mapping:
-					self._mapping[qb.id] = self._mapped_qubits
-					self._inverse_mapping[self._mapped_qubits] = qb.id
-					self._mapped_qubits += 1
-		for qb in cmd.control_qubits:
-			if not qb.id in self._mapping:
-				self._mapping[qb.id] = self._mapped_qubits
-				self._inverse_mapping[self._mapped_qubits] = qb.id
-				self._mapped_qubits += 1
-		
-		if gate == Measure:
-			for qr in cmd.qubits:
-				for qb in qr:
-					qb_pos = self._mapping[qb.id]
-					meas = _IBMGateCommand("measure", qb_pos)
-					self._cmds[qb_pos][self._positions[qb_pos]] = meas
-					self._positions[qb_pos] += 1
-					
-		elif not (gate == NOT and get_control_count(cmd) == 1):
-			cls = gate.__class__.__name__
-			if cls in self._gate_names:
-				gate_str = self._gate_names[cls]
-			else:
-				gate_str = str(gate).lower()
-			
-			qb_pos = self._mapping[cmd.qubits[0][0].id]
-			ibm_cmd = _IBMGateCommand(gate_str, qb_pos)
-			self._cmds[qb_pos][self._positions[qb_pos]] = ibm_cmd
-			self._positions[qb_pos] += 1
-		else:
-			ctrl_pos = self._mapping[cmd.control_qubits[0].id]
-			qb_pos = self._mapping[cmd.qubits[0][0].id]
-			pos = max(self._positions[qb_pos], self._positions[ctrl_pos])
-			self._positions[qb_pos] = pos
-			self._positions[ctrl_pos] = pos
-			ibm_cmd = _IBMGateCommand("cx", qb_pos, ctrl_pos)
-			self._cmds[qb_pos][self._positions[qb_pos]] = ibm_cmd
-			self._positions[qb_pos] += 1
-			self._positions[ctrl_pos] += 1
-	
-	def get_probabilities(self, qureg):
-		"""
-		Return the list of basis states with corresponding probabilities.
-		
-		The measured bits are ordered according to the supplied quantum register,
-		i.e., the left-most bit in the state-string corresponds to the first qubit
-		in the supplied quantum register.
-		
-		Warning:
-			Only call this function after the circuit has been executed!
-		
-		Args:
-			qureg (list<Qubit>): Quantum register determining the order of the
-				qubits.
-		
-		Returns:
-			probability_dict (dict): Dictionary mapping n-bit strings to
-			probabilities.
-		
-		Raises:
-			Exception: If no data is available (i.e., if the circuit has not been
-				executed).
-		"""
-		if len(self._probabilities) == 0:
-			raise RuntimeError("Please, run the circuit first!")
-		
-		probability_dict = dict()
-		
-		for state in self._probabilities:
-			mapped_state = ['0'] * len(qureg)
-			for i in range(len(qureg)):
-				mapped_state[i] = state[self._mapping[qureg[i].id]]
-			probability_dict["".join(mapped_state)] = self._probabilities[state]
-		
-		return probability_dict
-	
-	def _run(self):
-		"""
-		Run the circuit.
-		
-		Send the circuit via the IBM API (JSON QASM) using the provided user data
-		/ ask for username & password.
-		"""
-		lines = []
-		num_gates = 0
-		num_cols = min(max(self._positions), self._num_cols)
-		
-		cnot_qubit_id = 2
-		
-		if num_cols > 0:
-			for i in range(self._num_qubits):
-				gates = []
-				for j in range(num_cols):
-					cmd = self._cmds[i][j]
-					gate = dict()
-					gate['position'] = j
-					try:
-						gate['name'] = cmd.gate
-						gate['qasm'] = cmd.gate
-						if not cmd.ctrl is None:
-							gate['to'] = cmd.ctrl
-							cnot_qubit_id = i
-					except AttributeError:
-						pass
-					gates.append(gate)
-					num_gates += 1
+    """
+    The IBM Backend class, which stores the circuit, transforms it to JSON QASM,
+    and sends the circuit through the IBM API.
+    """
+    def __init__(self, use_hardware=False, num_runs=1024, verbose=False,
+                 user=None, password=None):
+        """
+        Initialize the Backend object.
 
-				lines.append(dict())
-				lines[i]['line'] = i
-				lines[i]['name'] = 'q'
-				lines[i]['gates'] = gates
-			
-				self._cmds[i] = []
-				self._positions[i] = 0
-			
-			for gate in lines[cnot_qubit_id]['gates']:
-				try:
-					if gate['to'] == 2:
-						gate['to'] = cnot_qubit_id
-				except KeyError:
-					pass
-					
-			lines[2], lines[cnot_qubit_id] = lines[cnot_qubit_id], lines[2]
-			# save this id, so we can later register the measurement result
-			# correctly
-			self._cnot_qubit_id = cnot_qubit_id
-			
-			info = dict()
-			info['playground'] = lines
-			info['numberColumns'] = num_cols
-			info['numberLines'] = self._num_qubits
-			info['numberGates'] = num_gates
-			info['hasMeasures'] = True
-			info['topology'] = '250e969c6b9e68aa2a045ffbceb3ac33'
-			
-			info = '{"playground":['
-			for i in range(len(lines)):
-				info += '{"line":' + str(i) + ',"name":"q","gates":['
-				gates = ""
-				for j in range(len(lines[i]['gates'])):
-					try:
-						name = lines[i]['gates'][j]['name']
-						qasm = lines[i]['gates'][j]['qasm']
-						gates += '{"position":' + str(j)
-						gates += ',"name":"' + name + '"'
-						gates += ',"qasm":"' + qasm + '"'
-						if name == "cx":
-							gates += ',"to":' + str(lines[i]['gates'][j]['to'])
-						gates += '},'
-					except:
-						pass
-				info = info + gates[:-1] + ']},'
-	
-			info = (info[:-1]
-			        + '],"numberColumns":' + str(40) + ',"numberLines":'
-			        + str(self._num_qubits) + ',"numberGates":' + str(200)
-			        + ',"hasMeasures":true,"topology":'
-			        + '"250e969c6b9e68aa2a045ffbceb3ac33"}')
+        Args:
+            use_hardware (bool): If True, the code is run on the IBM quantum chip
+                (instead of using the IBM simulator)
+            num_runs (int): Number of runs to collect statistics. (default is 1024)
+            verbose (bool): If True, statistics are printed, in addition to the
+                measurement result being registered (at the end of the circuit).
+            user (string): IBM Quantum Experience user name
+            password (string): IBM Quantum Experience password
+        """
+        BasicEngine.__init__(self)
+        self._reset()
+        if use_hardware:
+            self._device = 'real'
+        else:
+            self._device = 'sim_trivial_2'
+        self._num_runs = num_runs
+        self._verbose = verbose
+        self._user = user
+        self._password = password
+        self._mapping = dict()
+        self._inverse_mapping = dict()
+        self._mapped_qubits = 0
+        self._probabilities = dict()
 
-			try:
-				res = send(info, 'projectq_experiment', device=self._device,
-				           user=self._user, password=self._password,
-				           shots=self._num_runs, verbose=self._verbose)
+    def is_available(self, cmd):
+        """
+        Return true if the command can be executed.
 
-				data = res['data']['p']
-				
-				# Determine random outcome
-				P = random.random()
-				p_sum = 0.
-				measured = ""
-				for state, probability in zip(data['labels'], data['values']):
-					state = list(reversed(state))
-					state[2], state[self._cnot_qubit_id] = state[self._cnot_qubit_id], state[2]
-					state = "".join(state)
-					p_sum += probability
-					star = ""
-					if p_sum >= P and measured == "":
-						measured = state
-						star = "*"
-					self._probabilities[state] = probability
-					if self._verbose and probability > 0:
-						print(str(state) + " with p = " + str(probability) + star)
-					
-				class QB():
-					def __init__(self, ID):
-						self.id = ID
-				
-				# register measurement result
-				for ID in self._mapping:
-					location = self._mapping[ID]
-					self.main_engine.set_measurement_result(QB(ID), int(measured[location]))
-				self._reset()
-			except TypeError:
-				raise Exception("Failed to run the circuit. Aborting.")
-				
-	def receive(self, command_list):
-		"""
-		Receives a command list and, for each command, stores it until completion.
-		
-		Args:
-			command_list: List of commands to execute
-		"""
-		for cmd in command_list:
-			if not cmd.gate == FlushGate():
-				self._store(cmd)
-			else:
-				self._run()
-				self._reset()
-				
-	"""
-	Mapping of gate names from our gate objects to the IBM QASM representation.
-	"""
-	_gate_names = {Tdag.__class__.__name__: "tdg",
-	               Sdag.__class__.__name__: "sdg"}
+        The IBM quantum chip can do X, Y, Z, T, Tdag, S, Sdag, and CX / CNOT.
+
+        Args:
+            cmd (Command): Command for which to check availability
+        """
+        g = cmd.gate
+        if g == NOT and get_control_count(cmd) <= 1:
+            return True
+        if get_control_count(cmd) == 0:
+            if (g == T or g == Tdag or g == S or g == Sdag or g == H or g == Y
+               or g == Z):
+                return True
+        if g == Measure or g == Allocate or g == Deallocate:
+            return True
+        return False
+
+    def _reset(self):
+        """ Reset all temporary variables (after flush gate). """
+        self._num_cols = 40  # number of gates / columns in the circuit
+        self._num_qubits = 5  # number of lines
+        self._cmds = []
+        for _ in range(self._num_qubits):
+            self._cmds.append([""] * self._num_cols)
+        self._positions = [0] * self._num_qubits
+        self._mapped_qubits = 0
+
+    def _store(self, cmd):
+        """
+        Temporarily store the command cmd.
+
+        Translates the command and stores it in a local variable (self._cmds).
+
+        Args:
+            cmd: Command to store
+        """
+        gate = cmd.gate
+        if gate == Allocate or gate == Deallocate:
+            return
+
+        if self._mapped_qubits == 0:
+            self._mapping = dict()
+            self._inverse_mapping = dict()
+            self._probabilities = dict()
+
+        for qr in cmd.qubits:
+            for qb in qr:
+                if not qb.id in self._mapping:
+                    self._mapping[qb.id] = self._mapped_qubits
+                    self._inverse_mapping[self._mapped_qubits] = qb.id
+                    self._mapped_qubits += 1
+        for qb in cmd.control_qubits:
+            if not qb.id in self._mapping:
+                self._mapping[qb.id] = self._mapped_qubits
+                self._inverse_mapping[self._mapped_qubits] = qb.id
+                self._mapped_qubits += 1
+
+        if gate == Measure:
+            for qr in cmd.qubits:
+                for qb in qr:
+                    qb_pos = self._mapping[qb.id]
+                    meas = _IBMGateCommand("measure", qb_pos)
+                    self._cmds[qb_pos][self._positions[qb_pos]] = meas
+                    self._positions[qb_pos] += 1
+
+        elif not (gate == NOT and get_control_count(cmd) == 1):
+            cls = gate.__class__.__name__
+            if cls in self._gate_names:
+                gate_str = self._gate_names[cls]
+            else:
+                gate_str = str(gate).lower()
+
+            qb_pos = self._mapping[cmd.qubits[0][0].id]
+            ibm_cmd = _IBMGateCommand(gate_str, qb_pos)
+            self._cmds[qb_pos][self._positions[qb_pos]] = ibm_cmd
+            self._positions[qb_pos] += 1
+        else:
+            ctrl_pos = self._mapping[cmd.control_qubits[0].id]
+            qb_pos = self._mapping[cmd.qubits[0][0].id]
+            pos = max(self._positions[qb_pos], self._positions[ctrl_pos])
+            self._positions[qb_pos] = pos
+            self._positions[ctrl_pos] = pos
+            ibm_cmd = _IBMGateCommand("cx", qb_pos, ctrl_pos)
+            self._cmds[qb_pos][self._positions[qb_pos]] = ibm_cmd
+            self._positions[qb_pos] += 1
+            self._positions[ctrl_pos] += 1
+
+    def get_probabilities(self, qureg):
+        """
+        Return the list of basis states with corresponding probabilities.
+
+        The measured bits are ordered according to the supplied quantum register,
+        i.e., the left-most bit in the state-string corresponds to the first qubit
+        in the supplied quantum register.
+
+        Warning:
+            Only call this function after the circuit has been executed!
+
+        Args:
+            qureg (list<Qubit>): Quantum register determining the order of the
+                qubits.
+
+        Returns:
+            probability_dict (dict): Dictionary mapping n-bit strings to
+            probabilities.
+
+        Raises:
+            Exception: If no data is available (i.e., if the circuit has not been
+                executed).
+        """
+        if len(self._probabilities) == 0:
+            raise RuntimeError("Please, run the circuit first!")
+
+        probability_dict = dict()
+
+        for state in self._probabilities:
+            mapped_state = ['0'] * len(qureg)
+            for i in range(len(qureg)):
+                mapped_state[i] = state[self._mapping[qureg[i].id]]
+            probability_dict["".join(mapped_state)] = self._probabilities[state]
+
+        return probability_dict
+
+    def _run(self):
+        """
+        Run the circuit.
+
+        Send the circuit via the IBM API (JSON QASM) using the provided user data
+        / ask for username & password.
+        """
+        lines = []
+        num_gates = 0
+        num_cols = min(max(self._positions), self._num_cols)
+
+        cnot_qubit_id = 2
+
+        if num_cols > 0:
+            for i in range(self._num_qubits):
+                gates = []
+                for j in range(num_cols):
+                    cmd = self._cmds[i][j]
+                    gate = dict()
+                    gate['position'] = j
+                    try:
+                        gate['name'] = cmd.gate
+                        gate['qasm'] = cmd.gate
+                        if not cmd.ctrl is None:
+                            gate['to'] = cmd.ctrl
+                            cnot_qubit_id = i
+                    except AttributeError:
+                        pass
+                    gates.append(gate)
+                    num_gates += 1
+
+                lines.append(dict())
+                lines[i]['line'] = i
+                lines[i]['name'] = 'q'
+                lines[i]['gates'] = gates
+
+                self._cmds[i] = []
+                self._positions[i] = 0
+
+            for gate in lines[cnot_qubit_id]['gates']:
+                try:
+                    if gate['to'] == 2:
+                        gate['to'] = cnot_qubit_id
+                except KeyError:
+                    pass
+
+            lines[2], lines[cnot_qubit_id] = lines[cnot_qubit_id], lines[2]
+            # save this id, so we can later register the measurement result
+            # correctly
+            self._cnot_qubit_id = cnot_qubit_id
+
+            info = dict()
+            info['playground'] = lines
+            info['numberColumns'] = num_cols
+            info['numberLines'] = self._num_qubits
+            info['numberGates'] = num_gates
+            info['hasMeasures'] = True
+            info['topology'] = '250e969c6b9e68aa2a045ffbceb3ac33'
+
+            info = '{"playground":['
+            for i in range(len(lines)):
+                info += '{"line":' + str(i) + ',"name":"q","gates":['
+                gates = ""
+                for j in range(len(lines[i]['gates'])):
+                    try:
+                        name = lines[i]['gates'][j]['name']
+                        qasm = lines[i]['gates'][j]['qasm']
+                        gates += '{"position":' + str(j)
+                        gates += ',"name":"' + name + '"'
+                        gates += ',"qasm":"' + qasm + '"'
+                        if name == "cx":
+                            gates += ',"to":' + str(lines[i]['gates'][j]['to'])
+                        gates += '},'
+                    except:
+                        pass
+                info = info + gates[:-1] + ']},'
+
+            info = (info[:-1]
+                    + '],"numberColumns":' + str(40) + ',"numberLines":'
+                    + str(self._num_qubits) + ',"numberGates":' + str(200)
+                    + ',"hasMeasures":true,"topology":'
+                    + '"250e969c6b9e68aa2a045ffbceb3ac33"}')
+
+            try:
+                res = send(info, 'projectq_experiment', device=self._device,
+                           user=self._user, password=self._password,
+                           shots=self._num_runs, verbose=self._verbose)
+
+                data = res['data']['p']
+
+                # Determine random outcome
+                P = random.random()
+                p_sum = 0.
+                measured = ""
+                for state, probability in zip(data['labels'], data['values']):
+                    state = list(reversed(state))
+                    state[2], state[self._cnot_qubit_id] = state[self._cnot_qubit_id], state[2]
+                    state = "".join(state)
+                    p_sum += probability
+                    star = ""
+                    if p_sum >= P and measured == "":
+                        measured = state
+                        star = "*"
+                    self._probabilities[state] = probability
+                    if self._verbose and probability > 0:
+                        print(str(state) + " with p = " + str(probability) + star)
+
+                class QB():
+                    def __init__(self, ID):
+                        self.id = ID
+
+                # register measurement result
+                for ID in self._mapping:
+                    location = self._mapping[ID]
+                    self.main_engine.set_measurement_result(QB(ID), int(measured[location]))
+                self._reset()
+            except TypeError:
+                raise Exception("Failed to run the circuit. Aborting.")
+
+    def receive(self, command_list):
+        """
+        Receives a command list and, for each command, stores it until completion.
+
+        Args:
+            command_list: List of commands to execute
+        """
+        for cmd in command_list:
+            if not cmd.gate == FlushGate():
+                self._store(cmd)
+            else:
+                self._run()
+                self._reset()
+
+    """
+    Mapping of gate names from our gate objects to the IBM QASM representation.
+    """
+    _gate_names = {Tdag.__class__.__name__: "tdg",
+                   Sdag.__class__.__name__: "sdg"}

--- a/projectq/backends/_ibm/_ibm_http_client.py
+++ b/projectq/backends/_ibm/_ibm_http_client.py
@@ -24,148 +24,148 @@ _api_url = 'https://quantumexperience.ng.bluemix.net/api/'
 _api_url_status = 'https://quantumexperience.ng.bluemix.net/api/'
 
 class DeviceOfflineError(Exception):
-	pass
+    pass
 
 
 def send(json_qasm, name, device='sim_trivial_2', user=None, password=None,
          shots=1, verbose=False):
-	"""
-	Sends json QASM through the IBM API and runs the quantum circuit represented
-	by the json data.
-	
-	Args:
-		json_qasm: JSON QASM representation of the circuit to run.
-		name (str): Name of the experiment.
-		device (str): 'sim_trivial_2' or 'real' to run on simulator or on the real
-			chip, respectively.
-		user (str): IBM quantum experience user.
-		password (str): IBM quantum experience user password.
-		shots (int): Number of runs of the same circuit to collect statistics.
-		verbose (bool): If True, additional information is printed, such as
-			measurement statistics. Otherwise, the backend simply registers one
-			measurement result (same behavior as the projectq Simulator).
-	"""
-	# check if the device is online
-	if device == 'real':
-		r = requests.get(urljoin(_api_url_status, 'Status/queue'),
-		                 params={"device": "chip_real"})
-		online = r.json()['state']
-		
-		if not online:
-			print("The device is offline (for maintenance?). Use the simulator "
-			      "instead or try again later.")
-			raise DeviceOfflineError("Device is offline.")
-	
-	try:
-		if verbose:
-			print("Authenticating...")
-		user_id, access_token = _authenticate(user, password)
-		if verbose:
-			print("Saving code...")
-		code_id = _save_code(json_qasm, name, user_id, access_token)
-		if verbose:
-			print("Running code...")
-		execution_id = _run(json_qasm, device, user_id, code_id, access_token,
-		                    shots)
-		if verbose:
-			print("Waiting for results...")
-		res = _get_result(execution_id, access_token)
-		logging.info(res)
-		if verbose:
-			print("Done.")
-		return res
-	except requests.exceptions.HTTPError as err:
-		print("There was an error running your code:")
-		print(err)
-	except requests.exceptions.RequestException as err:
-		print("Looks like something is wrong with server:")
-		print(err)
-	except KeyError as err:
-		print("Failed to parse response:")
-		print(err)
+    """
+    Sends json QASM through the IBM API and runs the quantum circuit represented
+    by the json data.
+
+    Args:
+        json_qasm: JSON QASM representation of the circuit to run.
+        name (str): Name of the experiment.
+        device (str): 'sim_trivial_2' or 'real' to run on simulator or on the real
+            chip, respectively.
+        user (str): IBM quantum experience user.
+        password (str): IBM quantum experience user password.
+        shots (int): Number of runs of the same circuit to collect statistics.
+        verbose (bool): If True, additional information is printed, such as
+            measurement statistics. Otherwise, the backend simply registers one
+            measurement result (same behavior as the projectq Simulator).
+    """
+    # check if the device is online
+    if device == 'real':
+        r = requests.get(urljoin(_api_url_status, 'Status/queue'),
+                         params={"device": "chip_real"})
+        online = r.json()['state']
+
+        if not online:
+            print("The device is offline (for maintenance?). Use the simulator "
+                  "instead or try again later.")
+            raise DeviceOfflineError("Device is offline.")
+
+    try:
+        if verbose:
+            print("Authenticating...")
+        user_id, access_token = _authenticate(user, password)
+        if verbose:
+            print("Saving code...")
+        code_id = _save_code(json_qasm, name, user_id, access_token)
+        if verbose:
+            print("Running code...")
+        execution_id = _run(json_qasm, device, user_id, code_id, access_token,
+                            shots)
+        if verbose:
+            print("Waiting for results...")
+        res = _get_result(execution_id, access_token)
+        logging.info(res)
+        if verbose:
+            print("Done.")
+        return res
+    except requests.exceptions.HTTPError as err:
+        print("There was an error running your code:")
+        print(err)
+    except requests.exceptions.RequestException as err:
+        print("Looks like something is wrong with server:")
+        print(err)
+    except KeyError as err:
+        print("Failed to parse response:")
+        print(err)
 
 
 def _authenticate(email=None, password=None):
-	"""
-	:param email:
-	:param password:
-	:return:
-	"""
-	if email is None:
-		try:
-			input_fun = raw_input
-		except NameError:
-			input_fun = input
-		email = input_fun('IBM QE user (e-mail) > ')
-	if password is None:
-		password = getpass.getpass(prompt='IBM QE password > ')
+    """
+    :param email:
+    :param password:
+    :return:
+    """
+    if email is None:
+        try:
+            input_fun = raw_input
+        except NameError:
+            input_fun = input
+        email = input_fun('IBM QE user (e-mail) > ')
+    if password is None:
+        password = getpass.getpass(prompt='IBM QE password > ')
 
-	r = requests.post(urljoin(_api_url, 'users/login'),
-	                  data={"email": email, "password": password})
-	logging.info(r.text)
-	r.raise_for_status()
+    r = requests.post(urljoin(_api_url, 'users/login'),
+                      data={"email": email, "password": password})
+    logging.info(r.text)
+    r.raise_for_status()
 
-	json_data = r.json()
-	user_id = json_data['userId']
-	access_token = json_data['id']
+    json_data = r.json()
+    user_id = json_data['userId']
+    access_token = json_data['id']
 
-	return user_id, access_token
+    return user_id, access_token
 
 
 def _save_code(json_qasm, name, user_id, access_token):
-	suffix = 'users/{user_id}/codes'.format(user_id=user_id)
+    suffix = 'users/{user_id}/codes'.format(user_id=user_id)
 
-	name_item = '"name":"{name}", "jsonQASM":'.format(name=name)
-	json_body = ''.join([name_item, json_qasm])
-	json_data = ''.join(['{', json_body, '}'])
+    name_item = '"name":"{name}", "jsonQASM":'.format(name=name)
+    json_body = ''.join([name_item, json_qasm])
+    json_data = ''.join(['{', json_body, '}'])
 
-	r = requests.post(urljoin(_api_url, suffix),
-	                  data=json_data,
-	                  params={"access_token": access_token},
-	                  headers={"Content-Type": "application/json"})
-	logging.info(r.request.body)
-	logging.info(r.request.url)
-	logging.info(r.text)
-	r.raise_for_status()
+    r = requests.post(urljoin(_api_url, suffix),
+                      data=json_data,
+                      params={"access_token": access_token},
+                      headers={"Content-Type": "application/json"})
+    logging.info(r.request.body)
+    logging.info(r.request.url)
+    logging.info(r.text)
+    r.raise_for_status()
 
-	return r.json()['idCode']
+    return r.json()['idCode']
 
 
 def _run(json_qasm, device, user_id, code_id, access_token, shots):
-	suffix_tmpl = 'users/{user_id}/codes/{code_id}/executions'
-	suffix = suffix_tmpl.format(user_id=user_id, code_id=code_id)
+    suffix_tmpl = 'users/{user_id}/codes/{code_id}/executions'
+    suffix = suffix_tmpl.format(user_id=user_id, code_id=code_id)
 
-	json_data = ''.join(['{"jsonQasm":', json_qasm, '}'])
-	
-	r = requests.post(urljoin(_api_url, suffix),
-	                  data=json_data,
-	                  params={"access_token": access_token,
-	                          "deviceRunType": device,
-	                          "fromCache": "false",
-	                          "shots": shots},
-	                  headers={"Content-Type": "application/json"})
-	logging.info(r.request.body)
-	logging.info(r.request.url)
-	logging.info(r.text)
-	r.raise_for_status()
+    json_data = ''.join(['{"jsonQasm":', json_qasm, '}'])
 
-	r_json = r.json()
-	execution_id = r_json["execution"]["id"]
-	return execution_id
+    r = requests.post(urljoin(_api_url, suffix),
+                      data=json_data,
+                      params={"access_token": access_token,
+                              "deviceRunType": device,
+                              "fromCache": "false",
+                              "shots": shots},
+                      headers={"Content-Type": "application/json"})
+    logging.info(r.request.body)
+    logging.info(r.request.url)
+    logging.info(r.text)
+    r.raise_for_status()
+
+    r_json = r.json()
+    execution_id = r_json["execution"]["id"]
+    return execution_id
 
 
 def _get_result(execution_id, access_token, num_retries=100, interval=1):
-	suffix = 'Executions/{execution_id}'.format(execution_id=execution_id)
+    suffix = 'Executions/{execution_id}'.format(execution_id=execution_id)
 
-	for _ in range(num_retries):
-		r = requests.get(urljoin(_api_url, suffix),
-		                 params={"access_token": access_token})
-		logging.info(r.request.url)
-		logging.info(r.text)
-		r.raise_for_status()
+    for _ in range(num_retries):
+        r = requests.get(urljoin(_api_url, suffix),
+                         params={"access_token": access_token})
+        logging.info(r.request.url)
+        logging.info(r.text)
+        r.raise_for_status()
 
-		r_json = r.json()
-		status = r_json["status"]["id"]
-		if status == "DONE":
-			return r_json["result"]
-		time.sleep(interval)
+        r_json = r.json()
+        status = r_json["status"]["id"]
+        if status == "DONE":
+            return r_json["result"]
+        time.sleep(interval)

--- a/projectq/backends/_ibm/_ibm_http_client_test.py
+++ b/projectq/backends/_ibm/_ibm_http_client_test.py
@@ -30,257 +30,257 @@ _api_url_status = 'https://quantumexperience.ng.bluemix.net/api/'
 
 
 def test_send_real_device_online_verbose(monkeypatch):
-	json_qasm = "my_json_qasm"
-	name = 'projectq_test'
-	access_token = "access"
-	user_id = 2016
-	code_id = 11
-	name_item = '"name":"{name}", "jsonQASM":'.format(name=name)
-	json_body = ''.join([name_item, json_qasm])
-	json_data = ''.join(['{', json_body, '}'])
-	shots = 1
-	device = "real"
-	json_data_run = ''.join(['{"jsonQasm":', json_qasm, '}'])
-	execution_id = 3
-	result_ready = [False]
-	result = "my_result"
-	request_num = [0] # To assert correct order of calls
-	# Mock of IBM server:
-	def mocked_requests_get(*args, **kwargs):
-		class MockRequest:
-			def __init__(self, url=""):
-				self.url = url
-		class MockResponse:
-			def __init__(self, json_data, status_code):
-				self.json_data = json_data
-				self.status_code = status_code
-				self.request = MockRequest()
-				self.text = ""
+    json_qasm = "my_json_qasm"
+    name = 'projectq_test'
+    access_token = "access"
+    user_id = 2016
+    code_id = 11
+    name_item = '"name":"{name}", "jsonQASM":'.format(name=name)
+    json_body = ''.join([name_item, json_qasm])
+    json_data = ''.join(['{', json_body, '}'])
+    shots = 1
+    device = "real"
+    json_data_run = ''.join(['{"jsonQasm":', json_qasm, '}'])
+    execution_id = 3
+    result_ready = [False]
+    result = "my_result"
+    request_num = [0] # To assert correct order of calls
+    # Mock of IBM server:
+    def mocked_requests_get(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, url=""):
+                self.url = url
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+                self.request = MockRequest()
+                self.text = ""
 
-			def json(self):
-				return self.json_data
+            def json(self):
+                return self.json_data
 
-			def raise_for_status(self):
-				pass
+            def raise_for_status(self):
+                pass
 
-		# Accessing status of device. Return online.
-		if (args[0] == urljoin(_api_url_status, "Status/queue") and
-			kwargs["params"]["device"] == "chip_real" and
-			request_num[0] == 0):
-			request_num[0] += 1
-			return MockResponse({"state": True}, 200)
-		# Getting result
-		elif (args[0] == urljoin(_api_url, 
-		  "Executions/{execution_id}".format(execution_id=execution_id)) and
-		  kwargs["params"]["access_token"] == access_token and 
-		  not result_ready[0] and request_num[0] == 4):
-			result_ready[0] = True
-			return MockResponse({"status":{"id": "NotDone"}}, 200)
-		elif (args[0] == urljoin(_api_url, 
-		  "Executions/{execution_id}".format(execution_id=execution_id)) and
-		  kwargs["params"]["access_token"] == access_token and 
-		  result_ready[0] and request_num[0] == 4):
-			return MockResponse({"status":{"id": "DONE"}, 
-			                     "result": result}, 200)
+        # Accessing status of device. Return online.
+        if (args[0] == urljoin(_api_url_status, "Status/queue") and
+            kwargs["params"]["device"] == "chip_real" and
+            request_num[0] == 0):
+            request_num[0] += 1
+            return MockResponse({"state": True}, 200)
+        # Getting result
+        elif (args[0] == urljoin(_api_url,
+          "Executions/{execution_id}".format(execution_id=execution_id)) and
+          kwargs["params"]["access_token"] == access_token and
+          not result_ready[0] and request_num[0] == 4):
+            result_ready[0] = True
+            return MockResponse({"status":{"id": "NotDone"}}, 200)
+        elif (args[0] == urljoin(_api_url,
+          "Executions/{execution_id}".format(execution_id=execution_id)) and
+          kwargs["params"]["access_token"] == access_token and
+          result_ready[0] and request_num[0] == 4):
+            return MockResponse({"status":{"id": "DONE"},
+                                 "result": result}, 200)
 
-	def mocked_requests_post(*args, **kwargs):
-		class MockRequest:
-			def __init__(self, body="", url=""):
-				self.body = body
-				self.url = url
-		class MockPostResponse:
-			def __init__(self, json_data, text=" "):
-				self.json_data = json_data
-				self.text = text
-				self.request = MockRequest()
+    def mocked_requests_post(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, body="", url=""):
+                self.body = body
+                self.url = url
+        class MockPostResponse:
+            def __init__(self, json_data, text=" "):
+                self.json_data = json_data
+                self.text = text
+                self.request = MockRequest()
 
-			def json(self):
-				return self.json_data
+            def json(self):
+                return self.json_data
 
-			def raise_for_status(self):
-				pass
-		# Authentication
-		if (args[0] == urljoin(_api_url, "users/login") and
-			    kwargs["data"]["email"] == email and
-			    kwargs["data"]["password"] == password and
-			    request_num[0] == 1):
-			request_num[0] += 1 
-			return MockPostResponse({"userId": user_id, "id": access_token})
-		# Save code
-		elif (args[0] == urljoin(_api_url, 
-		                 "users/{user_id}/codes".format(user_id=user_id)) and
-		        kwargs["data"] == json_data and
-		        kwargs["params"]["access_token"] == access_token and
-		        kwargs["headers"]["Content-Type"] == "application/json" and
-		        request_num[0] == 2):
-			request_num[0] += 1
-			return MockPostResponse({"idCode": code_id})
-		# Run code
-		elif (args[0] == urljoin(_api_url, 
-		  "users/{user_id}/codes/{code_id}/executions".format(user_id=user_id,
-		                                                 code_id=code_id)) and
-		        kwargs["data"] == json_data_run and
-		        kwargs["params"]["access_token"] == access_token and
-		        kwargs["params"]["deviceRunType"] == device and
-		        kwargs["params"]["fromCache"] == "false" and
-		        kwargs["params"]["shots"] == shots and
-		        kwargs["headers"]["Content-Type"] == "application/json" and
-		        request_num[0] == 3):
-			request_num[0] += 1
-			return MockPostResponse({"execution": {"id": execution_id}})
+            def raise_for_status(self):
+                pass
+        # Authentication
+        if (args[0] == urljoin(_api_url, "users/login") and
+                kwargs["data"]["email"] == email and
+                kwargs["data"]["password"] == password and
+                request_num[0] == 1):
+            request_num[0] += 1
+            return MockPostResponse({"userId": user_id, "id": access_token})
+        # Save code
+        elif (args[0] == urljoin(_api_url,
+                         "users/{user_id}/codes".format(user_id=user_id)) and
+                kwargs["data"] == json_data and
+                kwargs["params"]["access_token"] == access_token and
+                kwargs["headers"]["Content-Type"] == "application/json" and
+                request_num[0] == 2):
+            request_num[0] += 1
+            return MockPostResponse({"idCode": code_id})
+        # Run code
+        elif (args[0] == urljoin(_api_url,
+          "users/{user_id}/codes/{code_id}/executions".format(user_id=user_id,
+                                                         code_id=code_id)) and
+                kwargs["data"] == json_data_run and
+                kwargs["params"]["access_token"] == access_token and
+                kwargs["params"]["deviceRunType"] == device and
+                kwargs["params"]["fromCache"] == "false" and
+                kwargs["params"]["shots"] == shots and
+                kwargs["headers"]["Content-Type"] == "application/json" and
+                request_num[0] == 3):
+            request_num[0] += 1
+            return MockPostResponse({"execution": {"id": execution_id}})
 
-	monkeypatch.setattr("requests.get", mocked_requests_get)
-	monkeypatch.setattr("requests.post", mocked_requests_post)
-	# Patch login data
-	password = 12345
-	email = "test@projectq.ch"
-	monkeypatch.setitem(__builtins__, "input", lambda x: email)
-	monkeypatch.setitem(__builtins__, "raw_input", lambda x: email)
-	def user_password_input(prompt):
-		if prompt == "IBM QE password > ":
-			return password
-	monkeypatch.setattr("getpass.getpass", user_password_input)
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    password = 12345
+    email = "test@projectq.ch"
+    monkeypatch.setitem(__builtins__, "input", lambda x: email)
+    monkeypatch.setitem(__builtins__, "raw_input", lambda x: email)
+    def user_password_input(prompt):
+        if prompt == "IBM QE password > ":
+            return password
+    monkeypatch.setattr("getpass.getpass", user_password_input)
 
-	# Code to test:
-	res = _ibm_http_client.send(json_qasm, name=name, 
-	                            device="real",
-	                            user=None, password=None, 
-	                            shots=shots, verbose=True)
-	print(res)
-	assert res == result
+    # Code to test:
+    res = _ibm_http_client.send(json_qasm, name=name,
+                                device="real",
+                                user=None, password=None,
+                                shots=shots, verbose=True)
+    print(res)
+    assert res == result
 
 
 def test_send_real_device_offline(monkeypatch):
-	def mocked_requests_get(*args, **kwargs):
-		class MockResponse:
-			def __init__(self, json_data, status_code):
-				self.json_data = json_data
-				self.status_code = status_code
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
 
-			def json(self):
-				return self.json_data
+            def json(self):
+                return self.json_data
 
-		# Accessing status of device. Return online.
-		if (args[0] == urljoin(_api_url_status, "Status/queue") and
-			kwargs["params"]["device"] == "chip_real"):
-			return MockResponse({"state": False}, 200)
-	monkeypatch.setattr("requests.get", mocked_requests_get)
-	shots = 1
-	json_qasm = "my_json_qasm"
-	name = 'projectq_test'
-	with pytest.raises(_ibm_http_client.DeviceOfflineError):
-		_ibm_http_client.send(json_qasm, name=name, 
-		                            device="real",
-		                            user=None, password=None, 
-		                            shots=shots, verbose=True)
+        # Accessing status of device. Return online.
+        if (args[0] == urljoin(_api_url_status, "Status/queue") and
+            kwargs["params"]["device"] == "chip_real"):
+            return MockResponse({"state": False}, 200)
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    shots = 1
+    json_qasm = "my_json_qasm"
+    name = 'projectq_test'
+    with pytest.raises(_ibm_http_client.DeviceOfflineError):
+        _ibm_http_client.send(json_qasm, name=name,
+                                    device="real",
+                                    user=None, password=None,
+                                    shots=shots, verbose=True)
 
 
 def test_send_that_errors_are_caught(monkeypatch):
-	def mocked_requests_get(*args, **kwargs):
-		class MockResponse:
-			def __init__(self, json_data, status_code):
-				self.json_data = json_data
-				self.status_code = status_code
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
 
-			def json(self):
-				return self.json_data
+            def json(self):
+                return self.json_data
 
-		# Accessing status of device. Return online.
-		if (args[0] == urljoin(_api_url_status, "Status/queue") and
-			kwargs["params"]["device"] == "chip_real"):
-			return MockResponse({"state": True}, 200)
-	def mocked_requests_post(*args, **kwargs):
-		# Test that this error gets caught
-		raise requests.exceptions.HTTPError
-	monkeypatch.setattr("requests.get", mocked_requests_get)
-	monkeypatch.setattr("requests.post", mocked_requests_post)
-	# Patch login data
-	password = 12345
-	email = "test@projectq.ch"
-	monkeypatch.setitem(__builtins__, "input", lambda x: email)
-	monkeypatch.setitem(__builtins__, "raw_input", lambda x: email)
-	def user_password_input(prompt):
-		if prompt == "IBM QE password > ":
-			return password
-	monkeypatch.setattr("getpass.getpass", user_password_input)
-	shots = 1
-	json_qasm = "my_json_qasm"
-	name = 'projectq_test'
-	_ibm_http_client.send(json_qasm, name=name, 
-	                            device="real",
-	                            user=None, password=None, 
-	                            shots=shots, verbose=True)
+        # Accessing status of device. Return online.
+        if (args[0] == urljoin(_api_url_status, "Status/queue") and
+            kwargs["params"]["device"] == "chip_real"):
+            return MockResponse({"state": True}, 200)
+    def mocked_requests_post(*args, **kwargs):
+        # Test that this error gets caught
+        raise requests.exceptions.HTTPError
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    password = 12345
+    email = "test@projectq.ch"
+    monkeypatch.setitem(__builtins__, "input", lambda x: email)
+    monkeypatch.setitem(__builtins__, "raw_input", lambda x: email)
+    def user_password_input(prompt):
+        if prompt == "IBM QE password > ":
+            return password
+    monkeypatch.setattr("getpass.getpass", user_password_input)
+    shots = 1
+    json_qasm = "my_json_qasm"
+    name = 'projectq_test'
+    _ibm_http_client.send(json_qasm, name=name,
+                                device="real",
+                                user=None, password=None,
+                                shots=shots, verbose=True)
 
 
 def test_send_that_errors_are_caught2(monkeypatch):
-	def mocked_requests_get(*args, **kwargs):
-		class MockResponse:
-			def __init__(self, json_data, status_code):
-				self.json_data = json_data
-				self.status_code = status_code
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
 
-			def json(self):
-				return self.json_data
+            def json(self):
+                return self.json_data
 
-		# Accessing status of device. Return online.
-		if (args[0] == urljoin(_api_url_status, "Status/queue") and
-			kwargs["params"]["device"] == "chip_real"):
-			return MockResponse({"state": True}, 200)
-	def mocked_requests_post(*args, **kwargs):
-		# Test that this error gets caught
-		raise requests.exceptions.RequestException 
-	monkeypatch.setattr("requests.get", mocked_requests_get)
-	monkeypatch.setattr("requests.post", mocked_requests_post)
-	# Patch login data
-	password = 12345
-	email = "test@projectq.ch"
-	monkeypatch.setitem(__builtins__, "input", lambda x: email)
-	monkeypatch.setitem(__builtins__, "raw_input", lambda x: email)
-	def user_password_input(prompt):
-		if prompt == "IBM QE password > ":
-			return password
-	monkeypatch.setattr("getpass.getpass", user_password_input)
-	shots = 1
-	json_qasm = "my_json_qasm"
-	name = 'projectq_test'
-	_ibm_http_client.send(json_qasm, name=name, 
-	                            device="real",
-	                            user=None, password=None, 
-	                            shots=shots, verbose=True)
+        # Accessing status of device. Return online.
+        if (args[0] == urljoin(_api_url_status, "Status/queue") and
+            kwargs["params"]["device"] == "chip_real"):
+            return MockResponse({"state": True}, 200)
+    def mocked_requests_post(*args, **kwargs):
+        # Test that this error gets caught
+        raise requests.exceptions.RequestException
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    password = 12345
+    email = "test@projectq.ch"
+    monkeypatch.setitem(__builtins__, "input", lambda x: email)
+    monkeypatch.setitem(__builtins__, "raw_input", lambda x: email)
+    def user_password_input(prompt):
+        if prompt == "IBM QE password > ":
+            return password
+    monkeypatch.setattr("getpass.getpass", user_password_input)
+    shots = 1
+    json_qasm = "my_json_qasm"
+    name = 'projectq_test'
+    _ibm_http_client.send(json_qasm, name=name,
+                                device="real",
+                                user=None, password=None,
+                                shots=shots, verbose=True)
 
 
 def test_send_that_errors_are_caught3(monkeypatch):
-	def mocked_requests_get(*args, **kwargs):
-		class MockResponse:
-			def __init__(self, json_data, status_code):
-				self.json_data = json_data
-				self.status_code = status_code
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
 
-			def json(self):
-				return self.json_data
+            def json(self):
+                return self.json_data
 
-		# Accessing status of device. Return online.
-		if (args[0] == urljoin(_api_url_status, "Status/queue") and
-			kwargs["params"]["device"] == "chip_real"):
-			return MockResponse({"state": True}, 200)
-	def mocked_requests_post(*args, **kwargs):
-		# Test that this error gets caught
-		raise KeyError 
-	monkeypatch.setattr("requests.get", mocked_requests_get)
-	monkeypatch.setattr("requests.post", mocked_requests_post)
-	# Patch login data
-	password = 12345
-	email = "test@projectq.ch"
-	monkeypatch.setitem(__builtins__, "input", lambda x: email)
-	monkeypatch.setitem(__builtins__, "raw_input", lambda x: email)
-	def user_password_input(prompt):
-		if prompt == "IBM QE password > ":
-			return password
-	monkeypatch.setattr("getpass.getpass", user_password_input)
-	shots = 1
-	json_qasm = "my_json_qasm"
-	name = 'projectq_test'
-	_ibm_http_client.send(json_qasm, name=name, 
-	                            device="real",
-	                            user=None, password=None, 
-	                            shots=shots, verbose=True)
+        # Accessing status of device. Return online.
+        if (args[0] == urljoin(_api_url_status, "Status/queue") and
+            kwargs["params"]["device"] == "chip_real"):
+            return MockResponse({"state": True}, 200)
+    def mocked_requests_post(*args, **kwargs):
+        # Test that this error gets caught
+        raise KeyError
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    password = 12345
+    email = "test@projectq.ch"
+    monkeypatch.setitem(__builtins__, "input", lambda x: email)
+    monkeypatch.setitem(__builtins__, "raw_input", lambda x: email)
+    def user_password_input(prompt):
+        if prompt == "IBM QE password > ":
+            return password
+    monkeypatch.setattr("getpass.getpass", user_password_input)
+    shots = 1
+    json_qasm = "my_json_qasm"
+    name = 'projectq_test'
+    _ibm_http_client.send(json_qasm, name=name,
+                                device="real",
+                                user=None, password=None,
+                                shots=shots, verbose=True)

--- a/projectq/backends/_ibm/_ibm_test.py
+++ b/projectq/backends/_ibm/_ibm_test.py
@@ -37,31 +37,31 @@ _api_url_status = 'https://quantumexperience.ng.bluemix.net/api/'
 
 
 @pytest.mark.parametrize("single_qubit_gate, is_available", [
-	(X, True), (Y, True), (Z, True), (T, True), (Tdag, True), (S, True),
-	(Sdag, True), (Allocate,True), (Deallocate, True), (Measure, True),
-	(NOT, True), (Rx(0.5), False)])
+    (X, True), (Y, True), (Z, True), (T, True), (Tdag, True), (S, True),
+    (Sdag, True), (Allocate,True), (Deallocate, True), (Measure, True),
+    (NOT, True), (Rx(0.5), False)])
 def test_ibm_backend_is_available(single_qubit_gate, is_available):
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	qubit1 = eng.allocate_qubit()
-	ibm_backend = _ibm.IBMBackend()
-	cmd = Command(eng, single_qubit_gate , (qubit1,))
-	assert ibm_backend.is_available(cmd) == is_available
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    qubit1 = eng.allocate_qubit()
+    ibm_backend = _ibm.IBMBackend()
+    cmd = Command(eng, single_qubit_gate , (qubit1,))
+    assert ibm_backend.is_available(cmd) == is_available
 
 
 @pytest.mark.parametrize("num_ctrl_qubits, is_available", [
-	(0, True), (1, True), (2, False), (3, False)])
+    (0, True), (1, True), (2, False), (3, False)])
 def test_ibm_backend_is_available_control_not(num_ctrl_qubits, is_available):
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	qubit1 = eng.allocate_qubit()
-	qureg = eng.allocate_qureg(num_ctrl_qubits)
-	ibm_backend = _ibm.IBMBackend()
-	cmd = Command(eng, NOT , (qubit1,))
-	cmd.add_control_qubits(qureg)
-	assert ibm_backend.is_available(cmd) == is_available
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    qubit1 = eng.allocate_qubit()
+    qureg = eng.allocate_qureg(num_ctrl_qubits)
+    ibm_backend = _ibm.IBMBackend()
+    cmd = Command(eng, NOT , (qubit1,))
+    cmd.add_control_qubits(qureg)
+    assert ibm_backend.is_available(cmd) == is_available
 
 
 def test_ibm_backend_functional_test(monkeypatch):
-	from projectq.setups.decompositions import (crz2cxandrz,
+    from projectq.setups.decompositions import (crz2cxandrz,
                                             r2rzandph,
                                             ph2r,
                                             globalphase,
@@ -69,26 +69,26 @@ def test_ibm_backend_functional_test(monkeypatch):
                                             toffoli2cnotandtgate,
                                             entangle,
                                             qft2crandhadamard)
-	correct_info = '{"playground":[{"line":0,"name":"q","gates":[{"position":0,"name":"h","qasm":"h"},{"position":2,"name":"h","qasm":"h"},{"position":3,"name":"measure","qasm":"measure"}]},{"line":1,"name":"q","gates":[{"position":0,"name":"h","qasm":"h"},{"position":3,"name":"h","qasm":"h"},{"position":4,"name":"measure","qasm":"measure"}]},{"line":2,"name":"q","gates":[{"position":1,"name":"cx","qasm":"cx","to":0},{"position":2,"name":"cx","qasm":"cx","to":1},{"position":3,"name":"h","qasm":"h"},{"position":4,"name":"measure","qasm":"measure"}]},{"line":3,"name":"q","gates":[]},{"line":4,"name":"q","gates":[]}],"numberColumns":40,"numberLines":5,"numberGates":200,"hasMeasures":true,"topology":"250e969c6b9e68aa2a045ffbceb3ac33"}'
-	# patch send 
-	def mock_send(*args, **kwargs):
-		assert args[0] == correct_info
-		return {'date': '2017-01-19T14:28:47.622Z', 'data': {'time': 14.429004907608032, 'serialNumberDevice': 'Real5Qv1', 'p': {'labels': ['00000', '00001', '00010', '00011', '00100', '00101', '00110', '00111'], 'values': [0.4521484375, 0.0419921875, 0.0185546875, 0.0146484375, 0.005859375, 0.0263671875, 0.0537109375, 0.38671875], 'qubits': [0, 1, 2]}, 'qasm': 'IBMQASM 2.0;\n\ninclude "qelib1.inc";\nqreg q[5];\ncreg c[5];\n\nh q[0];\nh q[1];\nCX q[0],q[2];\nh q[0];\nCX q[1],q[2];\nmeasure q[0] -> c[0];\nh q[1];\nh q[2];\nmeasure q[1] -> c[1];\nmeasure q[2] -> c[2];\n'}}
-	monkeypatch.setattr(_ibm, "send", mock_send)
+    correct_info = '{"playground":[{"line":0,"name":"q","gates":[{"position":0,"name":"h","qasm":"h"},{"position":2,"name":"h","qasm":"h"},{"position":3,"name":"measure","qasm":"measure"}]},{"line":1,"name":"q","gates":[{"position":0,"name":"h","qasm":"h"},{"position":3,"name":"h","qasm":"h"},{"position":4,"name":"measure","qasm":"measure"}]},{"line":2,"name":"q","gates":[{"position":1,"name":"cx","qasm":"cx","to":0},{"position":2,"name":"cx","qasm":"cx","to":1},{"position":3,"name":"h","qasm":"h"},{"position":4,"name":"measure","qasm":"measure"}]},{"line":3,"name":"q","gates":[]},{"line":4,"name":"q","gates":[]}],"numberColumns":40,"numberLines":5,"numberGates":200,"hasMeasures":true,"topology":"250e969c6b9e68aa2a045ffbceb3ac33"}'
+    # patch send
+    def mock_send(*args, **kwargs):
+        assert args[0] == correct_info
+        return {'date': '2017-01-19T14:28:47.622Z', 'data': {'time': 14.429004907608032, 'serialNumberDevice': 'Real5Qv1', 'p': {'labels': ['00000', '00001', '00010', '00011', '00100', '00101', '00110', '00111'], 'values': [0.4521484375, 0.0419921875, 0.0185546875, 0.0146484375, 0.005859375, 0.0263671875, 0.0537109375, 0.38671875], 'qubits': [0, 1, 2]}, 'qasm': 'IBMQASM 2.0;\n\ninclude "qelib1.inc";\nqreg q[5];\ncreg c[5];\n\nh q[0];\nh q[1];\nCX q[0],q[2];\nh q[0];\nCX q[1],q[2];\nmeasure q[0] -> c[0];\nh q[1];\nh q[2];\nmeasure q[1] -> c[1];\nmeasure q[2] -> c[2];\n'}}
+    monkeypatch.setattr(_ibm, "send", mock_send)
 
-	backend = _ibm.IBMBackend()
-	engine_list = [TagRemover(), LocalOptimizer(10), AutoReplacer(), 
-	               TagRemover(), IBMCNOTMapper(), LocalOptimizer(10)]
-	eng = MainEngine(backend=backend, engine_list=engine_list)
-	unused_qubit = eng.allocate_qubit()
-	qureg = eng.allocate_qureg(3)
-	# entangle the qureg
-	Entangle | qureg
-	# measure; should be all-0 or all-1
-	Measure | qureg
-	# run the circuit
-	eng.flush()
-	prob_dict = eng.backend.get_probabilities([qureg[0],qureg[2],qureg[1]])
-	assert prob_dict['111'] == pytest.approx(0.38671875)
-	assert prob_dict['101'] == pytest.approx(0.0263671875)
+    backend = _ibm.IBMBackend()
+    engine_list = [TagRemover(), LocalOptimizer(10), AutoReplacer(),
+                   TagRemover(), IBMCNOTMapper(), LocalOptimizer(10)]
+    eng = MainEngine(backend=backend, engine_list=engine_list)
+    unused_qubit = eng.allocate_qubit()
+    qureg = eng.allocate_qureg(3)
+    # entangle the qureg
+    Entangle | qureg
+    # measure; should be all-0 or all-1
+    Measure | qureg
+    # run the circuit
+    eng.flush()
+    prob_dict = eng.backend.get_probabilities([qureg[0],qureg[2],qureg[1]])
+    assert prob_dict['111'] == pytest.approx(0.38671875)
+    assert prob_dict['101'] == pytest.approx(0.0263671875)
 

--- a/projectq/backends/_printer.py
+++ b/projectq/backends/_printer.py
@@ -24,87 +24,87 @@ from projectq.meta import get_control_count
 
 
 class CommandPrinter(BasicEngine):
-	"""
-	CommandPrinter is a compiler engine which prints commands to stdout prior
-	to sending them on to the next compiler engine.
-	"""
-	def __init__(self, accept_input=True, default_measure=False, in_place=False):
-		"""
-		Initialize a CommandPrinter.
-		
-		Args:
-			accept_input (bool): If accept_input is true, the printer queries the user to
-				input measurement results if the CommandPrinter is the last engine.
-				Otherwise, all measurements yield 0.
-			default_measure (bool): Default measurement result (if accept_input is False).
-			in_place (bool): If in_place is true, all output is written on the same line of
-				the terminal.
-		"""
-		BasicEngine.__init__(self)
-		self._accept_input = accept_input
-		self._default_measure = default_measure
-		self._in_place = in_place
+    """
+    CommandPrinter is a compiler engine which prints commands to stdout prior
+    to sending them on to the next compiler engine.
+    """
+    def __init__(self, accept_input=True, default_measure=False, in_place=False):
+        """
+        Initialize a CommandPrinter.
 
-	def is_available(self, cmd):
-		"""
-		Specialized implementation of is_available: Returns True if the
-		CommandPrinter is the last engine (since it can print any command).
-		
-		Args:
-			cmd (Command): Command of which to check availability (all Commands can
-				be printed).
-		Returns:
-			availability (bool): True, unless the next engine cannot handle the
-			Command (if there is a next engine).
-		"""
-		try:
-			return BasicEngine.is_available(self, cmd)
-		except LastEngineException:
-			return True
-		
-	def _print_cmd(self, cmd):
-		"""
-		Print a command or, if the command is a measurement instruction and
-		the CommandPrinter is the last engine in the engine pipeline: Query the
-		user for the measurement result (if accept_input = True) / Set the result
-		to 0 (if it's False).
-		
-		Args:
-			cmd (Command): Command to print.
-		"""
-		if self.is_last_engine and cmd.gate == Measure:
-			assert(get_control_count(cmd) == 0)
-			print(cmd)
-			for qureg in cmd.qubits:
-				for qubit in qureg:
-					if self._accept_input:
-						m = None
-						while m != '0' and m != '1' and m != 1 and m != 0:
-							prompt = ("Input measurement result (0 or 1) for qubit "
-							          + str(qubit) + ": ")
-							m = input(prompt)
-					else:
-						m = self._default_measure
-					m = int(m)
-					self.main_engine.set_measurement_result(qubit, m)
-		else:
-			if self._in_place:
-				sys.stdout.write("\0\r\t\x1b[K" + str(cmd) + "\r")
-			else:
-				print(cmd)
-			
-	def receive(self, command_list):
-		"""
-		Receive a list of commands from the previous engine, print the commands,
-		and then send them on to the next engine.
-		
-		Args:
-			command_list (list<Command>): List of Commands to print (and potentially
-				send on to the next engine).
-		"""
-		for cmd in command_list:
-			if not cmd.gate == FlushGate():
-				self._print_cmd(cmd)
-			# (try to) send on
-			if not self.is_last_engine:
-				self.send([cmd])
+        Args:
+            accept_input (bool): If accept_input is true, the printer queries the user to
+                input measurement results if the CommandPrinter is the last engine.
+                Otherwise, all measurements yield 0.
+            default_measure (bool): Default measurement result (if accept_input is False).
+            in_place (bool): If in_place is true, all output is written on the same line of
+                the terminal.
+        """
+        BasicEngine.__init__(self)
+        self._accept_input = accept_input
+        self._default_measure = default_measure
+        self._in_place = in_place
+
+    def is_available(self, cmd):
+        """
+        Specialized implementation of is_available: Returns True if the
+        CommandPrinter is the last engine (since it can print any command).
+
+        Args:
+            cmd (Command): Command of which to check availability (all Commands can
+                be printed).
+        Returns:
+            availability (bool): True, unless the next engine cannot handle the
+            Command (if there is a next engine).
+        """
+        try:
+            return BasicEngine.is_available(self, cmd)
+        except LastEngineException:
+            return True
+
+    def _print_cmd(self, cmd):
+        """
+        Print a command or, if the command is a measurement instruction and
+        the CommandPrinter is the last engine in the engine pipeline: Query the
+        user for the measurement result (if accept_input = True) / Set the result
+        to 0 (if it's False).
+
+        Args:
+            cmd (Command): Command to print.
+        """
+        if self.is_last_engine and cmd.gate == Measure:
+            assert(get_control_count(cmd) == 0)
+            print(cmd)
+            for qureg in cmd.qubits:
+                for qubit in qureg:
+                    if self._accept_input:
+                        m = None
+                        while m != '0' and m != '1' and m != 1 and m != 0:
+                            prompt = ("Input measurement result (0 or 1) for qubit "
+                                      + str(qubit) + ": ")
+                            m = input(prompt)
+                    else:
+                        m = self._default_measure
+                    m = int(m)
+                    self.main_engine.set_measurement_result(qubit, m)
+        else:
+            if self._in_place:
+                sys.stdout.write("\0\r\t\x1b[K" + str(cmd) + "\r")
+            else:
+                print(cmd)
+
+    def receive(self, command_list):
+        """
+        Receive a list of commands from the previous engine, print the commands,
+        and then send them on to the next engine.
+
+        Args:
+            command_list (list<Command>): List of Commands to print (and potentially
+                send on to the next engine).
+        """
+        for cmd in command_list:
+            if not cmd.gate == FlushGate():
+                self._print_cmd(cmd)
+            # (try to) send on
+            if not self.is_last_engine:
+                self.send([cmd])

--- a/projectq/backends/_printer_test.py
+++ b/projectq/backends/_printer_test.py
@@ -24,40 +24,40 @@ from projectq.backends import _printer
 
 
 def test_command_printer_is_available():
-	inline_cmd_printer = _printer.CommandPrinter()
-	cmd_printer = _printer.CommandPrinter()
-	def available_cmd(self, cmd):
-		return cmd.gate == H
-	filter = InstructionFilter(available_cmd)
-	eng = MainEngine(backend=cmd_printer, 
-	                 engine_list=[inline_cmd_printer, filter])
-	qubit = eng.allocate_qubit()
-	cmd0 = Command(eng, H, (qubit,))
-	cmd1 = Command(eng, T, (qubit,))
-	assert inline_cmd_printer.is_available(cmd0)
-	assert not inline_cmd_printer.is_available(cmd1)
-	assert cmd_printer.is_available(cmd0)
-	assert cmd_printer.is_available(cmd1)
+    inline_cmd_printer = _printer.CommandPrinter()
+    cmd_printer = _printer.CommandPrinter()
+    def available_cmd(self, cmd):
+        return cmd.gate == H
+    filter = InstructionFilter(available_cmd)
+    eng = MainEngine(backend=cmd_printer,
+                     engine_list=[inline_cmd_printer, filter])
+    qubit = eng.allocate_qubit()
+    cmd0 = Command(eng, H, (qubit,))
+    cmd1 = Command(eng, T, (qubit,))
+    assert inline_cmd_printer.is_available(cmd0)
+    assert not inline_cmd_printer.is_available(cmd1)
+    assert cmd_printer.is_available(cmd0)
+    assert cmd_printer.is_available(cmd1)
 
 
 def test_command_printer_accept_input(monkeypatch):
-	cmd_printer = _printer.CommandPrinter()
-	eng = MainEngine(backend=cmd_printer, engine_list=[DummyEngine()])
-	monkeypatch.setattr(_printer, "input", lambda x: 1)
-	qubit = eng.allocate_qubit()
-	Measure | qubit
-	assert int(qubit) == 1
-	monkeypatch.setattr(_printer, "input", lambda x: 0)
-	qubit = eng.allocate_qubit()
-	NOT | qubit
-	Measure | qubit
-	assert int(qubit) == 0
+    cmd_printer = _printer.CommandPrinter()
+    eng = MainEngine(backend=cmd_printer, engine_list=[DummyEngine()])
+    monkeypatch.setattr(_printer, "input", lambda x: 1)
+    qubit = eng.allocate_qubit()
+    Measure | qubit
+    assert int(qubit) == 1
+    monkeypatch.setattr(_printer, "input", lambda x: 0)
+    qubit = eng.allocate_qubit()
+    NOT | qubit
+    Measure | qubit
+    assert int(qubit) == 0
 
 
 def test_command_printer_no_input_default_measure():
-	cmd_printer = _printer.CommandPrinter(accept_input=False)
-	eng = MainEngine(backend=cmd_printer, engine_list=[DummyEngine()])
-	qubit = eng.allocate_qubit()
-	NOT | qubit
-	Measure | qubit
-	assert int(qubit) == 0
+    cmd_printer = _printer.CommandPrinter(accept_input=False)
+    eng = MainEngine(backend=cmd_printer, engine_list=[DummyEngine()])
+    qubit = eng.allocate_qubit()
+    NOT | qubit
+    Measure | qubit
+    assert int(qubit) == 0

--- a/projectq/backends/_resource.py
+++ b/projectq/backends/_resource.py
@@ -20,96 +20,96 @@ from projectq.ops import FlushGate, Deallocate, Allocate, Measure
 
 
 class ResourceCounter(BasicEngine):
-	"""
-	ResourceCounter is a compiler engine which counts the number of gates and
-	max. number of active qubits.
-	
-	Attributes:
-		gate_counts (dict): Dictionary of gate counts.
-			The keys are string representations of the gate.
-		max_width (int): Maximal width (=max. number of active qubits at any given
-			point).
-	"""
-	def __init__(self):
-		"""
-		Initialize a resource counter engine.
-		
-		Sets all statistics to zero.
-		"""
-		BasicEngine.__init__(self)
-		self.gate_counts = dict()
-		self._active_qubits = 0
-		self.max_width = 0
-		
-	def is_available(self, cmd):
-		"""
-		Specialized implementation of is_available: Returns True if the
-		ResourceCounter is the last engine (since it can count any command).
-		
-		Args:
-			cmd (Command): Command for which to check availability (all Commands can
-				be counted).
-			
-		Returns:
-			availability (bool): True, unless the next engine cannot handle the
-			Command (if there is a next engine).
-		"""
-		try:
-			return BasicEngine.is_available(self, cmd)
-		except LastEngineException:
-			return True
-		
-	def _add_cmd(self, cmd):
-		"""
-		Add a gate to the count.
-		"""
-		if cmd.gate == Allocate:
-			self._active_qubits += 1
-		elif cmd.gate == Deallocate:
-			self._active_qubits -= 1
-		elif cmd.gate == Measure:
-			for qureg in cmd.qubits:
-				for qubit in qureg:
-					self.main_engine.set_measurement_result(qubit, 0)
-		
-		self.max_width = max(self.max_width, self._active_qubits)
-		
-		ctrl_cnt = get_control_count(cmd)
-		gate_name = ctrl_cnt * "C" + str(cmd.gate)
-		
-		try:
-			self.gate_counts[gate_name] += 1
-		except KeyError:
-			self.gate_counts[gate_name] = 1
-	
-	def __str__(self):
-		"""
-		Return the string representation of this ResourceCounter.
-		
-		Returns:
-			A summary (string) of resources used, including gates, number of calls,
-				and max. number of qubits that were active at the same time.
-		"""
-		if len(self.gate_counts) > 0:
-			gate_list = []
-			for gate, num in self.gate_counts.items():
-				gate_list.append(gate + " : " + str(num))
-			return ("\n".join(list(sorted(gate_list))) +
-			        "\n\nMax. width (number of qubits) : " +
-			        str(self.max_width) + ".")
-	
-	def receive(self, command_list):
-		"""
-		Receive a list of commands from the previous engine, print the commands,
-		and then send them on to the next engine.
-		
-		Args:
-			command_list (list<Command>): List of commands to receive (and count).
-		"""
-		for cmd in command_list:
-			if not cmd.gate == FlushGate():
-				self._add_cmd(cmd)
-			
-			# (try to) send on
-			if not self.is_last_engine:
-				self.send([cmd])
+    """
+    ResourceCounter is a compiler engine which counts the number of gates and
+    max. number of active qubits.
+
+    Attributes:
+        gate_counts (dict): Dictionary of gate counts.
+            The keys are string representations of the gate.
+        max_width (int): Maximal width (=max. number of active qubits at any given
+            point).
+    """
+    def __init__(self):
+        """
+        Initialize a resource counter engine.
+
+        Sets all statistics to zero.
+        """
+        BasicEngine.__init__(self)
+        self.gate_counts = dict()
+        self._active_qubits = 0
+        self.max_width = 0
+
+    def is_available(self, cmd):
+        """
+        Specialized implementation of is_available: Returns True if the
+        ResourceCounter is the last engine (since it can count any command).
+
+        Args:
+            cmd (Command): Command for which to check availability (all Commands can
+                be counted).
+
+        Returns:
+            availability (bool): True, unless the next engine cannot handle the
+            Command (if there is a next engine).
+        """
+        try:
+            return BasicEngine.is_available(self, cmd)
+        except LastEngineException:
+            return True
+
+    def _add_cmd(self, cmd):
+        """
+        Add a gate to the count.
+        """
+        if cmd.gate == Allocate:
+            self._active_qubits += 1
+        elif cmd.gate == Deallocate:
+            self._active_qubits -= 1
+        elif cmd.gate == Measure:
+            for qureg in cmd.qubits:
+                for qubit in qureg:
+                    self.main_engine.set_measurement_result(qubit, 0)
+
+        self.max_width = max(self.max_width, self._active_qubits)
+
+        ctrl_cnt = get_control_count(cmd)
+        gate_name = ctrl_cnt * "C" + str(cmd.gate)
+
+        try:
+            self.gate_counts[gate_name] += 1
+        except KeyError:
+            self.gate_counts[gate_name] = 1
+
+    def __str__(self):
+        """
+        Return the string representation of this ResourceCounter.
+
+        Returns:
+            A summary (string) of resources used, including gates, number of calls,
+                and max. number of qubits that were active at the same time.
+        """
+        if len(self.gate_counts) > 0:
+            gate_list = []
+            for gate, num in self.gate_counts.items():
+                gate_list.append(gate + " : " + str(num))
+            return ("\n".join(list(sorted(gate_list))) +
+                    "\n\nMax. width (number of qubits) : " +
+                    str(self.max_width) + ".")
+
+    def receive(self, command_list):
+        """
+        Receive a list of commands from the previous engine, print the commands,
+        and then send them on to the next engine.
+
+        Args:
+            command_list (list<Command>): List of commands to receive (and count).
+        """
+        for cmd in command_list:
+            if not cmd.gate == FlushGate():
+                self._add_cmd(cmd)
+
+            # (try to) send on
+            if not self.is_last_engine:
+                self.send([cmd])

--- a/projectq/backends/_resource_test.py
+++ b/projectq/backends/_resource_test.py
@@ -23,50 +23,50 @@ from projectq.backends import ResourceCounter
 
 
 class MockEngine(object):
-	def is_available(self, cmd):
-		return False
+    def is_available(self, cmd):
+        return False
 
 
 def test_resource_counter_isavailable():
-	resource_counter = ResourceCounter()
-	resource_counter.next_engine = MockEngine()
-	assert not resource_counter.is_available("test")
-	resource_counter.next_engine = None
-	resource_counter.is_last_engine = True
-	
-	assert resource_counter.is_available("test")
-	
-	
+    resource_counter = ResourceCounter()
+    resource_counter.next_engine = MockEngine()
+    assert not resource_counter.is_available("test")
+    resource_counter.next_engine = None
+    resource_counter.is_last_engine = True
+
+    assert resource_counter.is_available("test")
+
+
 def test_resource_counter():
-	resource_counter = ResourceCounter()
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend, [resource_counter])
-	
-	qubit1 = eng.allocate_qubit()
-	qubit2 = eng.allocate_qubit()
-	H | qubit1
-	X | qubit2
-	del qubit2
-	
-	qubit3 = eng.allocate_qubit()
-	CNOT | (qubit1, qubit3)
-	
-	Measure | (qubit1, qubit3)
-	
-	assert int(qubit1) == int(qubit3)
-	assert int(qubit1) == 0
-	
-	assert resource_counter.max_width == 2
-	
-	str_repr = str(resource_counter)
-	assert str_repr.count("H") == 1
-	assert str_repr.count("X") == 2
-	assert str_repr.count("CX") == 1
-	assert str_repr.count("Allocate : 3") == 1
-	assert str_repr.count("Deallocate : 1") == 1
-	
-	sent_gates = [cmd.gate for cmd in backend.received_commands]
-	assert sent_gates.count(H) == 1
-	assert sent_gates.count(X) == 2
-	assert sent_gates.count(Measure) == 1
-	
+    resource_counter = ResourceCounter()
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend, [resource_counter])
+
+    qubit1 = eng.allocate_qubit()
+    qubit2 = eng.allocate_qubit()
+    H | qubit1
+    X | qubit2
+    del qubit2
+
+    qubit3 = eng.allocate_qubit()
+    CNOT | (qubit1, qubit3)
+
+    Measure | (qubit1, qubit3)
+
+    assert int(qubit1) == int(qubit3)
+    assert int(qubit1) == 0
+
+    assert resource_counter.max_width == 2
+
+    str_repr = str(resource_counter)
+    assert str_repr.count("H") == 1
+    assert str_repr.count("X") == 2
+    assert str_repr.count("CX") == 1
+    assert str_repr.count("Allocate : 3") == 1
+    assert str_repr.count("Deallocate : 1") == 1
+
+    sent_gates = [cmd.gate for cmd in backend.received_commands]
+    assert sent_gates.count(H) == 1
+    assert sent_gates.count(X) == 2
+    assert sent_gates.count(Measure) == 1
+

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -22,237 +22,237 @@ import numpy as _np
 
 
 class Simulator(object):
-	"""
-	Python implementation of a quantum computer simulator.
-	
-	This Simulator can be used as a backup if compiling the c++ simulator is
-	not an option (for some reason). It has the same features but is much
-	slower, so please consider building the c++ version for larger experiments.
-	"""
-	def __init__(self, rnd_seed, *args, **kwargs):
-		"""
-		Initialize the simulator.
-		
-		Args:
-			rnd_seed (int): Seed to initialize the random number generator.
-			args: Dummy argument to allow an interface identical to the c++
-				simulator.
-			kwargs: Same as args.
-		"""
-		random.seed(rnd_seed)
-		self._state = _np.ones(1, dtype=_np.complex128)
-		self._map = dict()
-		self._num_qubits = 0
-		print("(Note: This is the (slow) Python simulator.)")
-	
-	
-	def cheat(self):
-		"""
-		Return the qubit index to bit location map and the corresponding state
-		vector.
-		
-		This function can be used to measure expectation values more efficiently
-		(emulation).
-		
-		Returns:
-			A tuple where the first entry is a dictionary mapping qubit indices to
-			bit-locations	and the second entry is the corresponding state vector
-		"""
-		return (self._map, self._state)
-	
-	def measure_qubits(self, ids):
-		"""
-		Measure the qubits with IDs ids and return a list of measurement outcomes
-		(True/False).
-		
-		Args:
-			ids (list<int>): List of qubit IDs to measure.
-			
-		Returns:
-			List of measurement results (containing either True or False).
-		"""
-		P = random.random()
-		val = 0.
-		i_picked = 0
-		while val < P and i_picked < len(self._state):
-			val += _np.abs(self._state[i_picked]) ** 2
-			i_picked += 1
-		
-		i_picked -= 1
-		
-		pos = [self._map[ID] for ID in ids]
-		res = [False] * len(pos)
-		
-		mask = 0
-		val = 0
-		for i in range(len(pos)):
-			res[i] = (((i_picked >> pos[i]) & 1) == 1)
-			mask |= (1 << pos[i])
-			val |= ((res[i] & 1) << pos[i])
-			
-		nrm = 0.
-		for i in range(len(self._state)):
-			if (mask & i) != val:
-				self._state[i] = 0.
-			else:
-				nrm += _np.abs(self._state[i]) ** 2
+    """
+    Python implementation of a quantum computer simulator.
 
-		self._state *= 1. / _np.sqrt(nrm)
-		return res
-	
-	def allocate_qubit(self, ID):
-		"""
-		Allocate a qubit.
-		
-		Args:
-			ID (int): ID of the qubit which is being allocated.
-		"""
-		self._map[ID] = self._num_qubits
-		self._num_qubits += 1
-		self._state.resize(1 << self._num_qubits)
-	
-	def get_classical_value(self, ID, tol=1.e-10):
-		"""
-		Return the classical value of a classical bit (i.e., a qubit which has
-		been measured / uncomputed).
-		
-		Args:
-			ID (int): ID of the qubit of which to get the classical value.
-			tol (float): Tolerance for numerical errors when determining whether
-				the qubit is indeed classical.
-			
-		Raises:
-			RuntimeError: If the qubit is in a superposition, i.e., has not been
-				measured / uncomputed.
-		"""
-		pos = self._map[ID]
-		up = down = False
-		
-		for i in range(0, len(self._state), (1 << (pos + 1))):
-			for j in range(0, (1 << pos)):
-				if _np.abs(self._state[i + j]) > tol:
-					up = True
-				if _np.abs(self._state[i + j + (1 << pos)]) > tol:
-					down = True
-				if up and down:
-					raise RuntimeError("Qubit has not been measured / uncomputed. Cannot "
-					                "access its classical value and/or deallocate a "
-					                "qubit in superposition!")
-		return down
-	
-	def deallocate_qubit(self, ID):
-		"""
-		Deallocate a qubit (if it has been measured / uncomputed).
-		
-		Args:
-			ID (int): ID of the qubit to deallocate.
-			
-		Raises:
-			RuntimeError: If the qubit is in a superposition, i.e., has not been
-				measured / uncomputed.
-		"""
-		pos = self._map[ID]
-		
-		cv = self.get_classical_value(ID)
-		
-		newstate = _np.zeros((1 << (self._num_qubits - 1)), dtype=_np.complex128)
-		k = 0
-		for i in range((1 << pos) * int(cv), len(self._state), (1 << (pos + 1))):
-			newstate[k:k + (1 << pos)] = self._state[i:i + (1 << pos)]
-			k += (1 << pos)
-			
-		newmap = dict()
-		for key, value in self._map.items():
-			if value > pos:
-				newmap[key] = value - 1
-			elif key != ID:
-				newmap[key] = value
-		self._map = newmap
-		self._state = newstate
-		self._num_qubits -= 1
-	
-	def _get_control_mask(self, ctrlids):
-		"""
-		Get control mask from list of control qubit IDs.
-		
-		Returns:
-			A mask which represents the control qubits in binary.
-		"""
-		mask = 0
-		for ctrlid in ctrlids:
-			ctrlpos = self._map[ctrlid]
-			mask |= (1 << ctrlpos)
-		return mask
-	
-	def emulate_math(self, f, qubit_ids, ctrlqubit_ids):
-		"""
-		Emulate a math function (e.g., BasicMathGate).
-		
-		Args:
-			f (function): Function executing the operation to emulate.
-			qubit_ids (list<list<int>>): List of lists of qubit IDs to which the
-				gate is being applied. Every gate is applied to a tuple of quantum
-				registers, which corresponds to this 'list of lists'.
-			ctrlqubit_ids (list<int>): List of control qubit ids.
-		"""
-		mask = self._get_control_mask(ctrlqubit_ids)
-		# determine qubit locations from their IDs
-		qb_locs = []
-		for qureg in qubit_ids:
-			qb_locs.append([])
-			for qubit_id in qureg:
-				qb_locs[-1].append(self._map[qubit_id])
+    This Simulator can be used as a backup if compiling the c++ simulator is
+    not an option (for some reason). It has the same features but is much
+    slower, so please consider building the c++ version for larger experiments.
+    """
+    def __init__(self, rnd_seed, *args, **kwargs):
+        """
+        Initialize the simulator.
 
-		newstate = _np.zeros_like(self._state)
-		for i in range(0, len(self._state)):
-			if (mask & i) == mask:
-				arg_list = [0] * len(qb_locs)
-				for qr_i in range(len(qb_locs)):
-					for qb_i in range(len(qb_locs[qr_i])):
-						arg_list[qr_i] |= (((i >> qb_locs[qr_i][qb_i]) & 1) << qb_i)
-				
-				res = f(arg_list)
-				new_i = i
-				for qr_i in range(len(qb_locs)):
-					for qb_i in range(len(qb_locs[qr_i])):
-						if not (((new_i >> qb_locs[qr_i][qb_i]) & 1) ==
-						        ((res[qr_i] >> qb_i) & 1)):
-							new_i ^= (1 << qb_locs[qr_i][qb_i])
-				newstate[new_i] = self._state[i]
-			else:
-				newstate[i] = self._state[i]
-			
-		self._state = newstate
-	
-	def apply_controlled_gate(self, m, ids, ctrlids):
-		"""
-		Applies the single qubit gate matrix m to the qubit with index ids[0],
-		using ctrlids as control qubits.
-		
-		Args:
-			m (list<list>): 2x2 complex matrix describing the single-qubit gate.
-			ids (list): A list containing the qubit ID to which to apply the gate.
-			ctrlids (list): A list of control qubit IDs (i.e., the gate is only
-				applied where these qubits are 1).
-		"""
-		ID = ids[0]
-		pos = self._map[ID]
-		
-		mask = self._get_control_mask(ctrlids)
+        Args:
+            rnd_seed (int): Seed to initialize the random number generator.
+            args: Dummy argument to allow an interface identical to the c++
+                simulator.
+            kwargs: Same as args.
+        """
+        random.seed(rnd_seed)
+        self._state = _np.ones(1, dtype=_np.complex128)
+        self._map = dict()
+        self._num_qubits = 0
+        print("(Note: This is the (slow) Python simulator.)")
 
-		def kernel(u, d, m):
-			return u * m[0][0] + d * m[0][1], u * m[1][0] + d * m[1][1]
-		
-		for i in range(0, len(self._state), (1 << (pos + 1))):
-			for j in range(0, 1 << pos):
-				if ((i + j) & mask) == mask:
-					self._state[i + j], self._state[i + j + (1 << pos)] = kernel(
+
+    def cheat(self):
+        """
+        Return the qubit index to bit location map and the corresponding state
+        vector.
+
+        This function can be used to measure expectation values more efficiently
+        (emulation).
+
+        Returns:
+            A tuple where the first entry is a dictionary mapping qubit indices to
+            bit-locations    and the second entry is the corresponding state vector
+        """
+        return (self._map, self._state)
+
+    def measure_qubits(self, ids):
+        """
+        Measure the qubits with IDs ids and return a list of measurement outcomes
+        (True/False).
+
+        Args:
+            ids (list<int>): List of qubit IDs to measure.
+
+        Returns:
+            List of measurement results (containing either True or False).
+        """
+        P = random.random()
+        val = 0.
+        i_picked = 0
+        while val < P and i_picked < len(self._state):
+            val += _np.abs(self._state[i_picked]) ** 2
+            i_picked += 1
+
+        i_picked -= 1
+
+        pos = [self._map[ID] for ID in ids]
+        res = [False] * len(pos)
+
+        mask = 0
+        val = 0
+        for i in range(len(pos)):
+            res[i] = (((i_picked >> pos[i]) & 1) == 1)
+            mask |= (1 << pos[i])
+            val |= ((res[i] & 1) << pos[i])
+
+        nrm = 0.
+        for i in range(len(self._state)):
+            if (mask & i) != val:
+                self._state[i] = 0.
+            else:
+                nrm += _np.abs(self._state[i]) ** 2
+
+        self._state *= 1. / _np.sqrt(nrm)
+        return res
+
+    def allocate_qubit(self, ID):
+        """
+        Allocate a qubit.
+
+        Args:
+            ID (int): ID of the qubit which is being allocated.
+        """
+        self._map[ID] = self._num_qubits
+        self._num_qubits += 1
+        self._state.resize(1 << self._num_qubits)
+
+    def get_classical_value(self, ID, tol=1.e-10):
+        """
+        Return the classical value of a classical bit (i.e., a qubit which has
+        been measured / uncomputed).
+
+        Args:
+            ID (int): ID of the qubit of which to get the classical value.
+            tol (float): Tolerance for numerical errors when determining whether
+                the qubit is indeed classical.
+
+        Raises:
+            RuntimeError: If the qubit is in a superposition, i.e., has not been
+                measured / uncomputed.
+        """
+        pos = self._map[ID]
+        up = down = False
+
+        for i in range(0, len(self._state), (1 << (pos + 1))):
+            for j in range(0, (1 << pos)):
+                if _np.abs(self._state[i + j]) > tol:
+                    up = True
+                if _np.abs(self._state[i + j + (1 << pos)]) > tol:
+                    down = True
+                if up and down:
+                    raise RuntimeError("Qubit has not been measured / uncomputed. Cannot "
+                                    "access its classical value and/or deallocate a "
+                                    "qubit in superposition!")
+        return down
+
+    def deallocate_qubit(self, ID):
+        """
+        Deallocate a qubit (if it has been measured / uncomputed).
+
+        Args:
+            ID (int): ID of the qubit to deallocate.
+
+        Raises:
+            RuntimeError: If the qubit is in a superposition, i.e., has not been
+                measured / uncomputed.
+        """
+        pos = self._map[ID]
+
+        cv = self.get_classical_value(ID)
+
+        newstate = _np.zeros((1 << (self._num_qubits - 1)), dtype=_np.complex128)
+        k = 0
+        for i in range((1 << pos) * int(cv), len(self._state), (1 << (pos + 1))):
+            newstate[k:k + (1 << pos)] = self._state[i:i + (1 << pos)]
+            k += (1 << pos)
+
+        newmap = dict()
+        for key, value in self._map.items():
+            if value > pos:
+                newmap[key] = value - 1
+            elif key != ID:
+                newmap[key] = value
+        self._map = newmap
+        self._state = newstate
+        self._num_qubits -= 1
+
+    def _get_control_mask(self, ctrlids):
+        """
+        Get control mask from list of control qubit IDs.
+
+        Returns:
+            A mask which represents the control qubits in binary.
+        """
+        mask = 0
+        for ctrlid in ctrlids:
+            ctrlpos = self._map[ctrlid]
+            mask |= (1 << ctrlpos)
+        return mask
+
+    def emulate_math(self, f, qubit_ids, ctrlqubit_ids):
+        """
+        Emulate a math function (e.g., BasicMathGate).
+
+        Args:
+            f (function): Function executing the operation to emulate.
+            qubit_ids (list<list<int>>): List of lists of qubit IDs to which the
+                gate is being applied. Every gate is applied to a tuple of quantum
+                registers, which corresponds to this 'list of lists'.
+            ctrlqubit_ids (list<int>): List of control qubit ids.
+        """
+        mask = self._get_control_mask(ctrlqubit_ids)
+        # determine qubit locations from their IDs
+        qb_locs = []
+        for qureg in qubit_ids:
+            qb_locs.append([])
+            for qubit_id in qureg:
+                qb_locs[-1].append(self._map[qubit_id])
+
+        newstate = _np.zeros_like(self._state)
+        for i in range(0, len(self._state)):
+            if (mask & i) == mask:
+                arg_list = [0] * len(qb_locs)
+                for qr_i in range(len(qb_locs)):
+                    for qb_i in range(len(qb_locs[qr_i])):
+                        arg_list[qr_i] |= (((i >> qb_locs[qr_i][qb_i]) & 1) << qb_i)
+
+                res = f(arg_list)
+                new_i = i
+                for qr_i in range(len(qb_locs)):
+                    for qb_i in range(len(qb_locs[qr_i])):
+                        if not (((new_i >> qb_locs[qr_i][qb_i]) & 1) ==
+                                ((res[qr_i] >> qb_i) & 1)):
+                            new_i ^= (1 << qb_locs[qr_i][qb_i])
+                newstate[new_i] = self._state[i]
+            else:
+                newstate[i] = self._state[i]
+
+        self._state = newstate
+
+    def apply_controlled_gate(self, m, ids, ctrlids):
+        """
+        Applies the single qubit gate matrix m to the qubit with index ids[0],
+        using ctrlids as control qubits.
+
+        Args:
+            m (list<list>): 2x2 complex matrix describing the single-qubit gate.
+            ids (list): A list containing the qubit ID to which to apply the gate.
+            ctrlids (list): A list of control qubit IDs (i.e., the gate is only
+                applied where these qubits are 1).
+        """
+        ID = ids[0]
+        pos = self._map[ID]
+
+        mask = self._get_control_mask(ctrlids)
+
+        def kernel(u, d, m):
+            return u * m[0][0] + d * m[0][1], u * m[1][0] + d * m[1][1]
+
+        for i in range(0, len(self._state), (1 << (pos + 1))):
+            for j in range(0, 1 << pos):
+                if ((i + j) & mask) == mask:
+                    self._state[i + j], self._state[i + j + (1 << pos)] = kernel(
                                               self._state[i + j],
                                               self._state[i + j + (1 << pos)],
                                               m)
-	
-	def run(self):
-		"""
-		Dummy function to implement the same interface as the c++ simulator.
-		"""
-		pass
+
+    def run(self):
+        """
+        Dummy function to implement the same interface as the c++ simulator.
+        """
+        pass

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -29,157 +29,157 @@ from projectq.ops import (NOT,
                           BasicMathGate)
 
 try:
-	from ._cppsim import Simulator as SimulatorBackend
+    from ._cppsim import Simulator as SimulatorBackend
 except ImportError:
-	from ._pysim import Simulator as SimulatorBackend
+    from ._pysim import Simulator as SimulatorBackend
 
 
 class Simulator(BasicEngine):
-	"""
-	Simulator is a compiler engine which simulates a quantum computer using C++-
-	based kernels.
-	
-	OpenMP is enabled and the number of threads can be controlled using the
-	OMP_NUM_THREADS environment variable, i.e.
-	
-	.. code-block:: bash
-	
-		export OMP_NUM_THREADS=4 # use 4 threads
-		export OMP_PROC_BIND=spread # bind threads to processors by spreading
-	"""
-	def __init__(self, gate_fusion=False, rnd_seed=None):
-		"""
-		Construct the C++/Python-simulator object and initialize it with a random
-		seed.
-		
-		Args:
-			gate_fusion (bool): If True, gates are cached and only executed once a
-				certain gate-size has been reached (only has an effect for the c++
-				simulator).
-			rnd_seed (int): Random seed (uses random.randint(0, 1024) by default).
-			
-		Example of gate_fusion: Instead of applying a Hadamard gate to 5 qubits,
-		the simulator calculates the kronecker product of the 1-qubit matrices and
-		then applies 1 5-qubit gate. This increases operational intensity and
-		keeps the simulator from having to iterate through the state vector
-		multiple times. Depending on the system (and, especially, number of
-		threads), this may or may not be beneficial.
-		
-		Note:
-			If the C++ Simulator extension was not built or cannot be found, the
-			Simulator defaults to a Python implementation of the kernels. While this
-			is much slower, it is still good enough to run basic quantum algorithms.
-			
-			If you need to run large simulations, check out the tutorial in the docs
-			which gives futher hints on how to build the C++ extension.
-		"""
-		if rnd_seed is None:
-			rnd_seed = random.randint(0, 1024)
-		BasicEngine.__init__(self)
-		self._simulator = SimulatorBackend(rnd_seed)
-		self._gate_fusion = gate_fusion
-	
-	def is_available(self, cmd):
-		"""
-		Specialized implementation of is_available: The simulator can deal with
-		all arbitrarily-controlled single-qubit gates which provide a gate-matrix
-		(via gate.get_matrix()).
-		
-		Args:
-			cmd (Command): Command for which to check availability (single-qubit
-				gate, arbitrary controls)
-			
-		Returns:
-			True if it can be simulated and False otherwise.
-		"""
-		if (cmd.gate == Measure or cmd.gate == Allocate or cmd.gate == Deallocate
-		    or isinstance(cmd.gate, BasicMathGate)):
-			return True
-		try:
-			m = cmd.gate.matrix
-			if len(m) > 2:
-				return False
-			return True
-		except:
-			return False
-	
-	def cheat(self):
-		"""
-		Access the ordering of the qubits and the state vector directly.
-		
-		This is a cheat function which enables, e.g., more efficient evaluation of
-		expectation values and debugging.
-		
-		Returns:
-			A tuple where the first entry is a dictionary mapping qubit indices to
-			bit-locations and the second entry is the corresponding state vector
-		"""
-		return self._simulator.cheat()
-	
-	def _handle(self, cmd):
-		"""
-		Handle all commands, i.e., call the member functions of the C++-simulator
-		object corresponding to measurement, allocation/deallocation, and
-		(controlled) single-qubit gate.
-		
-		Args:
-			cmd (Command): Command to handle.
-		
-		Raises:
-			Exception: If a non-single-qubit gate needs to be processed (which
-			should never happen due to is_available).
-		"""
-		#print(cmd)
-		if cmd.gate == Measure:
-			assert(get_control_count(cmd) == 0)
-			ids = [qb.id for qr in cmd.qubits for qb in qr]
-			out = self._simulator.measure_qubits(ids)
-			i = 0
-			for qr in cmd.qubits:
-				for qb in qr:
-					self.main_engine.set_measurement_result(qb, out[i])
-					i += 1
-		elif cmd.gate == Allocate:
-			ID = cmd.qubits[0][0].id
-			self._simulator.allocate_qubit(ID)
-		elif cmd.gate == Deallocate:
-			ID = cmd.qubits[0][0].id
-			self._simulator.deallocate_qubit(ID)
-		elif isinstance(cmd.gate, BasicMathGate):
-			qubitids = []
-			for qr in cmd.qubits:
-				qubitids.append([])
-				for qb in qr:
-					qubitids[-1].append(qb.id)
-			self._simulator.emulate_math(cmd.gate.get_math_function(cmd.qubits),
-			                             qubitids, [qb.id for
-			                                        qb in cmd.control_qubits])
-		elif len(cmd.gate.matrix) == 2:
-			matrix = cmd.gate.matrix
-			self._simulator.apply_controlled_gate(matrix.tolist(),
-			                                      [cmd.qubits[0][0].id],
-			                                      [qb.id for qb in
-			                                      cmd.control_qubits])
-			if not self._gate_fusion:
-				self._simulator.run()
-		else:
-			raise Exception("This simulator only supports controlled single-qubit "
-			                "gates!\nPlease add an auto-replacer engine to your "
-			                "list of compiler engines.")
-	
-	def receive(self, command_list):
-		"""
-		Receive a list of commands from the previous engine and handle them
-		(simulate them classically) prior to sending them on to the next engine.
-		
-		Args:
-			command_list (list<Command>): List of commands to execute on the
-				simulator.
-		"""
-		for cmd in command_list:
-			if not cmd.gate == FlushGate():
-				self._handle(cmd)
-			else:
-				self._simulator.run()  # flush gate --> run all saved gates
-			if not self.is_last_engine:
-				self.send([cmd])
+    """
+    Simulator is a compiler engine which simulates a quantum computer using C++-
+    based kernels.
+
+    OpenMP is enabled and the number of threads can be controlled using the
+    OMP_NUM_THREADS environment variable, i.e.
+
+    .. code-block:: bash
+
+        export OMP_NUM_THREADS=4 # use 4 threads
+        export OMP_PROC_BIND=spread # bind threads to processors by spreading
+    """
+    def __init__(self, gate_fusion=False, rnd_seed=None):
+        """
+        Construct the C++/Python-simulator object and initialize it with a random
+        seed.
+
+        Args:
+            gate_fusion (bool): If True, gates are cached and only executed once a
+                certain gate-size has been reached (only has an effect for the c++
+                simulator).
+            rnd_seed (int): Random seed (uses random.randint(0, 1024) by default).
+
+        Example of gate_fusion: Instead of applying a Hadamard gate to 5 qubits,
+        the simulator calculates the kronecker product of the 1-qubit matrices and
+        then applies 1 5-qubit gate. This increases operational intensity and
+        keeps the simulator from having to iterate through the state vector
+        multiple times. Depending on the system (and, especially, number of
+        threads), this may or may not be beneficial.
+
+        Note:
+            If the C++ Simulator extension was not built or cannot be found, the
+            Simulator defaults to a Python implementation of the kernels. While this
+            is much slower, it is still good enough to run basic quantum algorithms.
+
+            If you need to run large simulations, check out the tutorial in the docs
+            which gives futher hints on how to build the C++ extension.
+        """
+        if rnd_seed is None:
+            rnd_seed = random.randint(0, 1024)
+        BasicEngine.__init__(self)
+        self._simulator = SimulatorBackend(rnd_seed)
+        self._gate_fusion = gate_fusion
+
+    def is_available(self, cmd):
+        """
+        Specialized implementation of is_available: The simulator can deal with
+        all arbitrarily-controlled single-qubit gates which provide a gate-matrix
+        (via gate.get_matrix()).
+
+        Args:
+            cmd (Command): Command for which to check availability (single-qubit
+                gate, arbitrary controls)
+
+        Returns:
+            True if it can be simulated and False otherwise.
+        """
+        if (cmd.gate == Measure or cmd.gate == Allocate or cmd.gate == Deallocate
+            or isinstance(cmd.gate, BasicMathGate)):
+            return True
+        try:
+            m = cmd.gate.matrix
+            if len(m) > 2:
+                return False
+            return True
+        except:
+            return False
+
+    def cheat(self):
+        """
+        Access the ordering of the qubits and the state vector directly.
+
+        This is a cheat function which enables, e.g., more efficient evaluation of
+        expectation values and debugging.
+
+        Returns:
+            A tuple where the first entry is a dictionary mapping qubit indices to
+            bit-locations and the second entry is the corresponding state vector
+        """
+        return self._simulator.cheat()
+
+    def _handle(self, cmd):
+        """
+        Handle all commands, i.e., call the member functions of the C++-simulator
+        object corresponding to measurement, allocation/deallocation, and
+        (controlled) single-qubit gate.
+
+        Args:
+            cmd (Command): Command to handle.
+
+        Raises:
+            Exception: If a non-single-qubit gate needs to be processed (which
+            should never happen due to is_available).
+        """
+        #print(cmd)
+        if cmd.gate == Measure:
+            assert(get_control_count(cmd) == 0)
+            ids = [qb.id for qr in cmd.qubits for qb in qr]
+            out = self._simulator.measure_qubits(ids)
+            i = 0
+            for qr in cmd.qubits:
+                for qb in qr:
+                    self.main_engine.set_measurement_result(qb, out[i])
+                    i += 1
+        elif cmd.gate == Allocate:
+            ID = cmd.qubits[0][0].id
+            self._simulator.allocate_qubit(ID)
+        elif cmd.gate == Deallocate:
+            ID = cmd.qubits[0][0].id
+            self._simulator.deallocate_qubit(ID)
+        elif isinstance(cmd.gate, BasicMathGate):
+            qubitids = []
+            for qr in cmd.qubits:
+                qubitids.append([])
+                for qb in qr:
+                    qubitids[-1].append(qb.id)
+            self._simulator.emulate_math(cmd.gate.get_math_function(cmd.qubits),
+                                         qubitids, [qb.id for
+                                                    qb in cmd.control_qubits])
+        elif len(cmd.gate.matrix) == 2:
+            matrix = cmd.gate.matrix
+            self._simulator.apply_controlled_gate(matrix.tolist(),
+                                                  [cmd.qubits[0][0].id],
+                                                  [qb.id for qb in
+                                                  cmd.control_qubits])
+            if not self._gate_fusion:
+                self._simulator.run()
+        else:
+            raise Exception("This simulator only supports controlled single-qubit "
+                            "gates!\nPlease add an auto-replacer engine to your "
+                            "list of compiler engines.")
+
+    def receive(self, command_list):
+        """
+        Receive a list of commands from the previous engine and handle them
+        (simulate them classically) prior to sending them on to the next engine.
+
+        Args:
+            command_list (list<Command>): List of commands to execute on the
+                simulator.
+        """
+        for cmd in command_list:
+            if not cmd.gate == FlushGate():
+                self._handle(cmd)
+            else:
+                self._simulator.run()  # flush gate --> run all saved gates
+            if not self.is_last_engine:
+                self.send([cmd])

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -33,232 +33,232 @@ from projectq.backends import Simulator
 
 @pytest.fixture(params=["cpp_simulator","py_simulator"])
 def sim(request):
-	if request.param == "cpp_simulator":
-		from projectq.backends._sim._cppsim import Simulator as CppSim
-		sim = Simulator(gate_fusion=True)
-		sim._simulator = CppSim(1)
-		# If an ImportError occurs, the C++ simulator was either not installed
-		# or compiled for a different Python version.
-		return sim
-	if request.param == "py_simulator":
-		from projectq.backends._sim._pysim import Simulator as PySim
-		sim = Simulator()
-		sim._simulator = PySim(1)
-		return sim
+    if request.param == "cpp_simulator":
+        from projectq.backends._sim._cppsim import Simulator as CppSim
+        sim = Simulator(gate_fusion=True)
+        sim._simulator = CppSim(1)
+        # If an ImportError occurs, the C++ simulator was either not installed
+        # or compiled for a different Python version.
+        return sim
+    if request.param == "py_simulator":
+        from projectq.backends._sim._pysim import Simulator as PySim
+        sim = Simulator()
+        sim._simulator = PySim(1)
+        return sim
 
 
 class Mock1QubitGate(BasicGate):
-		def __init__(self):
-			BasicGate.__init__(self)
-			self.cnt = 0
-		
-		@property
-		def matrix(self):
-			self.cnt += 1
-			return [[0,1],[1,0]]
+        def __init__(self):
+            BasicGate.__init__(self)
+            self.cnt = 0
+
+        @property
+        def matrix(self):
+            self.cnt += 1
+            return [[0,1],[1,0]]
 
 
 class Mock2QubitGate(BasicGate):
-		def __init__(self):
-			BasicGate.__init__(self)
-			self.cnt = 0
-		
-		@property
-		def matrix(self):
-			self.cnt += 1
-			return [[0,1,0,0],[1,0,0,0],[0,0,1,0],[0,0,0,1]]
+        def __init__(self):
+            BasicGate.__init__(self)
+            self.cnt = 0
+
+        @property
+        def matrix(self):
+            self.cnt += 1
+            return [[0,1,0,0],[1,0,0,0],[0,0,1,0],[0,0,0,1]]
 
 
 class MockNoMatrixGate(BasicGate):
-		def __init__(self):
-			BasicGate.__init__(self)
-			self.cnt = 0
-		
-		@property
-		def matrix(self):
-			self.cnt += 1
-			raise AttributeError
+        def __init__(self):
+            BasicGate.__init__(self)
+            self.cnt = 0
+
+        @property
+        def matrix(self):
+            self.cnt += 1
+            raise AttributeError
 
 
 def test_simulator_is_available(sim):
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend, [])
-	qubit = eng.allocate_qubit()
-	Measure | qubit
-	BasicMathGate(lambda x:x) | qubit
-	del qubit
-	assert len(backend.received_commands) == 4
-	
-	# Test that allocate, measure, basic math, and deallocate are available.
-	for cmd in backend.received_commands:
-		assert sim.is_available(cmd)
-	
-	new_cmd = backend.received_commands[-1]
-	
-	new_cmd.gate = Mock1QubitGate()
-	assert sim.is_available(new_cmd)
-	assert new_cmd.gate.cnt == 1
-	
-	new_cmd.gate = Mock2QubitGate()
-	assert not sim.is_available(new_cmd)
-	assert new_cmd.gate.cnt == 1
-	
-	new_cmd.gate = MockNoMatrixGate()
-	assert not sim.is_available(new_cmd)
-	assert new_cmd.gate.cnt == 1
-	
-	eng = MainEngine(sim, [])
-	qubit1 = eng.allocate_qubit()
-	qubit2 = eng.allocate_qubit()
-	with pytest.raises(Exception):
-		Mock2QubitGate() | (qubit1, qubit2)
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend, [])
+    qubit = eng.allocate_qubit()
+    Measure | qubit
+    BasicMathGate(lambda x:x) | qubit
+    del qubit
+    assert len(backend.received_commands) == 4
+
+    # Test that allocate, measure, basic math, and deallocate are available.
+    for cmd in backend.received_commands:
+        assert sim.is_available(cmd)
+
+    new_cmd = backend.received_commands[-1]
+
+    new_cmd.gate = Mock1QubitGate()
+    assert sim.is_available(new_cmd)
+    assert new_cmd.gate.cnt == 1
+
+    new_cmd.gate = Mock2QubitGate()
+    assert not sim.is_available(new_cmd)
+    assert new_cmd.gate.cnt == 1
+
+    new_cmd.gate = MockNoMatrixGate()
+    assert not sim.is_available(new_cmd)
+    assert new_cmd.gate.cnt == 1
+
+    eng = MainEngine(sim, [])
+    qubit1 = eng.allocate_qubit()
+    qubit2 = eng.allocate_qubit()
+    with pytest.raises(Exception):
+        Mock2QubitGate() | (qubit1, qubit2)
 
 
 def test_simulator_cheat(sim):
-	# cheat function should return a tuple
-	assert isinstance(sim.cheat(), tuple)
-	# first entry is the qubit mapping.
-	# should be empty:
-	assert len(sim.cheat()[0]) == 0
-	# state vector should only have 1 entry:
-	assert len(sim.cheat()[1]) == 1
-	
-	eng = MainEngine(sim, [])
-	qubit = eng.allocate_qubit()
-	
-	# one qubit has been allocated
-	assert len(sim.cheat()[0]) == 1
-	assert sim.cheat()[0][0] == 0
-	assert len(sim.cheat()[1]) == 2
-	assert 1. == pytest.approx(abs(sim.cheat()[1][0]))
-	
-	del qubit
-	# should be empty:
-	assert len(sim.cheat()[0]) == 0
-	# state vector should only have 1 entry:
-	assert len(sim.cheat()[1]) == 1
+    # cheat function should return a tuple
+    assert isinstance(sim.cheat(), tuple)
+    # first entry is the qubit mapping.
+    # should be empty:
+    assert len(sim.cheat()[0]) == 0
+    # state vector should only have 1 entry:
+    assert len(sim.cheat()[1]) == 1
+
+    eng = MainEngine(sim, [])
+    qubit = eng.allocate_qubit()
+
+    # one qubit has been allocated
+    assert len(sim.cheat()[0]) == 1
+    assert sim.cheat()[0][0] == 0
+    assert len(sim.cheat()[1]) == 2
+    assert 1. == pytest.approx(abs(sim.cheat()[1][0]))
+
+    del qubit
+    # should be empty:
+    assert len(sim.cheat()[0]) == 0
+    # state vector should only have 1 entry:
+    assert len(sim.cheat()[1]) == 1
 
 
 def test_simulator_functional_measurement(sim):
-	eng = MainEngine(sim, [])
-	qubits = eng.allocate_qureg(5)
-	# entangle all qubits:
-	H | qubits[0]
-	for qb in qubits[1:]:
-		CNOT | (qubits[0], qb)
-	
-	Measure | qubits
-	
-	bit_value_sum = sum([int(qubit) for qubit in qubits])
-	assert bit_value_sum == 0 or bit_value_sum == 5
+    eng = MainEngine(sim, [])
+    qubits = eng.allocate_qureg(5)
+    # entangle all qubits:
+    H | qubits[0]
+    for qb in qubits[1:]:
+        CNOT | (qubits[0], qb)
+
+    Measure | qubits
+
+    bit_value_sum = sum([int(qubit) for qubit in qubits])
+    assert bit_value_sum == 0 or bit_value_sum == 5
 
 
 class Plus2Gate(BasicMathGate):
-	def __init__(self):
-		BasicMathGate.__init__(self, lambda x : (x+2,))
+    def __init__(self):
+        BasicMathGate.__init__(self, lambda x : (x+2,))
 
 
 def test_simulator_emulation(sim):
-	eng = MainEngine(sim, [])
-	qubit1 = eng.allocate_qubit()
-	qubit2 = eng.allocate_qubit()
-	qubit3 = eng.allocate_qubit()
-	
-	with Control(eng, qubit3):
-		Plus2Gate() | (qubit1 + qubit2)
-	
-	assert 1. == pytest.approx(sim.cheat()[1][0])
-	
-	X | qubit3
-	with Control(eng, qubit3):
-		Plus2Gate() | (qubit1 + qubit2)
-	assert 1. == pytest.approx(sim.cheat()[1][6])
-	
-	Measure | (qubit1 + qubit2 + qubit3)
+    eng = MainEngine(sim, [])
+    qubit1 = eng.allocate_qubit()
+    qubit2 = eng.allocate_qubit()
+    qubit3 = eng.allocate_qubit()
+
+    with Control(eng, qubit3):
+        Plus2Gate() | (qubit1 + qubit2)
+
+    assert 1. == pytest.approx(sim.cheat()[1][0])
+
+    X | qubit3
+    with Control(eng, qubit3):
+        Plus2Gate() | (qubit1 + qubit2)
+    assert 1. == pytest.approx(sim.cheat()[1][6])
+
+    Measure | (qubit1 + qubit2 + qubit3)
 
 
 def test_simulator_no_uncompute_exception(sim):
-	eng = MainEngine(sim, [])
-	qubit = eng.allocate_qubit()
-	H | qubit
-	with pytest.raises(RuntimeError):
-		qubit[0].__del__()
-	Measure | qubit
+    eng = MainEngine(sim, [])
+    qubit = eng.allocate_qubit()
+    H | qubit
+    with pytest.raises(RuntimeError):
+        qubit[0].__del__()
+    Measure | qubit
 
 class MockSimulatorBackend(object):
-	def __init__(self):
-		self.run_cnt = 0
-	
-	def run(self):
-		self.run_cnt += 1
+    def __init__(self):
+        self.run_cnt = 0
+
+    def run(self):
+        self.run_cnt += 1
 
 
 def test_simulator_flush():
-	sim = Simulator()
-	sim._simulator = MockSimulatorBackend()
-	
-	eng = MainEngine(sim)
-	eng.flush()
-	
-	assert sim._simulator.run_cnt == 1
+    sim = Simulator()
+    sim._simulator = MockSimulatorBackend()
+
+    eng = MainEngine(sim)
+    eng.flush()
+
+    assert sim._simulator.run_cnt == 1
 
 
 def test_simulator_send():
-	sim = Simulator()
-	backend = DummyEngine(save_commands=True)
-	
-	eng = MainEngine(backend, [sim])
-	
-	qubit = eng.allocate_qubit()
-	H | qubit
-	Measure | qubit
-	del qubit
-	eng.flush()
-	
-	assert len(backend.received_commands) == 5
+    sim = Simulator()
+    backend = DummyEngine(save_commands=True)
+
+    eng = MainEngine(backend, [sim])
+
+    qubit = eng.allocate_qubit()
+    H | qubit
+    Measure | qubit
+    del qubit
+    eng.flush()
+
+    assert len(backend.received_commands) == 5
 
 
 def test_simulator_functional_entangle(sim):
-	eng = MainEngine(sim, [])
-	qubits = eng.allocate_qureg(5)
-	# entangle all qubits:
-	H | qubits[0]
-	for qb in qubits[1:]:
-		CNOT | (qubits[0], qb)
-	
-	# check the state vector:
-	assert .5 == pytest.approx(abs(sim.cheat()[1][0])**2)
-	assert .5 == pytest.approx(abs(sim.cheat()[1][31])**2)
-	for i in range(1, 31):
-		assert 0. == pytest.approx(abs(sim.cheat()[1][i]))
-	
-	# unentangle all except the first 2
-	for qb in qubits[2:]:
-		CNOT | (qubits[0], qb)
-	
-	# entangle using Toffolis
-	for qb in qubits[2:]:
-		Toffoli | (qubits[0], qubits[1], qb)
-	
-	# check the state vector:
-	assert .5 == pytest.approx(abs(sim.cheat()[1][0])**2)
-	assert .5 == pytest.approx(abs(sim.cheat()[1][31])**2)
-	for i in range(1, 31):
-		assert 0. == pytest.approx(abs(sim.cheat()[1][i]))
-	
-	# uncompute using multi-controlled NOTs
-	with Control(eng, qubits[0:-1]):
-		X | qubits[-1]
-	with Control(eng, qubits[0:-2]):
-		X | qubits[-2]
-	with Control(eng, qubits[0:-3]):
-		X | qubits[-3]
-	CNOT | (qubits[0], qubits[1])
-	H | qubits[0]
-	
-	# check the state vector:
-	assert 1. == pytest.approx(abs(sim.cheat()[1][0])**2)
-	for i in range(1, 32):
-		assert 0. == pytest.approx(abs(sim.cheat()[1][i]))
-	
-	Measure | qubits
+    eng = MainEngine(sim, [])
+    qubits = eng.allocate_qureg(5)
+    # entangle all qubits:
+    H | qubits[0]
+    for qb in qubits[1:]:
+        CNOT | (qubits[0], qb)
+
+    # check the state vector:
+    assert .5 == pytest.approx(abs(sim.cheat()[1][0])**2)
+    assert .5 == pytest.approx(abs(sim.cheat()[1][31])**2)
+    for i in range(1, 31):
+        assert 0. == pytest.approx(abs(sim.cheat()[1][i]))
+
+    # unentangle all except the first 2
+    for qb in qubits[2:]:
+        CNOT | (qubits[0], qb)
+
+    # entangle using Toffolis
+    for qb in qubits[2:]:
+        Toffoli | (qubits[0], qubits[1], qb)
+
+    # check the state vector:
+    assert .5 == pytest.approx(abs(sim.cheat()[1][0])**2)
+    assert .5 == pytest.approx(abs(sim.cheat()[1][31])**2)
+    for i in range(1, 31):
+        assert 0. == pytest.approx(abs(sim.cheat()[1][i]))
+
+    # uncompute using multi-controlled NOTs
+    with Control(eng, qubits[0:-1]):
+        X | qubits[-1]
+    with Control(eng, qubits[0:-2]):
+        X | qubits[-2]
+    with Control(eng, qubits[0:-3]):
+        X | qubits[-3]
+    CNOT | (qubits[0], qubits[1])
+    H | qubits[0]
+
+    # check the state vector:
+    assert 1. == pytest.approx(abs(sim.cheat()[1][0])**2)
+    for i in range(1, 32):
+        assert 0. == pytest.approx(abs(sim.cheat()[1][i]))
+
+    Measure | qubits

--- a/projectq/cengines/_basics.py
+++ b/projectq/cengines/_basics.py
@@ -16,208 +16,208 @@ from projectq.ops import Command
 import projectq.cengines
 
 class LastEngineException(Exception):
-	"""
-	Exception thrown when the last engine tries to access the next one.
-	(Next engine does not exist)
-	
-	The default implementation of isAvailable simply asks the next engine
-	whether the command is available. An engine which legally may be the last
-	engine, this behavior needs to be adapted (see BasicEngine.isAvailable).
-	"""
-	def __init__(self, engine):
-		Exception.__init__(self, "\nERROR: Sending to next engine failed. " +
-	                    engine.__class__.__name__ + " as last engine?" +
-	                    "\nIf this is legal, please override"
-	                    "'isAvailable' to adapt its behavior.")
+    """
+    Exception thrown when the last engine tries to access the next one.
+    (Next engine does not exist)
+
+    The default implementation of isAvailable simply asks the next engine
+    whether the command is available. An engine which legally may be the last
+    engine, this behavior needs to be adapted (see BasicEngine.isAvailable).
+    """
+    def __init__(self, engine):
+        Exception.__init__(self, "\nERROR: Sending to next engine failed. " +
+                        engine.__class__.__name__ + " as last engine?" +
+                        "\nIf this is legal, please override"
+                        "'isAvailable' to adapt its behavior.")
 
 
 class BasicEngine(object):
-	"""
-	Basic compiler engine: All compiler engines are derived from this class.
-	It provides basic functionality such as qubit allocation/deallocation and
-	functions that provide information about the engine's position (e.g., next
-	engine).
-	
-	This information is provided by the MainEngine, which initializes all
-	further engines.
-	
-	Attributes:
-		next_engine (BasicEngine): Next compiler engine (or the back-end).
-		main_engine (MainEngine): Reference to the main compiler engine.
-		is_last_engine (bool): True for the last engine, which is the back-end.
-	"""
-	def __init__(self):
-		"""
-		Initialize the basic engine.
-		
-		Initializes local variables such as _next_engine, _main_engine, etc. to
-		None.
-		"""
-		self.main_engine = None
-		self.next_engine = None
-		self.is_last_engine = False
-	
-	def is_available(self, cmd):
-		"""
-		Default implementation of is_available:
-		Ask the next engine whether a command is available, i.e.,
-		whether it can be executed by the next engine(s).
-		
-		Args:
-			cmd (Command): Command for which to check availability.
-			
-		Returns:
-			True if the command can be executed.
+    """
+    Basic compiler engine: All compiler engines are derived from this class.
+    It provides basic functionality such as qubit allocation/deallocation and
+    functions that provide information about the engine's position (e.g., next
+    engine).
 
-		Raises:
-			LastEngineException: If is_last_engine is True but is_available is not
-			implemented.
-		"""
-		if not self.is_last_engine:
-			return self.next_engine.is_available(cmd)
-		else:
-			raise LastEngineException(self)
-	
-	def allocate_qubit(self, dirty=False):
-		"""
-		Return a new qubit as a list containing 1 qubit object (quantum register
-		of size 1).
-		
-		Allocates a new qubit by getting a (new) qubit id from the MainEngine,
-		creating the qubit object, and then sending an AllocateQubit command
-		down the pipeline. If dirty=True, the fresh qubit can be replaced by
-		a pre-allocated one (in an unknown, dirty, initial state). Dirty qubits
-		must be returned to their initial states before they are deallocated /
-		freed.
-		
-		All allocated qubits are added to the MainEngine's set of active qubits
-		as weak references. This allows proper clean-up at the end of the Python
-		program (using atexit), deallocating all qubits which are still alive.
-		Qubit ids of dirty qubits are registered in MainEngine's dirty_qubits
-		set.
-		
-		Args:
-			dirty (bool): If True, indicates that the allocated qubit may be dirty
-				(i.e., in an arbitrary initial state).
-		
-		Returns:
-			Qureg of length 1, where the first entry is the allocated qubit.
-		"""
-		new_id = self.main_engine.get_new_qubit_id()
-		qb = Qureg([Qubit(self, new_id)])
-		if dirty:
-			from projectq.meta import DirtyQubitTag
-			if self.is_meta_tag_supported(DirtyQubitTag):
-				oldnext = self.next_engine
-				def cmd_modifier(cmd):
-					assert(cmd.gate == Allocate)
-					cmd.tags += [DirtyQubitTag()]
-					return cmd
-				self.next_engine = projectq.cengines.CommandModifier(cmd_modifier)
-				self.next_engine.next_engine = oldnext
-				self.send([Command(self, Allocate, (qb,))])
-				self.next_engine = oldnext
-				self.main_engine.active_qubits.add(qb[0])
-				self.main_engine.dirty_qubits.add(qb[0].id)
-				return qb
+    This information is provided by the MainEngine, which initializes all
+    further engines.
 
-		self.send([Command(self, Allocate, (qb,))])
-		self.main_engine.active_qubits.add(qb[0])
-		return qb
-	
-	def allocate_qureg(self, n):
-		"""
-		Allocate n qubits and return them as a quantum register, which is a list
-		of qubit objects.
-		
-		Args:
-			n (int): Number of qubits to allocate
-		Returns:
-			Qureg of length n, a list of n newly allocated qubits.
-		"""
-		return Qureg([self.allocate_qubit()[0] for _ in range(n)])
-	
-	def deallocate_qubit(self, qubit):
-		"""
-		Deallocate a qubit (and sends the deallocation command down the pipeline).
-		If the qubit was allocated as a dirty qubit, add DirtyQubitTag() to
-		Deallocate command.
-		
-		Args:
-			qubit (BasicQubit): Qubit to deallocate.
-		"""
-		if qubit.id != -1:
-			if qubit.id not in self.main_engine.dirty_qubits:
-				self.send([Command(self, Deallocate, ([qubit],))])
-			else:
-				from projectq.meta import DirtyQubitTag
-				oldnext = self.next_engine
-				def cmd_modifier(cmd):
-					assert(cmd.gate == Deallocate)
-					cmd.tags += [DirtyQubitTag()]
-					return cmd
-				self.next_engine = projectq.cengines.CommandModifier(cmd_modifier)
-				self.next_engine.next_engine = oldnext
-				self.send([Command(self, Deallocate, ([qubit],))])
-				self.next_engine = oldnext
-			
-	def is_meta_tag_supported(self, meta_tag):
-		"""
-		Check if there is a compiler engine handling the meta tag
+    Attributes:
+        next_engine (BasicEngine): Next compiler engine (or the back-end).
+        main_engine (MainEngine): Reference to the main compiler engine.
+        is_last_engine (bool): True for the last engine, which is the back-end.
+    """
+    def __init__(self):
+        """
+        Initialize the basic engine.
 
-		Args:
-			engine: First engine to check (then iteratively calls getNextEngine)
-			meta_tag: Meta tag class for which to check support
-		
-		Returns:
-			supported (bool): True if one of the further compiler engines is a meta tag handler, i.e.,
-			engine.is_meta_tag_handler(meta_tag) returns True.
-		"""
-		engine = self
-		try:
-			while True:
-				try:
-					if engine.is_meta_tag_handler(meta_tag):
-						return True
-				except AttributeError:
-					pass
-				engine = engine.next_engine
-		except:
-			return False
-	
-	# sends the commandList to the next engine
-	def send(self, command_list):
-		""" Forward the list of commands to the next engine in the pipeline. """
-		self.next_engine.receive(command_list)
+        Initializes local variables such as _next_engine, _main_engine, etc. to
+        None.
+        """
+        self.main_engine = None
+        self.next_engine = None
+        self.is_last_engine = False
+
+    def is_available(self, cmd):
+        """
+        Default implementation of is_available:
+        Ask the next engine whether a command is available, i.e.,
+        whether it can be executed by the next engine(s).
+
+        Args:
+            cmd (Command): Command for which to check availability.
+
+        Returns:
+            True if the command can be executed.
+
+        Raises:
+            LastEngineException: If is_last_engine is True but is_available is not
+            implemented.
+        """
+        if not self.is_last_engine:
+            return self.next_engine.is_available(cmd)
+        else:
+            raise LastEngineException(self)
+
+    def allocate_qubit(self, dirty=False):
+        """
+        Return a new qubit as a list containing 1 qubit object (quantum register
+        of size 1).
+
+        Allocates a new qubit by getting a (new) qubit id from the MainEngine,
+        creating the qubit object, and then sending an AllocateQubit command
+        down the pipeline. If dirty=True, the fresh qubit can be replaced by
+        a pre-allocated one (in an unknown, dirty, initial state). Dirty qubits
+        must be returned to their initial states before they are deallocated /
+        freed.
+
+        All allocated qubits are added to the MainEngine's set of active qubits
+        as weak references. This allows proper clean-up at the end of the Python
+        program (using atexit), deallocating all qubits which are still alive.
+        Qubit ids of dirty qubits are registered in MainEngine's dirty_qubits
+        set.
+
+        Args:
+            dirty (bool): If True, indicates that the allocated qubit may be dirty
+                (i.e., in an arbitrary initial state).
+
+        Returns:
+            Qureg of length 1, where the first entry is the allocated qubit.
+        """
+        new_id = self.main_engine.get_new_qubit_id()
+        qb = Qureg([Qubit(self, new_id)])
+        if dirty:
+            from projectq.meta import DirtyQubitTag
+            if self.is_meta_tag_supported(DirtyQubitTag):
+                oldnext = self.next_engine
+                def cmd_modifier(cmd):
+                    assert(cmd.gate == Allocate)
+                    cmd.tags += [DirtyQubitTag()]
+                    return cmd
+                self.next_engine = projectq.cengines.CommandModifier(cmd_modifier)
+                self.next_engine.next_engine = oldnext
+                self.send([Command(self, Allocate, (qb,))])
+                self.next_engine = oldnext
+                self.main_engine.active_qubits.add(qb[0])
+                self.main_engine.dirty_qubits.add(qb[0].id)
+                return qb
+
+        self.send([Command(self, Allocate, (qb,))])
+        self.main_engine.active_qubits.add(qb[0])
+        return qb
+
+    def allocate_qureg(self, n):
+        """
+        Allocate n qubits and return them as a quantum register, which is a list
+        of qubit objects.
+
+        Args:
+            n (int): Number of qubits to allocate
+        Returns:
+            Qureg of length n, a list of n newly allocated qubits.
+        """
+        return Qureg([self.allocate_qubit()[0] for _ in range(n)])
+
+    def deallocate_qubit(self, qubit):
+        """
+        Deallocate a qubit (and sends the deallocation command down the pipeline).
+        If the qubit was allocated as a dirty qubit, add DirtyQubitTag() to
+        Deallocate command.
+
+        Args:
+            qubit (BasicQubit): Qubit to deallocate.
+        """
+        if qubit.id != -1:
+            if qubit.id not in self.main_engine.dirty_qubits:
+                self.send([Command(self, Deallocate, ([qubit],))])
+            else:
+                from projectq.meta import DirtyQubitTag
+                oldnext = self.next_engine
+                def cmd_modifier(cmd):
+                    assert(cmd.gate == Deallocate)
+                    cmd.tags += [DirtyQubitTag()]
+                    return cmd
+                self.next_engine = projectq.cengines.CommandModifier(cmd_modifier)
+                self.next_engine.next_engine = oldnext
+                self.send([Command(self, Deallocate, ([qubit],))])
+                self.next_engine = oldnext
+
+    def is_meta_tag_supported(self, meta_tag):
+        """
+        Check if there is a compiler engine handling the meta tag
+
+        Args:
+            engine: First engine to check (then iteratively calls getNextEngine)
+            meta_tag: Meta tag class for which to check support
+
+        Returns:
+            supported (bool): True if one of the further compiler engines is a meta tag handler, i.e.,
+            engine.is_meta_tag_handler(meta_tag) returns True.
+        """
+        engine = self
+        try:
+            while True:
+                try:
+                    if engine.is_meta_tag_handler(meta_tag):
+                        return True
+                except AttributeError:
+                    pass
+                engine = engine.next_engine
+        except:
+            return False
+
+    # sends the commandList to the next engine
+    def send(self, command_list):
+        """ Forward the list of commands to the next engine in the pipeline. """
+        self.next_engine.receive(command_list)
 
 
 class ForwarderEngine(BasicEngine):
-	"""
-	A ForwarderEngine is a trivial engine which forwards all commands to the
-	next engine.
-	
-	It is mainly used as a substitute for the MainEngine at lower levels such
-	that meta operations still work (e.g., with Compute).
-	"""
-	def __init__(self, engine, cmd_mod_fun=None):
-		"""
-		Initialize a ForwarderEngine.
-		
-		Args:
-			engine (BasicEngine): Engine to forward all commands to.
-			cmd_mod_fun (function): Function which is called before sending a
-				command. Each command cmd is replaced by the command it returns when
-				getting called with cmd.
-		"""
-		BasicEngine.__init__(self)
-		self.main_engine = engine.main_engine
-		self.next_engine = engine
-		if cmd_mod_fun is None:
-			cmd_mod_fun = lambda cmd: cmd
-			
-		self._cmd_mod_fun = cmd_mod_fun
-	
-	def receive(self, command_list):
-		""" Forward all commands to the next engine. """
-		new_command_list = [self._cmd_mod_fun(cmd) for cmd in command_list]
-		self.send(new_command_list)
+    """
+    A ForwarderEngine is a trivial engine which forwards all commands to the
+    next engine.
+
+    It is mainly used as a substitute for the MainEngine at lower levels such
+    that meta operations still work (e.g., with Compute).
+    """
+    def __init__(self, engine, cmd_mod_fun=None):
+        """
+        Initialize a ForwarderEngine.
+
+        Args:
+            engine (BasicEngine): Engine to forward all commands to.
+            cmd_mod_fun (function): Function which is called before sending a
+                command. Each command cmd is replaced by the command it returns when
+                getting called with cmd.
+        """
+        BasicEngine.__init__(self)
+        self.main_engine = engine.main_engine
+        self.next_engine = engine
+        if cmd_mod_fun is None:
+            cmd_mod_fun = lambda cmd: cmd
+
+        self._cmd_mod_fun = cmd_mod_fun
+
+    def receive(self, command_list):
+        """ Forward all commands to the next engine. """
+        new_command_list = [self._cmd_mod_fun(cmd) for cmd in command_list]
+        self.send(new_command_list)

--- a/projectq/cengines/_basics_test.py
+++ b/projectq/cengines/_basics_test.py
@@ -15,15 +15,15 @@
 import types
 import pytest
 # try:
-# 	import mock
+#     import mock
 # except ImportError:
-# 	from unittest import mock
+#     from unittest import mock
 
 from projectq import MainEngine
 from projectq.types import Qubit
 from projectq.cengines import DummyEngine, InstructionFilter
 from projectq.meta import DirtyQubitTag
-from projectq.ops import (AllocateQubitGate, 
+from projectq.ops import (AllocateQubitGate,
                           DeallocateQubitGate,
                           H, FastForwardingGate,
                           ClassicalInstructionGate)
@@ -32,150 +32,150 @@ from projectq.cengines import _basics
 
 
 def test_basic_engine_init():
-	eng = _basics.BasicEngine()
-	assert eng.main_engine == None
-	assert eng.next_engine == None
-	assert eng.is_last_engine == False
+    eng = _basics.BasicEngine()
+    assert eng.main_engine == None
+    assert eng.next_engine == None
+    assert eng.is_last_engine == False
 
 
 def test_basic_engine_is_available():
-	eng = _basics.BasicEngine()
-	with pytest.raises(_basics.LastEngineException):
-		eng.is_last_engine = True
-		eng.is_available("FakeCommand")
-	
-	def filter(self, cmd):
-		if cmd == "supported":
-			return True
-		return False
-	
-	filter_eng = InstructionFilter(filter)
-	eng.next_engine = filter_eng
-	eng.is_last_engine = False
-	assert eng.is_available("supported")
-	assert not eng.is_available("something else")
+    eng = _basics.BasicEngine()
+    with pytest.raises(_basics.LastEngineException):
+        eng.is_last_engine = True
+        eng.is_available("FakeCommand")
+
+    def filter(self, cmd):
+        if cmd == "supported":
+            return True
+        return False
+
+    filter_eng = InstructionFilter(filter)
+    eng.next_engine = filter_eng
+    eng.is_last_engine = False
+    assert eng.is_available("supported")
+    assert not eng.is_available("something else")
 
 
 def test_basic_engine_allocate_and_deallocate_qubit_and_qureg():
-	eng = _basics.BasicEngine()
-	# custom receive function which checks that main_engine does not send
-	# any allocate or deallocate gates
-	cmd_sent_by_main_engine = []
-	def receive(self, cmd_list):
-		cmd_sent_by_main_engine.append(cmd_list)
-	
-	eng.receive = types.MethodType(receive, eng)
-	# Create test engines:
-	saving_backend = DummyEngine(save_commands=True)
-	main_engine = MainEngine(backend=saving_backend,
-		engine_list=[eng, DummyEngine()])
-	# Allocate and deallocate qubits
-	qubit = eng.allocate_qubit()
-	# Try to allocate dirty qubit but it should give a non dirty qubit
-	not_dirty_qubit = eng.allocate_qubit(dirty=True)
-	# Allocate an actual dirty qubit
-	def allow_dirty_qubits(self, meta_tag):
-		if meta_tag == DirtyQubitTag:
-			return True
-		return False
-	
-	saving_backend.is_meta_tag_handler = types.MethodType(allow_dirty_qubits,
-		saving_backend)
-	dirty_qubit = eng.allocate_qubit(dirty=True)
-	qureg = eng.allocate_qureg(2)
-	# Test qubit allocation
-	assert isinstance(qubit, list)
-	assert len(qubit) == 1 and isinstance(qubit[0], Qubit)
-	assert qubit[0] in main_engine.active_qubits
-	assert id(qubit[0].engine) == id(eng)
-	# Test non dirty qubit allocation
-	assert isinstance(not_dirty_qubit, list)
-	assert len(not_dirty_qubit) == 1 and isinstance(not_dirty_qubit[0], Qubit)
-	assert not_dirty_qubit[0] in main_engine.active_qubits
-	assert id(not_dirty_qubit[0].engine) == id(eng)
-	# Test dirty_qubit allocation
-	assert isinstance(dirty_qubit, list)
-	assert len(dirty_qubit) == 1 and isinstance(dirty_qubit[0], Qubit)
-	assert dirty_qubit[0] in main_engine.active_qubits
-	assert dirty_qubit[0].id in main_engine.dirty_qubits
-	assert id(dirty_qubit[0].engine) == id(eng)
-	# Test qureg allocation
-	assert isinstance(qureg, list)
-	assert len(qureg) == 2
-	for tmp_qubit in qureg:
-		assert tmp_qubit in main_engine.active_qubits
-		assert id(tmp_qubit.engine) == id(eng)
-	# Test uniqueness of ids
-	assert len(set([qubit[0].id, not_dirty_qubit[0].id, dirty_qubit[0].id, 
-		qureg[0].id, qureg[1].id])) == 5
-	# Test allocate gates were sent
-	assert len(cmd_sent_by_main_engine) == 0
-	assert len(saving_backend.received_commands) == 5
-	for cmd in saving_backend.received_commands:
-		assert cmd.gate == AllocateQubitGate()
-	assert saving_backend.received_commands[2].tags == [DirtyQubitTag()]
-	# Test deallocate gates were sent
-	eng.deallocate_qubit(qubit[0])
-	eng.deallocate_qubit(not_dirty_qubit[0])
-	eng.deallocate_qubit(dirty_qubit[0])
-	eng.deallocate_qubit(qureg[0])
-	eng.deallocate_qubit(qureg[1])
-	assert len(cmd_sent_by_main_engine) == 0
-	assert len(saving_backend.received_commands) == 10
-	for cmd in saving_backend.received_commands[5:]:
-		assert cmd.gate == DeallocateQubitGate()
-	assert saving_backend.received_commands[7].tags == [DirtyQubitTag()]
+    eng = _basics.BasicEngine()
+    # custom receive function which checks that main_engine does not send
+    # any allocate or deallocate gates
+    cmd_sent_by_main_engine = []
+    def receive(self, cmd_list):
+        cmd_sent_by_main_engine.append(cmd_list)
+
+    eng.receive = types.MethodType(receive, eng)
+    # Create test engines:
+    saving_backend = DummyEngine(save_commands=True)
+    main_engine = MainEngine(backend=saving_backend,
+        engine_list=[eng, DummyEngine()])
+    # Allocate and deallocate qubits
+    qubit = eng.allocate_qubit()
+    # Try to allocate dirty qubit but it should give a non dirty qubit
+    not_dirty_qubit = eng.allocate_qubit(dirty=True)
+    # Allocate an actual dirty qubit
+    def allow_dirty_qubits(self, meta_tag):
+        if meta_tag == DirtyQubitTag:
+            return True
+        return False
+
+    saving_backend.is_meta_tag_handler = types.MethodType(allow_dirty_qubits,
+        saving_backend)
+    dirty_qubit = eng.allocate_qubit(dirty=True)
+    qureg = eng.allocate_qureg(2)
+    # Test qubit allocation
+    assert isinstance(qubit, list)
+    assert len(qubit) == 1 and isinstance(qubit[0], Qubit)
+    assert qubit[0] in main_engine.active_qubits
+    assert id(qubit[0].engine) == id(eng)
+    # Test non dirty qubit allocation
+    assert isinstance(not_dirty_qubit, list)
+    assert len(not_dirty_qubit) == 1 and isinstance(not_dirty_qubit[0], Qubit)
+    assert not_dirty_qubit[0] in main_engine.active_qubits
+    assert id(not_dirty_qubit[0].engine) == id(eng)
+    # Test dirty_qubit allocation
+    assert isinstance(dirty_qubit, list)
+    assert len(dirty_qubit) == 1 and isinstance(dirty_qubit[0], Qubit)
+    assert dirty_qubit[0] in main_engine.active_qubits
+    assert dirty_qubit[0].id in main_engine.dirty_qubits
+    assert id(dirty_qubit[0].engine) == id(eng)
+    # Test qureg allocation
+    assert isinstance(qureg, list)
+    assert len(qureg) == 2
+    for tmp_qubit in qureg:
+        assert tmp_qubit in main_engine.active_qubits
+        assert id(tmp_qubit.engine) == id(eng)
+    # Test uniqueness of ids
+    assert len(set([qubit[0].id, not_dirty_qubit[0].id, dirty_qubit[0].id,
+        qureg[0].id, qureg[1].id])) == 5
+    # Test allocate gates were sent
+    assert len(cmd_sent_by_main_engine) == 0
+    assert len(saving_backend.received_commands) == 5
+    for cmd in saving_backend.received_commands:
+        assert cmd.gate == AllocateQubitGate()
+    assert saving_backend.received_commands[2].tags == [DirtyQubitTag()]
+    # Test deallocate gates were sent
+    eng.deallocate_qubit(qubit[0])
+    eng.deallocate_qubit(not_dirty_qubit[0])
+    eng.deallocate_qubit(dirty_qubit[0])
+    eng.deallocate_qubit(qureg[0])
+    eng.deallocate_qubit(qureg[1])
+    assert len(cmd_sent_by_main_engine) == 0
+    assert len(saving_backend.received_commands) == 10
+    for cmd in saving_backend.received_commands[5:]:
+        assert cmd.gate == DeallocateQubitGate()
+    assert saving_backend.received_commands[7].tags == [DirtyQubitTag()]
 
 
 def test_basic_engine_is_meta_tag_supported():
-	eng = _basics.BasicEngine()
-	# BasicEngine needs receive function to function so let's add it:
-	def receive(self, cmd_list):
-		self.send(cmd_list)
-	
-	eng.receive = types.MethodType(receive, eng)
-	backend = DummyEngine()
-	engine0 = DummyEngine()
-	engine1 = DummyEngine()
-	engine2 = DummyEngine()
-	
-	def allow_dirty_qubits(self, meta_tag):
-		if meta_tag == DirtyQubitTag:
-			return True
-		return False
-	
-	engine2.is_meta_tag_handler = types.MethodType(allow_dirty_qubits,
-		engine2)
-	main_engine = MainEngine(backend=backend,
-		engine_list=[engine0, engine1, engine2])
-	assert not main_engine.is_meta_tag_supported("NotSupported")
-	assert main_engine.is_meta_tag_supported(DirtyQubitTag)
+    eng = _basics.BasicEngine()
+    # BasicEngine needs receive function to function so let's add it:
+    def receive(self, cmd_list):
+        self.send(cmd_list)
+
+    eng.receive = types.MethodType(receive, eng)
+    backend = DummyEngine()
+    engine0 = DummyEngine()
+    engine1 = DummyEngine()
+    engine2 = DummyEngine()
+
+    def allow_dirty_qubits(self, meta_tag):
+        if meta_tag == DirtyQubitTag:
+            return True
+        return False
+
+    engine2.is_meta_tag_handler = types.MethodType(allow_dirty_qubits,
+        engine2)
+    main_engine = MainEngine(backend=backend,
+        engine_list=[engine0, engine1, engine2])
+    assert not main_engine.is_meta_tag_supported("NotSupported")
+    assert main_engine.is_meta_tag_supported(DirtyQubitTag)
 
 
 def test_forwarder_engine():
-	backend = DummyEngine(save_commands=True)
-	engine0 = DummyEngine()
-	main_engine = MainEngine(backend=backend,
-		engine_list = [engine0])
-	def cmd_mod_fun(cmd):
-		cmd.tags = "NewTag"
-		return cmd
-	
-	forwarder_eng = _basics.ForwarderEngine(backend, cmd_mod_fun)
-	engine0.next_engine = forwarder_eng
-	forwarder_eng2 = _basics.ForwarderEngine(engine0)
-	main_engine.next_engine = forwarder_eng2
-	qubit = main_engine.allocate_qubit()
-	H | qubit
-	# Test if H gate was sent through forwarder_eng and tag was added
-	received_commands = []
-	# Remove Allocate and Deallocate gates
-	for cmd in backend.received_commands:
-		if not (isinstance(cmd.gate, FastForwardingGate) or 
-	            isinstance(cmd.gate, ClassicalInstructionGate)):
-			received_commands.append(cmd)
-	for cmd in received_commands:
-		print(cmd)
-	assert len(received_commands) == 1
-	assert received_commands[0].gate == H
-	assert received_commands[0].tags == "NewTag"
+    backend = DummyEngine(save_commands=True)
+    engine0 = DummyEngine()
+    main_engine = MainEngine(backend=backend,
+        engine_list = [engine0])
+    def cmd_mod_fun(cmd):
+        cmd.tags = "NewTag"
+        return cmd
+
+    forwarder_eng = _basics.ForwarderEngine(backend, cmd_mod_fun)
+    engine0.next_engine = forwarder_eng
+    forwarder_eng2 = _basics.ForwarderEngine(engine0)
+    main_engine.next_engine = forwarder_eng2
+    qubit = main_engine.allocate_qubit()
+    H | qubit
+    # Test if H gate was sent through forwarder_eng and tag was added
+    received_commands = []
+    # Remove Allocate and Deallocate gates
+    for cmd in backend.received_commands:
+        if not (isinstance(cmd.gate, FastForwardingGate) or
+                isinstance(cmd.gate, ClassicalInstructionGate)):
+            received_commands.append(cmd)
+    for cmd in received_commands:
+        print(cmd)
+    assert len(received_commands) == 1
+    assert received_commands[0].gate == H
+    assert received_commands[0].tags == "NewTag"

--- a/projectq/cengines/_cmdmodifier.py
+++ b/projectq/cengines/_cmdmodifier.py
@@ -18,38 +18,38 @@ from projectq.cengines import BasicEngine
 
 
 class CommandModifier(BasicEngine):
-	"""
-	CommandModifier is a compiler engine which applies a function to all
-	incoming commands, sending on the resulting command instead of the
-	original one.
-	"""
-	def __init__(self, cmd_mod_fun):
-		"""
-		Initialize the CommandModifier.
-		
-		Args:
-			cmd_mod_fun (function): Function which, given a command cmd, returns
-				the command it should send instead.
-				
-		Example:
-			.. code-block:: python
-			
-				def cmd_mod_fun(cmd):
-					cmd.tags += [MyOwnTag()]
-				compiler_engine = CommandModifier(cmd_mod_fun)
-				...
-		"""
-		BasicEngine.__init__(self)
-		self._cmd_mod_fun = cmd_mod_fun
-	
-	def receive(self, command_list):
-		"""
-		Receive a list of commands from the previous engine, modify all commands,
-		and send them on to the next engine.
-		
-		Args:
-			command_list (list<Command>): List of commands to receive and then
-				(after modification) send on.
-		"""
-		new_command_list = [self._cmd_mod_fun(cmd) for cmd in command_list]
-		self.send(command_list)
+    """
+    CommandModifier is a compiler engine which applies a function to all
+    incoming commands, sending on the resulting command instead of the
+    original one.
+    """
+    def __init__(self, cmd_mod_fun):
+        """
+        Initialize the CommandModifier.
+
+        Args:
+            cmd_mod_fun (function): Function which, given a command cmd, returns
+                the command it should send instead.
+
+        Example:
+            .. code-block:: python
+
+                def cmd_mod_fun(cmd):
+                    cmd.tags += [MyOwnTag()]
+                compiler_engine = CommandModifier(cmd_mod_fun)
+                ...
+        """
+        BasicEngine.__init__(self)
+        self._cmd_mod_fun = cmd_mod_fun
+
+    def receive(self, command_list):
+        """
+        Receive a list of commands from the previous engine, modify all commands,
+        and send them on to the next engine.
+
+        Args:
+            command_list (list<Command>): List of commands to receive and then
+                (after modification) send on.
+        """
+        new_command_list = [self._cmd_mod_fun(cmd) for cmd in command_list]
+        self.send(command_list)

--- a/projectq/cengines/_cmdmodifier_test.py
+++ b/projectq/cengines/_cmdmodifier_test.py
@@ -20,24 +20,24 @@ from projectq.cengines import _cmdmodifier
 
 
 def test_command_modifier():
-	def cmd_mod_fun(cmd):
-		cmd.tags = "NewTag"
-		return cmd
+    def cmd_mod_fun(cmd):
+        cmd.tags = "NewTag"
+        return cmd
 
-	backend = DummyEngine(save_commands=True)
-	main_engine = MainEngine(backend=backend,
-		engine_list=[_cmdmodifier.CommandModifier(cmd_mod_fun)])
-	qubit = main_engine.allocate_qubit()
-	H | qubit
-	# Test if H gate was sent through forwarder_eng and tag was added
-	received_commands = []
-	# Remove Allocate and Deallocate gates
-	for cmd in backend.received_commands:
-		if not (isinstance(cmd.gate, FastForwardingGate) or 
-	            isinstance(cmd.gate, ClassicalInstructionGate)):
-			received_commands.append(cmd)
-	for cmd in received_commands:
-		print(cmd)
-	assert len(received_commands) == 1
-	assert received_commands[0].gate == H
-	assert received_commands[0].tags == "NewTag"
+    backend = DummyEngine(save_commands=True)
+    main_engine = MainEngine(backend=backend,
+        engine_list=[_cmdmodifier.CommandModifier(cmd_mod_fun)])
+    qubit = main_engine.allocate_qubit()
+    H | qubit
+    # Test if H gate was sent through forwarder_eng and tag was added
+    received_commands = []
+    # Remove Allocate and Deallocate gates
+    for cmd in backend.received_commands:
+        if not (isinstance(cmd.gate, FastForwardingGate) or
+                isinstance(cmd.gate, ClassicalInstructionGate)):
+            received_commands.append(cmd)
+    for cmd in received_commands:
+        print(cmd)
+    assert len(received_commands) == 1
+    assert received_commands[0].gate == H
+    assert received_commands[0].tags == "NewTag"

--- a/projectq/cengines/_ibmcnotmapper.py
+++ b/projectq/cengines/_ibmcnotmapper.py
@@ -30,167 +30,167 @@ from projectq.backends import IBMBackend
 
 
 class IBMCNOTMapper(BasicEngine):
-	"""
-	CNOT mapper for the IBM backend.
+    """
+    CNOT mapper for the IBM backend.
 
-	Transforms CNOTs such that all CNOTs within the circuit have the same
-	target qubit (required by IBM backend). If necessary, it will flip
-	around the CNOT gate by first applying Hadamard gates to both qubits, then
-	CNOT with swapped control and target qubit, and finally Hadamard gates to
-	both qubits.
-	
-	Note:
-		The mapper has to be run once on the entire circuit. Else, an Exception
-		will be raised (if, e.g., several measurements are performed without re-
-		initializing the mapper).
-	
-	Warning:
-		If the provided circuit cannot be mapped to the hardware layout without
-		performing Swaps, the mapping procedure **raises an Exception**.
-	"""
+    Transforms CNOTs such that all CNOTs within the circuit have the same
+    target qubit (required by IBM backend). If necessary, it will flip
+    around the CNOT gate by first applying Hadamard gates to both qubits, then
+    CNOT with swapped control and target qubit, and finally Hadamard gates to
+    both qubits.
 
-	def __init__(self):
-		"""
-		Initialize an IBM CNOT Mapper compiler engine.
-		
-		Resets the mapping.
-		"""
-		BasicEngine.__init__(self)
-		self._reset()
-		
-	def is_available(self, cmd):
-		"""
-		Check if the IBM backend can perform the Command cmd and return True if
-		so.
+    Note:
+        The mapper has to be run once on the entire circuit. Else, an Exception
+        will be raised (if, e.g., several measurements are performed without re-
+        initializing the mapper).
 
-		Args:
-			cmd (Command): The command to check
-		"""
-		return IBMBackend().is_available(cmd)
-	
-	def _reset(self):
-		"""
-		Reset the mapping parameters so the next circuit can be mapped.
-		"""
-		self._cmds = []
-		self._cnot_ids = []
-		self._cnot_id = -1
-	
-	def _is_cnot(self, cmd):
-		"""
-		Check if the command corresponds to a CNOT (controlled NOT gate).
-		
-		Args:
-			cmd (Command): Command to check whether it is a controlled NOT gate.
-		"""
-		return isinstance(cmd.gate, NOT.__class__) and get_control_count(cmd) == 1
-	
-	def _run(self):
-		"""
-		Runs all stored gates.
+    Warning:
+        If the provided circuit cannot be mapped to the hardware layout without
+        performing Swaps, the mapping procedure **raises an Exception**.
+    """
 
-		Raises:
-			Exception:
-				If the mapping to the IBM backend cannot be performed or if the
-				mapping was already determined but more CNOTs get sent down the
-				pipeline.
-		"""
-		cnot_id = self._cnot_id
-		if cnot_id == -1 and len(self._cnot_ids) > 0:
-			cnot_id = self._cnot_ids[0]
-			if len(self._cnot_ids) == 2:  # we can optimize (at least a little bit)!
-				count1 = 0
-				count2 = 0
-				for cmd in self._cmds:
-					if self._is_cnot(cmd):
-						qb = cmd.qubits[0][0]
-						ctrl = cmd.control_qubits[0]
-						if ctrl.id == self._cnot_ids[0]:
-							count1 += 1
-						elif ctrl.id == self._cnot_ids[1]:
-							count2 += 1
-				if count1 > count2:
-					cnot_id = self._cnot_ids[1]
-		
-		for cmd in self._cmds:
-			if self._is_cnot(cmd) and not cmd.qubits[0][0].id == cnot_id:
-				# we have to flip it around. To have nice syntax, we'll use a
-				# forwarder engine and a command modifier to get the tags right.
-				# (If the CNOT is an 'uncompute', then so must be the remapped CNOT)
-				def cmd_mod(command):
-					command.tags = cmd.tags[:] + command.tags
-					command.engine = self.main_engine
-					return command
-					
-				cmd_mod_eng = CommandModifier(cmd_mod)  # will add potential meta tags
-				cmd_mod_eng.next_engine = self.next_engine # and send on all commands
-				cmd_mod_eng.main_engine = self.main_engine
-				# forward everything to the command modifier
-				forwarder_eng = ForwarderEngine(cmd_mod_eng)
-				cmd.engine = forwarder_eng  # and send all gates to forwarder engine.
-				
-				qubit = cmd.qubits[0]
-				ctrl = cmd.control_qubits
-				# flip the CNOT using Hadamard gates:
-				All(H) | (ctrl + qubit)
-				CNOT | (qubit, ctrl)
-				All(H) | (ctrl + qubit)
-				
-				# This cmd would require remapping --> 
-				# raise an exception if the CNOT id has already been determined.
-				if self._cnot_id != -1:
-					self._reset()
-					raise Exception("\nIBM Quantum Experience does not allow "
-					                "intermediate measurements / \ndestruction of "
-					                "qubits! CNOT mapping may be inconsistent.\n")
-			else:
-				self.next_engine.receive([cmd])
-		self._cmds = []
-		self._cnot_id = cnot_id
-	
-	def _store(self, cmd):
-		"""
-		Store a command and handle CNOTs.
+    def __init__(self):
+        """
+        Initialize an IBM CNOT Mapper compiler engine.
 
-		Args:
-			cmd (Command): A command to store
-		Raises:
-			Exception: If the mapping to the IBM backend cannot be performed without
-				SWAPs.
-		"""
-		if self._is_cnot(cmd):
-			# CNOT encountered
-			if len(self._cnot_ids) == 0:
-				self._cnot_ids += [cmd.control_qubits[0].id, cmd.qubits[0][0].id]
-			else:
-				apply_to = cmd.qubits[0][0].id
-				ctrl = cmd.control_qubits[0].id
-				if not apply_to in self._cnot_ids:
-					if not ctrl in self._cnot_ids:
-						raise Exception("Mapping without SWAPs failed! Sorry...")
-					else:
-						self._cnot_ids = [ctrl]
-				elif not ctrl in self._cnot_ids:
-					self._cnot_ids = [apply_to]
-		
-		self._cmds.append(cmd)
-	
-	def receive(self, command_list):
-		"""
-		Receives a command list and, for each command, stores it until completion.
+        Resets the mapping.
+        """
+        BasicEngine.__init__(self)
+        self._reset()
 
-		Args:
-			command_list (list of Command objects): list of commands to receive.
-		
-		Raises:
-			Exception: If mapping the CNOT gates to 1 qubit would require Swaps. The
-				current version only supports remapping of CNOT gates without
-				performing any Swaps due to the large costs associated with Swapping
-				given the CNOT constraints.
-		"""
-		for cmd in command_list:
-			self._store(cmd)
-			if isinstance(cmd.gate, FastForwardingGate):
-				self._run()
-			if isinstance(cmd.gate, FlushGate):
-				self._reset()
+    def is_available(self, cmd):
+        """
+        Check if the IBM backend can perform the Command cmd and return True if
+        so.
+
+        Args:
+            cmd (Command): The command to check
+        """
+        return IBMBackend().is_available(cmd)
+
+    def _reset(self):
+        """
+        Reset the mapping parameters so the next circuit can be mapped.
+        """
+        self._cmds = []
+        self._cnot_ids = []
+        self._cnot_id = -1
+
+    def _is_cnot(self, cmd):
+        """
+        Check if the command corresponds to a CNOT (controlled NOT gate).
+
+        Args:
+            cmd (Command): Command to check whether it is a controlled NOT gate.
+        """
+        return isinstance(cmd.gate, NOT.__class__) and get_control_count(cmd) == 1
+
+    def _run(self):
+        """
+        Runs all stored gates.
+
+        Raises:
+            Exception:
+                If the mapping to the IBM backend cannot be performed or if the
+                mapping was already determined but more CNOTs get sent down the
+                pipeline.
+        """
+        cnot_id = self._cnot_id
+        if cnot_id == -1 and len(self._cnot_ids) > 0:
+            cnot_id = self._cnot_ids[0]
+            if len(self._cnot_ids) == 2:  # we can optimize (at least a little bit)!
+                count1 = 0
+                count2 = 0
+                for cmd in self._cmds:
+                    if self._is_cnot(cmd):
+                        qb = cmd.qubits[0][0]
+                        ctrl = cmd.control_qubits[0]
+                        if ctrl.id == self._cnot_ids[0]:
+                            count1 += 1
+                        elif ctrl.id == self._cnot_ids[1]:
+                            count2 += 1
+                if count1 > count2:
+                    cnot_id = self._cnot_ids[1]
+
+        for cmd in self._cmds:
+            if self._is_cnot(cmd) and not cmd.qubits[0][0].id == cnot_id:
+                # we have to flip it around. To have nice syntax, we'll use a
+                # forwarder engine and a command modifier to get the tags right.
+                # (If the CNOT is an 'uncompute', then so must be the remapped CNOT)
+                def cmd_mod(command):
+                    command.tags = cmd.tags[:] + command.tags
+                    command.engine = self.main_engine
+                    return command
+
+                cmd_mod_eng = CommandModifier(cmd_mod)  # will add potential meta tags
+                cmd_mod_eng.next_engine = self.next_engine # and send on all commands
+                cmd_mod_eng.main_engine = self.main_engine
+                # forward everything to the command modifier
+                forwarder_eng = ForwarderEngine(cmd_mod_eng)
+                cmd.engine = forwarder_eng  # and send all gates to forwarder engine.
+
+                qubit = cmd.qubits[0]
+                ctrl = cmd.control_qubits
+                # flip the CNOT using Hadamard gates:
+                All(H) | (ctrl + qubit)
+                CNOT | (qubit, ctrl)
+                All(H) | (ctrl + qubit)
+
+                # This cmd would require remapping -->
+                # raise an exception if the CNOT id has already been determined.
+                if self._cnot_id != -1:
+                    self._reset()
+                    raise Exception("\nIBM Quantum Experience does not allow "
+                                    "intermediate measurements / \ndestruction of "
+                                    "qubits! CNOT mapping may be inconsistent.\n")
+            else:
+                self.next_engine.receive([cmd])
+        self._cmds = []
+        self._cnot_id = cnot_id
+
+    def _store(self, cmd):
+        """
+        Store a command and handle CNOTs.
+
+        Args:
+            cmd (Command): A command to store
+        Raises:
+            Exception: If the mapping to the IBM backend cannot be performed without
+                SWAPs.
+        """
+        if self._is_cnot(cmd):
+            # CNOT encountered
+            if len(self._cnot_ids) == 0:
+                self._cnot_ids += [cmd.control_qubits[0].id, cmd.qubits[0][0].id]
+            else:
+                apply_to = cmd.qubits[0][0].id
+                ctrl = cmd.control_qubits[0].id
+                if not apply_to in self._cnot_ids:
+                    if not ctrl in self._cnot_ids:
+                        raise Exception("Mapping without SWAPs failed! Sorry...")
+                    else:
+                        self._cnot_ids = [ctrl]
+                elif not ctrl in self._cnot_ids:
+                    self._cnot_ids = [apply_to]
+
+        self._cmds.append(cmd)
+
+    def receive(self, command_list):
+        """
+        Receives a command list and, for each command, stores it until completion.
+
+        Args:
+            command_list (list of Command objects): list of commands to receive.
+
+        Raises:
+            Exception: If mapping the CNOT gates to 1 qubit would require Swaps. The
+                current version only supports remapping of CNOT gates without
+                performing any Swaps due to the large costs associated with Swapping
+                given the CNOT constraints.
+        """
+        for cmd in command_list:
+            self._store(cmd)
+            if isinstance(cmd.gate, FastForwardingGate):
+                self._run()
+            if isinstance(cmd.gate, FlushGate):
+                self._reset()

--- a/projectq/cengines/_ibmcnotmapper_test.py
+++ b/projectq/cengines/_ibmcnotmapper_test.py
@@ -22,77 +22,77 @@ from projectq.cengines import _ibmcnotmapper
 
 
 def test_ibmcnotmapper_is_available(monkeypatch):
-	# Test that IBMCNOTMapper calls IBMBackend if gate is available.
-	def mock_send(*args, **kwargs):
-		return "Yes"
-	monkeypatch.setattr(_ibmcnotmapper.IBMBackend, "is_available", mock_send)
-	mapper = _ibmcnotmapper.IBMCNOTMapper()
-	assert mapper.is_available("TestCommand") == "Yes"
+    # Test that IBMCNOTMapper calls IBMBackend if gate is available.
+    def mock_send(*args, **kwargs):
+        return "Yes"
+    monkeypatch.setattr(_ibmcnotmapper.IBMBackend, "is_available", mock_send)
+    mapper = _ibmcnotmapper.IBMCNOTMapper()
+    assert mapper.is_available("TestCommand") == "Yes"
 
 
 def test_ibmcnotmapper_invalid_circuit():
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, 
-	                 engine_list=[_ibmcnotmapper.IBMCNOTMapper()])
-	qb0 = eng.allocate_qubit()
-	qb1 = eng.allocate_qubit()
-	qb2 = eng.allocate_qubit()
-	qb3 = eng.allocate_qubit()
-	CNOT | (qb1, qb2)
-	CNOT | (qb0, qb1)
-	with pytest.raises(Exception):
-		CNOT | (qb3, qb2)
-		eng.flush()
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend,
+                     engine_list=[_ibmcnotmapper.IBMCNOTMapper()])
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+    qb2 = eng.allocate_qubit()
+    qb3 = eng.allocate_qubit()
+    CNOT | (qb1, qb2)
+    CNOT | (qb0, qb1)
+    with pytest.raises(Exception):
+        CNOT | (qb3, qb2)
+        eng.flush()
 
 
 def test_ibmcnotmapper_nointermediate_measurements():
-	backend = DummyEngine()
-	eng = MainEngine(backend=backend, 
-	                 engine_list=[_ibmcnotmapper.IBMCNOTMapper()])
-	qb0 = eng.allocate_qubit()
-	qb1 = eng.allocate_qubit()
-	
-	CNOT | (qb0, qb1)
-	Measure | qb0
-	CNOT | (qb1, qb0)
-	with pytest.raises(Exception):
-		Measure | qb0
+    backend = DummyEngine()
+    eng = MainEngine(backend=backend,
+                     engine_list=[_ibmcnotmapper.IBMCNOTMapper()])
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+
+    CNOT | (qb0, qb1)
+    Measure | qb0
+    CNOT | (qb1, qb0)
+    with pytest.raises(Exception):
+        Measure | qb0
 
 def test_ibmcnotmapper_optimizeifpossible():
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, 
-	                 engine_list=[_ibmcnotmapper.IBMCNOTMapper()])
-	qb0 = eng.allocate_qubit()
-	qb1 = eng.allocate_qubit()
-	qb2 = eng.allocate_qubit()
-	qb3 = eng.allocate_qubit()
-	CNOT | (qb1, qb2)
-	CNOT | (qb2, qb1)
-	CNOT | (qb1, qb2)
-	
-	eng.flush()
-	
-	hadamard_count = 0
-	for cmd in backend.received_commands:
-		if cmd.gate == H:
-			hadamard_count += 1
-		if cmd.gate == X:
-			assert cmd.qubits[0][0].id == qb2[0].id
-	
-	assert hadamard_count == 4
-	backend.received_commands = []
-	
-	CNOT | (qb2, qb1)
-	CNOT | (qb1, qb2)
-	CNOT | (qb2, qb1)
-	
-	eng.flush()
-	
-	hadamard_count = 0
-	for cmd in backend.received_commands:
-		if cmd.gate == H:
-			hadamard_count += 1
-		if cmd.gate == X:
-			assert cmd.qubits[0][0].id == qb1[0].id
-	
-	assert hadamard_count == 4
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend,
+                     engine_list=[_ibmcnotmapper.IBMCNOTMapper()])
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+    qb2 = eng.allocate_qubit()
+    qb3 = eng.allocate_qubit()
+    CNOT | (qb1, qb2)
+    CNOT | (qb2, qb1)
+    CNOT | (qb1, qb2)
+
+    eng.flush()
+
+    hadamard_count = 0
+    for cmd in backend.received_commands:
+        if cmd.gate == H:
+            hadamard_count += 1
+        if cmd.gate == X:
+            assert cmd.qubits[0][0].id == qb2[0].id
+
+    assert hadamard_count == 4
+    backend.received_commands = []
+
+    CNOT | (qb2, qb1)
+    CNOT | (qb1, qb2)
+    CNOT | (qb2, qb1)
+
+    eng.flush()
+
+    hadamard_count = 0
+    for cmd in backend.received_commands:
+        if cmd.gate == H:
+            hadamard_count += 1
+        if cmd.gate == X:
+            assert cmd.qubits[0][0].id == qb1[0].id
+
+    assert hadamard_count == 4

--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -25,207 +25,207 @@ from projectq.backends import Simulator
 
 
 class NotYetMeasuredError(Exception):
-	pass
+    pass
 
 
 class UnsupportedEngineError(Exception):
-	pass
+    pass
 
 
 class MainEngine(BasicEngine):
-	"""
-	The MainEngine class provides all functionality of the main compiler engine.
-	
-	It initializes all further compiler engines (calls, e.g., .next_engine=...)
-	and keeps track of measurement results and active qubits (and their IDs).
-	
-	Attributes:
-		next_engine (BasicEngine): Next compiler engine (or the back-end).
-		main_engine (MainEngine): Self.
-		active_qubits (WeakSet): WeakSet containing all active qubits
-		dirty_qubits (Set): Containing all dirty qubit ids
-		backend (BasicEngine): Access the back-end.
-		
-	"""
-	def __init__(self, backend=None, engine_list=None):
-		"""
-		Initialize the main compiler engine and all compiler engines.
-		
-		Sets 'next_engine'- and 'main_engine'-attributes of all compiler engines
-		and adds the back-end as the last engine.
-		
-		Args:
-			backend (BasicEngine): Backend to send the circuit to.
-			engine_list (list<BasicEngine>): List of engines / backends to use as
-				compiler engines.
-			
-		Example:
-			.. code-block:: python
-				
-				from projectq import MainEngine
-				eng = MainEngine() # will load default setup using Simulator backend
-			
-		Alternatively, one can specify all compiler engines explicitly, e.g., 
-		
-		Example:
-			.. code-block:: python
-				
-				from projectq.cengines import TagRemover,AutoReplacer,LocalOptimizer
-				from projectq.backends import Simulator
-				from projectq import MainEngine
-				engines = [AutoReplacer(), TagRemover(), LocalOptimizer(3)]
-				eng = MainEngine(Simulator(), engines)
-		"""
-		BasicEngine.__init__(self)
-		
-		if backend is None:
-			backend = Simulator()
-		else: # Test that backend is BasicEngine object
-			if not isinstance(backend, BasicEngine):
-				raise UnsupportedEngineError(
-					"\nYou supplied a backend which is not supported,\n" +
-					"i.e. not an instance of BasicEngine.\n"+
-					"Did you forget the brackets to create an instance?\n" +
-					"E.g. MainEngine(backend=Simulator) instead of \n" +
-					"     MainEngine(backend=Simulator())")
-		if engine_list is None:
-			try:
-				engine_list = projectq.default_engines()
-			except AttributeError:
-				from projectq.setups.default import default_engines
-				engine_list = default_engines()
-		else: # Test that engine list elements are all BasicEngine objects
-			if not isinstance(engine_list, list):
-				raise UnsupportedEngineError(
-					"\n The engine_list argument is not a list!\n")
-			for current_eng in engine_list:
-				if not isinstance(current_eng, BasicEngine):
-					raise UnsupportedEngineError(
-						"\nYou supplied an unsupported engine in engine_list,\n" +
-						"i.e. not an instance of BasicEngine.\n"+
-						"Did you forget the brackets to create an instance?\n" +
-						"E.g. MainEngine(engine_list=[AutoReplacer]) instead of \n" +
-						"     MainEngine(engine_list=[AutoReplacer()])")
-		
-		engine_list.append(backend)
-		self.backend = backend
-		
-		# Test that user did not supply twice the same engine instance
-		num_different_engines = len(set([id(item) for item in engine_list]))
-		if len(engine_list) != num_different_engines:
-			raise UnsupportedEngineError(
-				"\n Error:\n You supplied twice the same engine as backend" +
-				" or item in engine_list. This doesn't work. Create two \n" +
-				" separate instances of a compiler engine if it is needed\n" +
-				" twice.\n")
-		
-		self._qubit_idx = int(0)
-		for i in range(len(engine_list) - 1):
-			engine_list[i].next_engine = engine_list[i + 1]
-			engine_list[i].main_engine = self
-		engine_list[-1].main_engine = self
-		engine_list[-1].is_last_engine = True
-		self.next_engine = engine_list[0]
-		self.main_engine = self
-		self.active_qubits = weakref.WeakSet()
-		self._measurements = dict()
-		self.dirty_qubits = set()
-		
-		# In order to terminate an example code without eng.flush or Measure
-		self._delfun = lambda x: x.flush(deallocate_qubits=True)
-		atexit.register(self._delfun, self)
-	
-	def __del__(self):
-		"""
-		Destroy the main engine.
-		
-		Flushes the entire circuit down the pipeline, clearing all temporary
-		buffers (in, e.g., optimizers).
-		"""
-		self.flush()
-		try:
-			atexit.unregister(self._delfun)  # only available in Python3
-		except AttributeError:
-			pass
-	
-	def set_measurement_result(self, qubit, value):
-		"""
-		Register a measurement result
-		
-		The engine being responsible for measurement results needs to register
-		these results with the master engine such that they are available when the
-		user calls an int() or bool() conversion operator on a measured qubit.
-		
-		Args:
-			qubit (BasicQubit): Qubit for which to register the measurement result.
-			value (bool): Boolean value of the measurement outcome (True / False = 1
-				/ 0 respectively)
-		"""
-		self._measurements[qubit.id] = bool(value)
-	
-	def get_measurement_result(self, qubit):
-		"""
-		Return the classical value of a measured qubit, given that an engine
-		registered this result previously (see setMeasurementResult).
-		
-		Args:
-			qubit (BasicQubit): Qubit of which to get the measurement result.
-			
-		Example:
-			.. code-block:: python
-			
-				from projectq.ops import H, Measure
-				from projectq import MainEngine
-				eng = MainEngine()
-				qubit = eng.allocate_qubit() # quantum register of size 1
-				H | qubit
-				Measure | qubit
-				eng.get_measurement_result(qubit[0]) == int(qubit)
-		"""
-		if qubit.id in self._measurements:
-			return self._measurements[qubit.id]
-		else:
-			raise NotYetMeasuredError(
-			                "\nError: Can't access measurement result for " +
-			                "qubit #" + str(qubit.id) + ". The problem may " +
-			                "be:\n\t1. Your " +
-			                "code lacks a measurement statement\n\t" +
-			                "2. You have not yet called engine.flush() to " +
-			                "force execution of your code\n\t3. The " +
-			                "underlying backend failed to register " +
-			                "the measurement result\n")
-	
-	def get_new_qubit_id(self):
-		"""
-		Returns a unique qubit id to be used for the next qubit allocation.
-		
-		Returns:
-			new_qubit_id (int): New unique qubit id.
-		"""
-		self._qubit_idx += 1
-		return (self._qubit_idx - 1)
-	
-	def receive(self, command_list):
-		"""
-		Forward the list of commands to the first engine.
-		
-		Args:
-			command_list (list<Command>): List of commands to receive (and then send
-				on)
-		"""
-		self.send(command_list)
-	
-	def flush(self, deallocate_qubits=False):
-		"""
-		Flush the entire circuit down the pipeline, clearing potential buffers
-		(of, e.g., optimizers).
-		
-		Args:
-			deallocate_qubits (bool): If True, deallocates all qubits that are still
-				alive (invalidating references to them by setting their id to -1)
-		"""
-		if deallocate_qubits:
-			for qb in self.active_qubits:
-				qb.__del__()
-			self.active_qubits = weakref.WeakSet()
-		self.receive([Command(self, FlushGate(), ([WeakQubitRef(self, -1)],))])
+    """
+    The MainEngine class provides all functionality of the main compiler engine.
+
+    It initializes all further compiler engines (calls, e.g., .next_engine=...)
+    and keeps track of measurement results and active qubits (and their IDs).
+
+    Attributes:
+        next_engine (BasicEngine): Next compiler engine (or the back-end).
+        main_engine (MainEngine): Self.
+        active_qubits (WeakSet): WeakSet containing all active qubits
+        dirty_qubits (Set): Containing all dirty qubit ids
+        backend (BasicEngine): Access the back-end.
+
+    """
+    def __init__(self, backend=None, engine_list=None):
+        """
+        Initialize the main compiler engine and all compiler engines.
+
+        Sets 'next_engine'- and 'main_engine'-attributes of all compiler engines
+        and adds the back-end as the last engine.
+
+        Args:
+            backend (BasicEngine): Backend to send the circuit to.
+            engine_list (list<BasicEngine>): List of engines / backends to use as
+                compiler engines.
+
+        Example:
+            .. code-block:: python
+
+                from projectq import MainEngine
+                eng = MainEngine() # will load default setup using Simulator backend
+
+        Alternatively, one can specify all compiler engines explicitly, e.g.,
+
+        Example:
+            .. code-block:: python
+
+                from projectq.cengines import TagRemover,AutoReplacer,LocalOptimizer
+                from projectq.backends import Simulator
+                from projectq import MainEngine
+                engines = [AutoReplacer(), TagRemover(), LocalOptimizer(3)]
+                eng = MainEngine(Simulator(), engines)
+        """
+        BasicEngine.__init__(self)
+
+        if backend is None:
+            backend = Simulator()
+        else: # Test that backend is BasicEngine object
+            if not isinstance(backend, BasicEngine):
+                raise UnsupportedEngineError(
+                    "\nYou supplied a backend which is not supported,\n" +
+                    "i.e. not an instance of BasicEngine.\n"+
+                    "Did you forget the brackets to create an instance?\n" +
+                    "E.g. MainEngine(backend=Simulator) instead of \n" +
+                    "     MainEngine(backend=Simulator())")
+        if engine_list is None:
+            try:
+                engine_list = projectq.default_engines()
+            except AttributeError:
+                from projectq.setups.default import default_engines
+                engine_list = default_engines()
+        else: # Test that engine list elements are all BasicEngine objects
+            if not isinstance(engine_list, list):
+                raise UnsupportedEngineError(
+                    "\n The engine_list argument is not a list!\n")
+            for current_eng in engine_list:
+                if not isinstance(current_eng, BasicEngine):
+                    raise UnsupportedEngineError(
+                        "\nYou supplied an unsupported engine in engine_list,\n" +
+                        "i.e. not an instance of BasicEngine.\n"+
+                        "Did you forget the brackets to create an instance?\n" +
+                        "E.g. MainEngine(engine_list=[AutoReplacer]) instead of \n" +
+                        "     MainEngine(engine_list=[AutoReplacer()])")
+
+        engine_list.append(backend)
+        self.backend = backend
+
+        # Test that user did not supply twice the same engine instance
+        num_different_engines = len(set([id(item) for item in engine_list]))
+        if len(engine_list) != num_different_engines:
+            raise UnsupportedEngineError(
+                "\n Error:\n You supplied twice the same engine as backend" +
+                " or item in engine_list. This doesn't work. Create two \n" +
+                " separate instances of a compiler engine if it is needed\n" +
+                " twice.\n")
+
+        self._qubit_idx = int(0)
+        for i in range(len(engine_list) - 1):
+            engine_list[i].next_engine = engine_list[i + 1]
+            engine_list[i].main_engine = self
+        engine_list[-1].main_engine = self
+        engine_list[-1].is_last_engine = True
+        self.next_engine = engine_list[0]
+        self.main_engine = self
+        self.active_qubits = weakref.WeakSet()
+        self._measurements = dict()
+        self.dirty_qubits = set()
+
+        # In order to terminate an example code without eng.flush or Measure
+        self._delfun = lambda x: x.flush(deallocate_qubits=True)
+        atexit.register(self._delfun, self)
+
+    def __del__(self):
+        """
+        Destroy the main engine.
+
+        Flushes the entire circuit down the pipeline, clearing all temporary
+        buffers (in, e.g., optimizers).
+        """
+        self.flush()
+        try:
+            atexit.unregister(self._delfun)  # only available in Python3
+        except AttributeError:
+            pass
+
+    def set_measurement_result(self, qubit, value):
+        """
+        Register a measurement result
+
+        The engine being responsible for measurement results needs to register
+        these results with the master engine such that they are available when the
+        user calls an int() or bool() conversion operator on a measured qubit.
+
+        Args:
+            qubit (BasicQubit): Qubit for which to register the measurement result.
+            value (bool): Boolean value of the measurement outcome (True / False = 1
+                / 0 respectively)
+        """
+        self._measurements[qubit.id] = bool(value)
+
+    def get_measurement_result(self, qubit):
+        """
+        Return the classical value of a measured qubit, given that an engine
+        registered this result previously (see setMeasurementResult).
+
+        Args:
+            qubit (BasicQubit): Qubit of which to get the measurement result.
+
+        Example:
+            .. code-block:: python
+
+                from projectq.ops import H, Measure
+                from projectq import MainEngine
+                eng = MainEngine()
+                qubit = eng.allocate_qubit() # quantum register of size 1
+                H | qubit
+                Measure | qubit
+                eng.get_measurement_result(qubit[0]) == int(qubit)
+        """
+        if qubit.id in self._measurements:
+            return self._measurements[qubit.id]
+        else:
+            raise NotYetMeasuredError(
+                            "\nError: Can't access measurement result for " +
+                            "qubit #" + str(qubit.id) + ". The problem may " +
+                            "be:\n\t1. Your " +
+                            "code lacks a measurement statement\n\t" +
+                            "2. You have not yet called engine.flush() to " +
+                            "force execution of your code\n\t3. The " +
+                            "underlying backend failed to register " +
+                            "the measurement result\n")
+
+    def get_new_qubit_id(self):
+        """
+        Returns a unique qubit id to be used for the next qubit allocation.
+
+        Returns:
+            new_qubit_id (int): New unique qubit id.
+        """
+        self._qubit_idx += 1
+        return (self._qubit_idx - 1)
+
+    def receive(self, command_list):
+        """
+        Forward the list of commands to the first engine.
+
+        Args:
+            command_list (list<Command>): List of commands to receive (and then send
+                on)
+        """
+        self.send(command_list)
+
+    def flush(self, deallocate_qubits=False):
+        """
+        Flush the entire circuit down the pipeline, clearing potential buffers
+        (of, e.g., optimizers).
+
+        Args:
+            deallocate_qubits (bool): If True, deallocates all qubits that are still
+                alive (invalidating references to them by setting their id to -1)
+        """
+        if deallocate_qubits:
+            for qb in self.active_qubits:
+                qb.__del__()
+            self.active_qubits = weakref.WeakSet()
+        self.receive([Command(self, FlushGate(), ([WeakQubitRef(self, -1)],))])

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -21,95 +21,95 @@ from projectq.cengines import _main
 
 
 def test_main_engine_init():
-	ceng1 = DummyEngine()
-	ceng2 = DummyEngine()
-	test_backend = DummyEngine()
-	eng = _main.MainEngine(backend=test_backend, engine_list=[ceng1, ceng2])
-	assert id(eng.next_engine) == id(ceng1)
-	assert id(eng.main_engine) == id(eng)
-	assert not eng.is_last_engine
-	assert id(ceng1.next_engine) == id(ceng2)
-	assert id(ceng1.main_engine) == id(eng)
-	assert not ceng1.is_last_engine
-	assert id(ceng2.next_engine) == id(test_backend)
-	assert id(ceng2.main_engine) == id(eng)
-	assert not ceng2.is_last_engine
-	assert test_backend.is_last_engine
-	assert id(test_backend.main_engine) == id(eng)
-	assert not test_backend.next_engine
+    ceng1 = DummyEngine()
+    ceng2 = DummyEngine()
+    test_backend = DummyEngine()
+    eng = _main.MainEngine(backend=test_backend, engine_list=[ceng1, ceng2])
+    assert id(eng.next_engine) == id(ceng1)
+    assert id(eng.main_engine) == id(eng)
+    assert not eng.is_last_engine
+    assert id(ceng1.next_engine) == id(ceng2)
+    assert id(ceng1.main_engine) == id(eng)
+    assert not ceng1.is_last_engine
+    assert id(ceng2.next_engine) == id(test_backend)
+    assert id(ceng2.main_engine) == id(eng)
+    assert not ceng2.is_last_engine
+    assert test_backend.is_last_engine
+    assert id(test_backend.main_engine) == id(eng)
+    assert not test_backend.next_engine
 
 
 def test_main_engine_init_failure():
-	with pytest.raises(_main.UnsupportedEngineError):
-		eng = _main.MainEngine(backend=DummyEngine)
-	with pytest.raises(_main.UnsupportedEngineError):
-		eng = _main.MainEngine(engine_list=DummyEngine)
-	with pytest.raises(_main.UnsupportedEngineError):
-		eng = _main.MainEngine(engine_list=[DummyEngine(), DummyEngine])
-	with pytest.raises(_main.UnsupportedEngineError):
-		engine = DummyEngine()
-		eng = _main.MainEngine(backend=engine, engine_list=[engine])
+    with pytest.raises(_main.UnsupportedEngineError):
+        eng = _main.MainEngine(backend=DummyEngine)
+    with pytest.raises(_main.UnsupportedEngineError):
+        eng = _main.MainEngine(engine_list=DummyEngine)
+    with pytest.raises(_main.UnsupportedEngineError):
+        eng = _main.MainEngine(engine_list=[DummyEngine(), DummyEngine])
+    with pytest.raises(_main.UnsupportedEngineError):
+        engine = DummyEngine()
+        eng = _main.MainEngine(backend=engine, engine_list=[engine])
 
 
 def test_main_engine_init_defaults():
-	eng = _main.MainEngine()
-	eng_list = []
-	current_engine = eng.next_engine
-	while not current_engine.is_last_engine:
-		eng_list.append(current_engine)
-		current_engine = current_engine.next_engine
-	assert isinstance(eng_list[-1].next_engine, Simulator)
-	from projectq.setups.default import default_engines
-	for engine, expected in zip(eng_list, default_engines()):
-		assert type(engine) == type(expected)
+    eng = _main.MainEngine()
+    eng_list = []
+    current_engine = eng.next_engine
+    while not current_engine.is_last_engine:
+        eng_list.append(current_engine)
+        current_engine = current_engine.next_engine
+    assert isinstance(eng_list[-1].next_engine, Simulator)
+    from projectq.setups.default import default_engines
+    for engine, expected in zip(eng_list, default_engines()):
+        assert type(engine) == type(expected)
 
 
 def test_main_engine_del():
-	# need engine which caches commands to test that del calls flush
-	caching_engine = LocalOptimizer(m=5)
-	backend = DummyEngine(save_commands=True)
-	eng = _main.MainEngine(backend=backend, engine_list=[caching_engine])
-	qubit = eng.allocate_qubit()
-	H | qubit
-	assert len(backend.received_commands) == 0
-	eng.__del__()
-	# Allocate, H, and Flush Gate
-	assert len(backend.received_commands) == 3
+    # need engine which caches commands to test that del calls flush
+    caching_engine = LocalOptimizer(m=5)
+    backend = DummyEngine(save_commands=True)
+    eng = _main.MainEngine(backend=backend, engine_list=[caching_engine])
+    qubit = eng.allocate_qubit()
+    H | qubit
+    assert len(backend.received_commands) == 0
+    eng.__del__()
+    # Allocate, H, and Flush Gate
+    assert len(backend.received_commands) == 3
 
 
 def test_main_engine_set_and_get_measurement_result():
-	eng = _main.MainEngine()
-	qubit0 = eng.allocate_qubit()
-	qubit1 = eng.allocate_qubit()
-	with pytest.raises(_main.NotYetMeasuredError):
-		print(int(qubit0))
-	eng.set_measurement_result(qubit0[0], True)
-	eng.set_measurement_result(qubit1[0], False)
-	assert int(qubit0)
-	assert not int(qubit1)
+    eng = _main.MainEngine()
+    qubit0 = eng.allocate_qubit()
+    qubit1 = eng.allocate_qubit()
+    with pytest.raises(_main.NotYetMeasuredError):
+        print(int(qubit0))
+    eng.set_measurement_result(qubit0[0], True)
+    eng.set_measurement_result(qubit1[0], False)
+    assert int(qubit0)
+    assert not int(qubit1)
 
 
 def test_main_engine_get_qubit_id():
-	# Test that ids are not identical
-	eng = _main.MainEngine()
-	ids = []
-	for _ in range(10):
-		ids.append(eng.get_new_qubit_id())
-	assert len(set(ids)) == 10
+    # Test that ids are not identical
+    eng = _main.MainEngine()
+    ids = []
+    for _ in range(10):
+        ids.append(eng.get_new_qubit_id())
+    assert len(set(ids)) == 10
 
 
 def test_main_engine_flush():
-	backend = DummyEngine(save_commands=True)
-	eng = _main.MainEngine(backend=backend, engine_list=[DummyEngine()])
-	qubit = eng.allocate_qubit()
-	H | qubit
-	eng.flush()
-	assert len(backend.received_commands) == 3
-	assert backend.received_commands[0].gate == AllocateQubitGate()
-	assert backend.received_commands[1].gate == H
-	assert backend.received_commands[2].gate == FlushGate()
-	eng.flush(deallocate_qubits=True)
-	assert len(backend.received_commands) == 5
-	assert backend.received_commands[3].gate == DeallocateQubitGate()
-	#keep the qubit alive until at least here
-	assert len(str(qubit)) != 0
+    backend = DummyEngine(save_commands=True)
+    eng = _main.MainEngine(backend=backend, engine_list=[DummyEngine()])
+    qubit = eng.allocate_qubit()
+    H | qubit
+    eng.flush()
+    assert len(backend.received_commands) == 3
+    assert backend.received_commands[0].gate == AllocateQubitGate()
+    assert backend.received_commands[1].gate == H
+    assert backend.received_commands[2].gate == FlushGate()
+    eng.flush(deallocate_qubits=True)
+    assert len(backend.received_commands) == 5
+    assert backend.received_commands[3].gate == DeallocateQubitGate()
+    #keep the qubit alive until at least here
+    assert len(str(qubit)) != 0

--- a/projectq/cengines/_optimize.py
+++ b/projectq/cengines/_optimize.py
@@ -20,217 +20,217 @@ from projectq.ops import FlushGate, FastForwardingGate, NotMergeable
 
 
 class LocalOptimizer(BasicEngine):
-	"""
-	LocalOptimizer is a compiler engine which optimizes locally (merging
-	rotations, cancelling gates with their inverse) in a local window of user-
-	defined size.
-	
-	It stores all commands in a list of lists, where each qubit has its own gate
-	pipeline. After adding a gate, it tries to merge / cancel successive gates
-	using the get_merged and get_inverse functions of the gate (if available).
-	For examples, see BasicRotationGate. Once a list corresponding to a qubit
-	contains >=m gates, the pipeline is sent on to the next engine.
-	"""
-	def __init__(self, m=5):
-		"""
-		Initialize a LocalOptimizer object.
-		
-		Args:
-			m (int): Number of gates to cache per qubit, before sending on the first
-				gate.
-		"""
-		BasicEngine.__init__(self)
-		self._l = [[]]  # list of lists containing the operations for each qubit
-		self._m = m  # wait for m gates before sending on
-		
-	# sends n gate operations of the qubit with index idx
-	def _send_qubit_pipeline(self, idx, n):
-		"""
-		Send n gate operations of the qubit with index idx to the next engine.
-		"""
-		il = self._l[idx]  # temporary label for readability
-		for i in range(0, min(n, len(il))):  # loop over first n operations
-			# send all gates before n-qubit gate for other qubits involved
-			# --> recursively call send_helper
-			for qreg in il[i].all_qubits:  # loop over tuples of quregs
-				for qb in qreg:  # ... and qubits involved
-					Id = qb.id
-					if Id != idx:  # is a different qubit than the current one
-						try:
-							gateloc = 0
-							# find location of this gate within its list
-							while self._l[Id][gateloc] != il[i]:
-								gateloc += 1
-								
-							gateloc = self._optimize(Id, gateloc)
-							
-							# flush the gates before the n-qubit gate
-							self._send_qubit_pipeline(Id, gateloc)
-							# delete the n-qubit gate, we're taking care of it
-							# and don't want the other qubit to do so
-							self._l[Id] = self._l[Id][1:]
-						except IndexError:
-							print("Invalid qubit pipeline encountered (in the process of "
-							      "shutting down?).")
-						
-			# all qubits that need to be flushed have been flushed
-			# --> send on the n-qubit gate
-			self.send([il[i]])
-		# n operations have been sent on --> resize our gate list
-		self._l[idx] = self._l[idx][n:]
-	
-	def _get_gate_indices(self, idx, i, IDs):
-		"""
-		Return all indices of a command, each index corresponding to the command's
-		index in one of the qubits' command lists.
-		
-		Args:
-			idx (int): qubit index
-			i (int): command position in qubit idx's command list
-			IDs (list<int>): IDs of all qubits involved in the command
-		"""
-		N = len(IDs)
-		# 1-qubit gate: only gate at index i in list #idx is involved
-		if N == 1:
-			return [i]
-		indices = [0] * N
-		
-		numidentical = 0  # number of identical commands (gate & arguments)
-		j = 0
-		while j < i:
-			# this gate would otherwise be recognized as the right one in other qubits
-			# find #times this happens before the right gate is found
-			if self._l[idx][j] == self._l[idx][i]:
-				numidentical += 1
-			j += 1
-		
-		for k in range(len(IDs)):
-			j = found = 0
-			while found <= numidentical:
-				# if ==, it may be the same gate, check using numidentical
-				if self._l[IDs[k]][j] == self._l[idx][i]:
-					found += 1
-				j += 1
-			
-			# this is the index of the gate in the gate list of qubit IDs[k]
-			indices[k] = j - 1
-		return indices
-	
-	def _optimize(self, idx, lim=None):
-		"""
-		Try to merge or even cancel successive gates using the get_merged and
-		get_inverse functions of the gate (see, e.g., BasicRotationGate).
-		
-		It does so for all qubit command lists.
-		"""
-		# loop over all qubit indices
-		i = 0
-		new_gateloc = 0
-		limit = len(self._l[idx])
-		if not lim is None:
-			limit = lim
-			new_gateloc = limit
-			
-		while i < limit - 1:
-			# can be dropped if two in a row are self-inverses
-			inv = self._l[idx][i].get_inverse()
-			
-			if inv == self._l[idx][i + 1]:
-				# determine index of this gate on all qubits
-				qubitids = [qb.id for sublist in self._l[idx][i].all_qubits for qb
-				            in sublist]
-				gid = self._get_gate_indices(idx, i, qubitids)
-				# check that there are no other gates between this and its inverse
-				# on any of the other qubits involved
-				erase = True
-				for j in range(len(qubitids)):
-					erase *= (inv == self._l[qubitids[j]][gid[j] + 1])
-						
-				# drop these two gates if possible and goto next iteration
-				if erase:
-					for j in range(len(qubitids)):
-						self._l[qubitids[j]] = (self._l[qubitids[j]][0:gid[j]] +
-						                        self._l[qubitids[j]][gid[j] + 2:])
-					i = 0
-					limit -= 2
-					continue
-					
-			# gates are not each other's inverses --> check if they're mergeable
-			try:
-				merged_command = self._l[idx][i].get_merged(self._l[idx][i + 1])
-				# determine index of this gate on all qubits
-				qubitids = [qb.id for sublist in self._l[idx][i].all_qubits
-				            for qb in sublist]
-				gid = self._get_gate_indices(idx, i, qubitids)
-				
-				merge = True
-				for j in range(len(qubitids)):
-					m = self._l[qubitids[j]][gid[j]].get_merged(
-								self._l[qubitids[j]][gid[j] + 1])
-					merge *= (m == merged_command)
-				
-				if merge:
-					for j in range(len(qubitids)):
-						self._l[qubitids[j]][gid[j]] = merged_command
-						self._l[qubitids[j]] = (self._l[qubitids[j]][0:gid[j] + 1] +
-						                        self._l[qubitids[j]][gid[j] + 2:])
-					i = 0
-					limit -= 1
-					continue
-			except NotMergeable:
-				pass  # can't merge these two commands.
+    """
+    LocalOptimizer is a compiler engine which optimizes locally (merging
+    rotations, cancelling gates with their inverse) in a local window of user-
+    defined size.
 
-			i += 1  # next iteration: look at next gate
-		return limit
+    It stores all commands in a list of lists, where each qubit has its own gate
+    pipeline. After adding a gate, it tries to merge / cancel successive gates
+    using the get_merged and get_inverse functions of the gate (if available).
+    For examples, see BasicRotationGate. Once a list corresponding to a qubit
+    contains >=m gates, the pipeline is sent on to the next engine.
+    """
+    def __init__(self, m=5):
+        """
+        Initialize a LocalOptimizer object.
 
-	def _check_and_send(self):
-		"""
-		Check whether a qubit pipeline must be sent on and, if so,
-		optimize the pipeline and then send it on.
-		"""
-		for i in range(len(self._l)):
-			if (len(self._l[i]) >= self._m or len(self._l[i]) > 0
-			    and isinstance(self._l[i][-1].gate, FastForwardingGate)):
-				self._optimize(i)
-				if (len(self._l[i]) >= self._m
-				    and not isinstance(self._l[i][-1].gate, FastForwardingGate)):
-					self._send_qubit_pipeline(i, len(self._l[i]) - self._m + 1)
-				elif (len(self._l[i]) > 0 and
-				      isinstance(self._l[i][-1].gate, FastForwardingGate)):
-					self._send_qubit_pipeline(i, len(self._l[i]))
-		
-	def _cache_cmd(self, cmd):
-		"""
-		Cache a command, i.e., inserts it into the command lists of all qubits
-		involved.
-		"""
-		# are there qubit ids that haven't been added to the list?
-		idlist = [qubit.id for sublist in cmd.all_qubits for qubit in sublist]
-		maxidx = int(0)
-		for ID in idlist:
-			maxidx = max(maxidx, ID)
-		
-		# if so, increase size of list to account for these qubits
-		add = maxidx + 1 - len(self._l)
-		if add > 0:
-			self._l += [[] for _ in range(add)]
-			
-		# add gate command to each of the qubits involved
-		for ID in idlist:
-			self._l[ID] += [cmd]
+        Args:
+            m (int): Number of gates to cache per qubit, before sending on the first
+                gate.
+        """
+        BasicEngine.__init__(self)
+        self._l = [[]]  # list of lists containing the operations for each qubit
+        self._m = m  # wait for m gates before sending on
 
-		self._check_and_send()
-		
-	def receive(self, command_list):
-		"""
-		Receive commands from the previous engine and cache them.
-		If a flush gate arrives, the entire buffer is sent on.
-		"""
-		for cmd in command_list:
-			if cmd.gate == FlushGate():  # flush gate --> optimize and flush
-				for i in range(len(self._l)):
-					self._optimize(i)
-					self._send_qubit_pipeline(i, len(self._l[i]))
-				self.send([cmd])
-			else:
-				self._cache_cmd(cmd)
+    # sends n gate operations of the qubit with index idx
+    def _send_qubit_pipeline(self, idx, n):
+        """
+        Send n gate operations of the qubit with index idx to the next engine.
+        """
+        il = self._l[idx]  # temporary label for readability
+        for i in range(0, min(n, len(il))):  # loop over first n operations
+            # send all gates before n-qubit gate for other qubits involved
+            # --> recursively call send_helper
+            for qreg in il[i].all_qubits:  # loop over tuples of quregs
+                for qb in qreg:  # ... and qubits involved
+                    Id = qb.id
+                    if Id != idx:  # is a different qubit than the current one
+                        try:
+                            gateloc = 0
+                            # find location of this gate within its list
+                            while self._l[Id][gateloc] != il[i]:
+                                gateloc += 1
+
+                            gateloc = self._optimize(Id, gateloc)
+
+                            # flush the gates before the n-qubit gate
+                            self._send_qubit_pipeline(Id, gateloc)
+                            # delete the n-qubit gate, we're taking care of it
+                            # and don't want the other qubit to do so
+                            self._l[Id] = self._l[Id][1:]
+                        except IndexError:
+                            print("Invalid qubit pipeline encountered (in the process of "
+                                  "shutting down?).")
+
+            # all qubits that need to be flushed have been flushed
+            # --> send on the n-qubit gate
+            self.send([il[i]])
+        # n operations have been sent on --> resize our gate list
+        self._l[idx] = self._l[idx][n:]
+
+    def _get_gate_indices(self, idx, i, IDs):
+        """
+        Return all indices of a command, each index corresponding to the command's
+        index in one of the qubits' command lists.
+
+        Args:
+            idx (int): qubit index
+            i (int): command position in qubit idx's command list
+            IDs (list<int>): IDs of all qubits involved in the command
+        """
+        N = len(IDs)
+        # 1-qubit gate: only gate at index i in list #idx is involved
+        if N == 1:
+            return [i]
+        indices = [0] * N
+
+        numidentical = 0  # number of identical commands (gate & arguments)
+        j = 0
+        while j < i:
+            # this gate would otherwise be recognized as the right one in other qubits
+            # find #times this happens before the right gate is found
+            if self._l[idx][j] == self._l[idx][i]:
+                numidentical += 1
+            j += 1
+
+        for k in range(len(IDs)):
+            j = found = 0
+            while found <= numidentical:
+                # if ==, it may be the same gate, check using numidentical
+                if self._l[IDs[k]][j] == self._l[idx][i]:
+                    found += 1
+                j += 1
+
+            # this is the index of the gate in the gate list of qubit IDs[k]
+            indices[k] = j - 1
+        return indices
+
+    def _optimize(self, idx, lim=None):
+        """
+        Try to merge or even cancel successive gates using the get_merged and
+        get_inverse functions of the gate (see, e.g., BasicRotationGate).
+
+        It does so for all qubit command lists.
+        """
+        # loop over all qubit indices
+        i = 0
+        new_gateloc = 0
+        limit = len(self._l[idx])
+        if not lim is None:
+            limit = lim
+            new_gateloc = limit
+
+        while i < limit - 1:
+            # can be dropped if two in a row are self-inverses
+            inv = self._l[idx][i].get_inverse()
+
+            if inv == self._l[idx][i + 1]:
+                # determine index of this gate on all qubits
+                qubitids = [qb.id for sublist in self._l[idx][i].all_qubits for qb
+                            in sublist]
+                gid = self._get_gate_indices(idx, i, qubitids)
+                # check that there are no other gates between this and its inverse
+                # on any of the other qubits involved
+                erase = True
+                for j in range(len(qubitids)):
+                    erase *= (inv == self._l[qubitids[j]][gid[j] + 1])
+
+                # drop these two gates if possible and goto next iteration
+                if erase:
+                    for j in range(len(qubitids)):
+                        self._l[qubitids[j]] = (self._l[qubitids[j]][0:gid[j]] +
+                                                self._l[qubitids[j]][gid[j] + 2:])
+                    i = 0
+                    limit -= 2
+                    continue
+
+            # gates are not each other's inverses --> check if they're mergeable
+            try:
+                merged_command = self._l[idx][i].get_merged(self._l[idx][i + 1])
+                # determine index of this gate on all qubits
+                qubitids = [qb.id for sublist in self._l[idx][i].all_qubits
+                            for qb in sublist]
+                gid = self._get_gate_indices(idx, i, qubitids)
+
+                merge = True
+                for j in range(len(qubitids)):
+                    m = self._l[qubitids[j]][gid[j]].get_merged(
+                                self._l[qubitids[j]][gid[j] + 1])
+                    merge *= (m == merged_command)
+
+                if merge:
+                    for j in range(len(qubitids)):
+                        self._l[qubitids[j]][gid[j]] = merged_command
+                        self._l[qubitids[j]] = (self._l[qubitids[j]][0:gid[j] + 1] +
+                                                self._l[qubitids[j]][gid[j] + 2:])
+                    i = 0
+                    limit -= 1
+                    continue
+            except NotMergeable:
+                pass  # can't merge these two commands.
+
+            i += 1  # next iteration: look at next gate
+        return limit
+
+    def _check_and_send(self):
+        """
+        Check whether a qubit pipeline must be sent on and, if so,
+        optimize the pipeline and then send it on.
+        """
+        for i in range(len(self._l)):
+            if (len(self._l[i]) >= self._m or len(self._l[i]) > 0
+                and isinstance(self._l[i][-1].gate, FastForwardingGate)):
+                self._optimize(i)
+                if (len(self._l[i]) >= self._m
+                    and not isinstance(self._l[i][-1].gate, FastForwardingGate)):
+                    self._send_qubit_pipeline(i, len(self._l[i]) - self._m + 1)
+                elif (len(self._l[i]) > 0 and
+                      isinstance(self._l[i][-1].gate, FastForwardingGate)):
+                    self._send_qubit_pipeline(i, len(self._l[i]))
+
+    def _cache_cmd(self, cmd):
+        """
+        Cache a command, i.e., inserts it into the command lists of all qubits
+        involved.
+        """
+        # are there qubit ids that haven't been added to the list?
+        idlist = [qubit.id for sublist in cmd.all_qubits for qubit in sublist]
+        maxidx = int(0)
+        for ID in idlist:
+            maxidx = max(maxidx, ID)
+
+        # if so, increase size of list to account for these qubits
+        add = maxidx + 1 - len(self._l)
+        if add > 0:
+            self._l += [[] for _ in range(add)]
+
+        # add gate command to each of the qubits involved
+        for ID in idlist:
+            self._l[ID] += [cmd]
+
+        self._check_and_send()
+
+    def receive(self, command_list):
+        """
+        Receive commands from the previous engine and cache them.
+        If a flush gate arrives, the entire buffer is sent on.
+        """
+        for cmd in command_list:
+            if cmd.gate == FlushGate():  # flush gate --> optimize and flush
+                for i in range(len(self._l)):
+                    self._optimize(i)
+                    self._send_qubit_pipeline(i, len(self._l[i]))
+                self.send([cmd])
+            else:
+                self._cache_cmd(cmd)

--- a/projectq/cengines/_optimize_test.py
+++ b/projectq/cengines/_optimize_test.py
@@ -23,105 +23,105 @@ from projectq.cengines import _optimize
 
 
 def test_local_optimizer_caching():
-	local_optimizer = _optimize.LocalOptimizer(m=4)
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[local_optimizer])
-	# Test that it caches for each qubit 3 gates
-	qb0 = eng.allocate_qubit()
-	qb1 = eng.allocate_qubit()
-	assert len(backend.received_commands) == 0
-	H | qb0
-	H | qb1
-	CNOT | (qb0, qb1)
-	assert len(backend.received_commands) == 0
-	Rx(0.5) | qb0
-	assert len(backend.received_commands) == 1
-	assert backend.received_commands[0].gate == AllocateQubitGate()
-	H | qb0
-	assert len(backend.received_commands) == 2
-	assert backend.received_commands[1].gate == H
-	# Another gate on qb0 means it needs to send CNOT but clear pipeline of qb1
-	Rx(0.6) | qb0
-	for cmd in backend.received_commands:
-		print(cmd)
-	assert len(backend.received_commands) == 5
-	assert backend.received_commands[2].gate == AllocateQubitGate()
-	assert backend.received_commands[3].gate == H
-	assert backend.received_commands[3].qubits[0][0].id == qb1[0].id
-	assert backend.received_commands[4].gate == X
-	assert backend.received_commands[4].control_qubits[0].id == qb0[0].id
-	assert backend.received_commands[4].qubits[0][0].id == qb1[0].id
+    local_optimizer = _optimize.LocalOptimizer(m=4)
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[local_optimizer])
+    # Test that it caches for each qubit 3 gates
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+    assert len(backend.received_commands) == 0
+    H | qb0
+    H | qb1
+    CNOT | (qb0, qb1)
+    assert len(backend.received_commands) == 0
+    Rx(0.5) | qb0
+    assert len(backend.received_commands) == 1
+    assert backend.received_commands[0].gate == AllocateQubitGate()
+    H | qb0
+    assert len(backend.received_commands) == 2
+    assert backend.received_commands[1].gate == H
+    # Another gate on qb0 means it needs to send CNOT but clear pipeline of qb1
+    Rx(0.6) | qb0
+    for cmd in backend.received_commands:
+        print(cmd)
+    assert len(backend.received_commands) == 5
+    assert backend.received_commands[2].gate == AllocateQubitGate()
+    assert backend.received_commands[3].gate == H
+    assert backend.received_commands[3].qubits[0][0].id == qb1[0].id
+    assert backend.received_commands[4].gate == X
+    assert backend.received_commands[4].control_qubits[0].id == qb0[0].id
+    assert backend.received_commands[4].qubits[0][0].id == qb1[0].id
 
 
 def test_local_optimizer_flush_gate():
-	local_optimizer = _optimize.LocalOptimizer(m=4)
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[local_optimizer])
-	# Test that it caches for each qubit 3 gates
-	qb0 = eng.allocate_qubit()
-	qb1 = eng.allocate_qubit()
-	H | qb0
-	H | qb1
-	assert len(backend.received_commands) == 0
-	eng.flush()
-	# Two allocate gates, two H gates and one flush gate
-	assert len(backend.received_commands) == 5
+    local_optimizer = _optimize.LocalOptimizer(m=4)
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[local_optimizer])
+    # Test that it caches for each qubit 3 gates
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+    H | qb0
+    H | qb1
+    assert len(backend.received_commands) == 0
+    eng.flush()
+    # Two allocate gates, two H gates and one flush gate
+    assert len(backend.received_commands) == 5
 
 
 def test_local_optimizer_fast_forwarding_gate():
-	local_optimizer = _optimize.LocalOptimizer(m=4)
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[local_optimizer])
-	# Test that FastForwardingGate (e.g. Deallocate) flushes that qb0 pipeline
-	qb0 = eng.allocate_qubit()
-	qb1 = eng.allocate_qubit()
-	H | qb0
-	H | qb1
-	assert len(backend.received_commands) == 0
-	qb0[0].__del__()
-	# As Deallocate gate is a FastForwardingGate, we should get gates of qb0
-	assert len(backend.received_commands) == 3
+    local_optimizer = _optimize.LocalOptimizer(m=4)
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[local_optimizer])
+    # Test that FastForwardingGate (e.g. Deallocate) flushes that qb0 pipeline
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+    H | qb0
+    H | qb1
+    assert len(backend.received_commands) == 0
+    qb0[0].__del__()
+    # As Deallocate gate is a FastForwardingGate, we should get gates of qb0
+    assert len(backend.received_commands) == 3
 
 
 def test_local_optimizer_cancel_inverse():
-	local_optimizer = _optimize.LocalOptimizer(m=4)
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[local_optimizer])
-	# Test that it cancels inverses (H, CNOT are self-inverse)
-	qb0 = eng.allocate_qubit()
-	qb1 = eng.allocate_qubit()
-	assert len(backend.received_commands) == 0
-	for _ in range(11):
-		H | qb0
-	assert len(backend.received_commands) == 0
-	for _ in range(11):
-		CNOT | (qb0, qb1)
-	assert len(backend.received_commands) == 0
-	eng.flush()
-	received_commands = []
-	# Remove Allocate and Deallocate gates
-	for cmd in backend.received_commands:
-		if not (isinstance(cmd.gate, FastForwardingGate) or 
-	            isinstance(cmd.gate, ClassicalInstructionGate)):
-			received_commands.append(cmd)
-	assert len(received_commands) == 2
-	assert received_commands[0].gate == H
-	assert received_commands[0].qubits[0][0].id == qb0[0].id
-	assert received_commands[1].gate == X
-	assert received_commands[1].qubits[0][0].id == qb1[0].id
-	assert received_commands[1].control_qubits[0].id == qb0[0].id
+    local_optimizer = _optimize.LocalOptimizer(m=4)
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[local_optimizer])
+    # Test that it cancels inverses (H, CNOT are self-inverse)
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+    assert len(backend.received_commands) == 0
+    for _ in range(11):
+        H | qb0
+    assert len(backend.received_commands) == 0
+    for _ in range(11):
+        CNOT | (qb0, qb1)
+    assert len(backend.received_commands) == 0
+    eng.flush()
+    received_commands = []
+    # Remove Allocate and Deallocate gates
+    for cmd in backend.received_commands:
+        if not (isinstance(cmd.gate, FastForwardingGate) or
+                isinstance(cmd.gate, ClassicalInstructionGate)):
+            received_commands.append(cmd)
+    assert len(received_commands) == 2
+    assert received_commands[0].gate == H
+    assert received_commands[0].qubits[0][0].id == qb0[0].id
+    assert received_commands[1].gate == X
+    assert received_commands[1].qubits[0][0].id == qb1[0].id
+    assert received_commands[1].control_qubits[0].id == qb0[0].id
 
 
 def test_local_optimizer_mergeable_gates():
-	local_optimizer = _optimize.LocalOptimizer(m=4)
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[local_optimizer])
-	# Test that it merges mergeable gates such as Rx
-	qb0 = eng.allocate_qubit()
-	for _ in range(10):
-		Rx(0.5) | qb0
-	assert len(backend.received_commands) == 0
-	eng.flush()
-	# Expect allocate, one Rx gate, and flush gate
-	assert len(backend.received_commands) == 3
-	assert backend.received_commands[1].gate == Rx(10 * 0.5)
+    local_optimizer = _optimize.LocalOptimizer(m=4)
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[local_optimizer])
+    # Test that it merges mergeable gates such as Rx
+    qb0 = eng.allocate_qubit()
+    for _ in range(10):
+        Rx(0.5) | qb0
+    assert len(backend.received_commands) == 0
+    eng.flush()
+    # Expect allocate, one Rx gate, and flush gate
+    assert len(backend.received_commands) == 3
+    assert backend.received_commands[1].gate == Rx(10 * 0.5)

--- a/projectq/cengines/_replacer/_decomposition.py
+++ b/projectq/cengines/_replacer/_decomposition.py
@@ -19,69 +19,69 @@ from projectq.meta import Dagger
 
 
 class Decomposition(object):
-	"""
-	The Decomposition class can be used to register a decomposition rule (by
-	calling register_decomposition)
-	"""
-	def __init__(self, replacement_fun, recogn_fun):
-		"""
-		Construct the Decomposition object.
-		
-		Args:
-			replacement_fun: Function that, when called with a `Command` object,
-				decomposes this command.
-			recogn_fun: Function that, when called with a `Command` object, returns
-				True if and only if the replacement rule can handle this command.
-			
-		Every Decomposition is registered with the gate class. The Decomposition
-		rule is then potentially valid for all objects which are an instance of
-		that same class (i.e., instance of gate_object.__class__). All other
-		parameters have to be checked by the recogn_fun, i.e., it has to decide
-		whether the decomposition rule can indeed be applied to replace the given
-		Command.
-		
-		As an example, consider recognizing the Toffoli gate, which is a Pauli-X
-		gate with 2 control qubits. The recognizer function would then be:
-		
-		.. code-block:: python
-		
-			def recogn_toffoli(cmd):
-				# can be applied if the gate is an X-gate with 2 control qubits:
-				return len(cmd.control_qubits) == 2
-		
-		and, given a replacement function `replace_toffoli`, the decomposition
-		rule can be registered as
-		
-		.. code-block:: python
-		
-			register_decomposition(X.__class__, decompose_toffoli, recogn_toffoli)
-		
-		Note:
-			See projectq.setups.decompositions for more example codes.
-		
-		"""
-		self.decompose = replacement_fun
-		self.check = recogn_fun
-	
-	def get_inverse_decomposition(self):
-		"""
-		Return the Decomposition object which handles the inverse of the original
-		command.
-		
-		This simulates the user having added a decomposition rule for the inverse
-		as well. Since decomposing the inverse of a command can be achieved by
-		running the original decomposition inside a `with Dagger(engine):`
-		statement, this is not necessary (and will be done automatically by the
-		framework).
-		
-		Returns:
-			Decomposition handling the inverse of the original command.
-		"""
-		def decomp(cmd):
-			with Dagger(cmd.engine):
-				self.decompose(cmd.get_inverse())
-		
-		def recogn(cmd):
-			return self.check(cmd.get_inverse())
-		
-		return Decomposition(decomp, recogn)
+    """
+    The Decomposition class can be used to register a decomposition rule (by
+    calling register_decomposition)
+    """
+    def __init__(self, replacement_fun, recogn_fun):
+        """
+        Construct the Decomposition object.
+
+        Args:
+            replacement_fun: Function that, when called with a `Command` object,
+                decomposes this command.
+            recogn_fun: Function that, when called with a `Command` object, returns
+                True if and only if the replacement rule can handle this command.
+
+        Every Decomposition is registered with the gate class. The Decomposition
+        rule is then potentially valid for all objects which are an instance of
+        that same class (i.e., instance of gate_object.__class__). All other
+        parameters have to be checked by the recogn_fun, i.e., it has to decide
+        whether the decomposition rule can indeed be applied to replace the given
+        Command.
+
+        As an example, consider recognizing the Toffoli gate, which is a Pauli-X
+        gate with 2 control qubits. The recognizer function would then be:
+
+        .. code-block:: python
+
+            def recogn_toffoli(cmd):
+                # can be applied if the gate is an X-gate with 2 control qubits:
+                return len(cmd.control_qubits) == 2
+
+        and, given a replacement function `replace_toffoli`, the decomposition
+        rule can be registered as
+
+        .. code-block:: python
+
+            register_decomposition(X.__class__, decompose_toffoli, recogn_toffoli)
+
+        Note:
+            See projectq.setups.decompositions for more example codes.
+
+        """
+        self.decompose = replacement_fun
+        self.check = recogn_fun
+
+    def get_inverse_decomposition(self):
+        """
+        Return the Decomposition object which handles the inverse of the original
+        command.
+
+        This simulates the user having added a decomposition rule for the inverse
+        as well. Since decomposing the inverse of a command can be achieved by
+        running the original decomposition inside a `with Dagger(engine):`
+        statement, this is not necessary (and will be done automatically by the
+        framework).
+
+        Returns:
+            Decomposition handling the inverse of the original command.
+        """
+        def decomp(cmd):
+            with Dagger(cmd.engine):
+                self.decompose(cmd.get_inverse())
+
+        def recogn(cmd):
+            return self.check(cmd.get_inverse())
+
+        return Decomposition(decomp, recogn)

--- a/projectq/cengines/_replacer/_decompositionhandling.py
+++ b/projectq/cengines/_replacer/_decompositionhandling.py
@@ -16,60 +16,60 @@ decompositions = dict()
 
 
 class ThisIsNotAGateClassError(Exception):
-	pass
+    pass
 
 
 def register_decomposition(gate_class, gate_decomposer, gate_recognizer=None):
-	"""
-	Add a decomposition rule for compiling 'gate' to the global setup.
-	
-	The decomposition rule is a Decomposition object (see _decomposition.py) and
-	consists of a function which recognizes a command (i.e., determines whether
-	it can handle it) and a function which executes the decomposition. The
-	gate_class parameter determines the gate class for which the decomposition
-	is valid (keeps the number of calls to recognize functions lower).
-	
-	Args:
-		gate_class: Gate class for which the decomposition should be applicable;
-			this parameter is only used to enable binary search on
-			`gate_object.__class__`.
-			If your class is defined as 
-			
-			.. code-block:: python
-			
-				class MyGate(BasicGate):
-					pass
-			
-			Then you supply gate_class=MyGate
-			However, if MyGate is overridden as often is the case when
-			
-			.. code-block:: python
-			
-				MyGate = MyGate() # Because it allows the syntax MyGate | qubit
-			
-			then gate_class = MyGate.__class__
-		gate_decomposer (function): Function which, given the command to
-			decompose, applies a sequence of gates corresponding to the high-level
-			function of a gate of type gate_class.
-		gate_recognizer (function): Optional function which, given the command to
-			decompose, returns whether the decomposition supports the given command.
-			E.g., rotation gates may be rewritten using one decomposition for some
-			angles, and another one for other angles. If no such function is
-			provided, the decomposition rule will be valid for all gates of type
-			gate_class.
-	"""
-	if gate_recognizer is None:
-		gate_recognizer = lambda cmd: True
-	
-	decomp_obj = Decomposition(gate_decomposer, gate_recognizer)
-	# Check that gate_class is a gate class and not type
-	if gate_class == type.__class__:
-		raise ThisIsNotAGateClassError(
-			"gate_class is not a valid gate_class.\n" +
-			"Did you forget to create an instance and call" + 
-			" .__class__ in that one?\n" +
-			" Rx.__class__ instead of Rx(0.6).__class__?\n")
-	cls = gate_class.__name__
-	if not cls in decompositions:
-		decompositions[cls] = []
-	decompositions[cls].append(decomp_obj)
+    """
+    Add a decomposition rule for compiling 'gate' to the global setup.
+
+    The decomposition rule is a Decomposition object (see _decomposition.py) and
+    consists of a function which recognizes a command (i.e., determines whether
+    it can handle it) and a function which executes the decomposition. The
+    gate_class parameter determines the gate class for which the decomposition
+    is valid (keeps the number of calls to recognize functions lower).
+
+    Args:
+        gate_class: Gate class for which the decomposition should be applicable;
+            this parameter is only used to enable binary search on
+            `gate_object.__class__`.
+            If your class is defined as
+
+            .. code-block:: python
+
+                class MyGate(BasicGate):
+                    pass
+
+            Then you supply gate_class=MyGate
+            However, if MyGate is overridden as often is the case when
+
+            .. code-block:: python
+
+                MyGate = MyGate() # Because it allows the syntax MyGate | qubit
+
+            then gate_class = MyGate.__class__
+        gate_decomposer (function): Function which, given the command to
+            decompose, applies a sequence of gates corresponding to the high-level
+            function of a gate of type gate_class.
+        gate_recognizer (function): Optional function which, given the command to
+            decompose, returns whether the decomposition supports the given command.
+            E.g., rotation gates may be rewritten using one decomposition for some
+            angles, and another one for other angles. If no such function is
+            provided, the decomposition rule will be valid for all gates of type
+            gate_class.
+    """
+    if gate_recognizer is None:
+        gate_recognizer = lambda cmd: True
+
+    decomp_obj = Decomposition(gate_decomposer, gate_recognizer)
+    # Check that gate_class is a gate class and not type
+    if gate_class == type.__class__:
+        raise ThisIsNotAGateClassError(
+            "gate_class is not a valid gate_class.\n" +
+            "Did you forget to create an instance and call" +
+            " .__class__ in that one?\n" +
+            " Rx.__class__ instead of Rx(0.6).__class__?\n")
+    cls = gate_class.__name__
+    if not cls in decompositions:
+        decompositions[cls] = []
+    decompositions[cls].append(decomp_obj)

--- a/projectq/cengines/_replacer/_decompositionhandling_test.py
+++ b/projectq/cengines/_replacer/_decompositionhandling_test.py
@@ -20,17 +20,17 @@ from projectq.cengines._replacer import _decompositionhandling
 
 
 def test_register_decomposition_wrong_input():
-	class WrongInput(BasicRotationGate):
-		pass
-	
-	def decompose_func(cmd):
-		pass
-	
-	def recognize_func(cmd):
-		pass
-	
-	with pytest.raises(_decompositionhandling.ThisIsNotAGateClassError):
-		_decompositionhandling.register_decomposition(WrongInput.__class__, 
-		                                     decompose_func, recognize_func)
-	decompose_func("")
-	recognize_func("")
+    class WrongInput(BasicRotationGate):
+        pass
+
+    def decompose_func(cmd):
+        pass
+
+    def recognize_func(cmd):
+        pass
+
+    with pytest.raises(_decompositionhandling.ThisIsNotAGateClassError):
+        _decompositionhandling.register_decomposition(WrongInput.__class__,
+                                             decompose_func, recognize_func)
+    decompose_func("")
+    recognize_func("")

--- a/projectq/cengines/_replacer/_replacer.py
+++ b/projectq/cengines/_replacer/_replacer.py
@@ -30,161 +30,161 @@ from . import _decompositionhandling as dh
 
 
 class NoGateDecompositionError(Exception):
-	pass
+    pass
 
 
 class InstructionFilter(BasicEngine):
-	"""
-	The InstructionFilter is a compiler engine which changes the behavior of
-	is_available according to a filter function. All commands are passed to this
-	function, which then returns whether this command can be executed (True) or
-	needs replacement (False).
-	"""
-	def __init__(self, filterfun):
-		"""
-		Constructor: The provided filterfun returns True for all commands which do
-		not need replacement and False for commands that do.
-		
-		Args:
-			filterfun (function): Filter function which returns True for available
-				commands, and False otherwise. filterfun will be called as
-				filterfun(self, cmd).
-		"""
-		BasicEngine.__init__(self)
-		self._filterfun = filterfun
-	
-	def is_available(self, cmd):
-		"""
-		Specialized implementation of BasicBackend.is_available: Forwards this
-		call to the filter function given to the constructor.
-		
-		Args:
-			cmd (Command): Command for which to check availability.
-		"""
-		return self._filterfun(self, cmd)
-		
-	def receive(self, command_list):
-		"""
-		Forward all commands to the next engine.
-		
-		Args:
-			command_list (list<Command>): List of commands to receive.
-		"""
-		self.next_engine.receive(command_list)
+    """
+    The InstructionFilter is a compiler engine which changes the behavior of
+    is_available according to a filter function. All commands are passed to this
+    function, which then returns whether this command can be executed (True) or
+    needs replacement (False).
+    """
+    def __init__(self, filterfun):
+        """
+        Constructor: The provided filterfun returns True for all commands which do
+        not need replacement and False for commands that do.
 
-			
+        Args:
+            filterfun (function): Filter function which returns True for available
+                commands, and False otherwise. filterfun will be called as
+                filterfun(self, cmd).
+        """
+        BasicEngine.__init__(self)
+        self._filterfun = filterfun
+
+    def is_available(self, cmd):
+        """
+        Specialized implementation of BasicBackend.is_available: Forwards this
+        call to the filter function given to the constructor.
+
+        Args:
+            cmd (Command): Command for which to check availability.
+        """
+        return self._filterfun(self, cmd)
+
+    def receive(self, command_list):
+        """
+        Forward all commands to the next engine.
+
+        Args:
+            command_list (list<Command>): List of commands to receive.
+        """
+        self.next_engine.receive(command_list)
+
+
 class AutoReplacer(BasicEngine):
-	"""
-	The AutoReplacer is a compiler engine which uses engine.is_available in
-	order to determine which commands need to be replaced/decomposed/compiled
-	further. The loaded setup is used to find decomposition rules appropriate
-	for each command (e.g., setups.default).
-	"""
-	def __init__(self, decomposition_chooser=
-	             lambda cmd, decomposition_list: decomposition_list[0]):
-		"""
-		Initialize an AutoReplacer.
-		
-		Args:
-			decomposition_chooser (function): A function which, given the Command
-				to decompose and a list of potential Decomposition objects,
-				determines (and then returns) the 'best' decomposition.
-		
-		The default decomposition chooser simply returns the first list element,
-		i.e., calling
-		
-		.. code-block:: python
-		
-			repl = AutoReplacer()
-		
-		Amounts to
-		
-		.. code-block:: python
-		
-			def decomposition_chooser(cmd, decomp_list):
-				return decomp_list[0]
-			repl = AutoReplacer(decomposition_chooser)
-		"""
-		BasicEngine.__init__(self)
-		self._decomp_chooser = decomposition_chooser
-		
-	def _process_command(self, cmd):
-		"""
-		Check whether a command cmd can be handled by further engines and, if not,
-		replace it using the decomposition rules loaded with the setup
-		(e.g., setups.default).
-		
-		Args:
-			cmd (Command): Command to process.
-		
-		Raises:
-			Exception if no replacement is available in the loaded setup.
-		"""
-		if self.is_available(cmd):
-			self.send([cmd])
-		else:			
-			# check for decomposition rules
-			decomp_list = []
-			potential_decomps = []
-			inv_list = []
-			
-			# check for forward rules
-			cls = cmd.gate.__class__.__name__
-			try:
-				potential_decomps = [d for d in dh.decompositions[cls]]
-			except KeyError:
-				pass
-			# check for rules implementing the inverse gate and run them in reverse
-			inv_cls = get_inverse(cmd.gate).__class__.__name__
-			try:
-				potential_decomps += [d.get_inverse_decomposition()
-				                      for d in dh.decompositions[inv_cls]]
-			except KeyError:
-				pass
-			# throw out the ones which don't recognize the command
-			for d in potential_decomps:
-				if d.check(cmd):
-					decomp_list.append(d)
-					
-			if len(decomp_list) == 0:
-				raise NoGateDecompositionError("\nNo replacement found for "
-				                                + str(cmd) + "!")
-			
-			# use decomposition chooser to determine the best decomposition
-			chosen_decomp = self._decomp_chooser(cmd, decomp_list)
-			
-			# the decomposed command must have the same tags (plus the ones it gets
-			# from meta-statements inside the decomposition rule).
-			# --> use a CommandModifier with a ForwarderEngine to achieve this.
-			old_tags = cmd.tags[:]
-			def cmd_mod_fun(cmd):  # Adds the tags
-				cmd.tags = old_tags[:] + cmd.tags
-				cmd.engine = self.main_engine
-				return cmd
-			# the CommandModifier calls cmd_mod_fun for each command --> commands
-			# get the right tags.
-			cmod_eng = CommandModifier(cmd_mod_fun)
-			cmod_eng.next_engine = self  # send modified commands back here
-			cmod_eng.main_engine = self.main_engine
-			# forward everything to cmod_eng using the ForwarderEngine
-			# which behaves just like MainEngine (--> meta functions still work)
-			forwarder_eng = ForwarderEngine(cmod_eng)
-			cmd.engine = forwarder_eng  # gates will be sent directly to forwarder
-			# (and not to main engine, which would screw up the ordering).
-			
-			chosen_decomp.decompose(cmd)  # run the decomposition
-	
-	def receive(self, command_list):
-		"""
-		Receive a list of commands from the previous compiler engine and, if
-		necessary, replace/decompose the gates according to the decomposition
-		rules in the loaded setup.
-		
-		Args:
-			command_list (list<Command>): List of commands to handle.
-		"""
-		for cmd in command_list:
-			if not isinstance(cmd.gate, FlushGate):
-				self._process_command(cmd)
-			else:
-				self.send([cmd])
+    """
+    The AutoReplacer is a compiler engine which uses engine.is_available in
+    order to determine which commands need to be replaced/decomposed/compiled
+    further. The loaded setup is used to find decomposition rules appropriate
+    for each command (e.g., setups.default).
+    """
+    def __init__(self, decomposition_chooser=
+                 lambda cmd, decomposition_list: decomposition_list[0]):
+        """
+        Initialize an AutoReplacer.
+
+        Args:
+            decomposition_chooser (function): A function which, given the Command
+                to decompose and a list of potential Decomposition objects,
+                determines (and then returns) the 'best' decomposition.
+
+        The default decomposition chooser simply returns the first list element,
+        i.e., calling
+
+        .. code-block:: python
+
+            repl = AutoReplacer()
+
+        Amounts to
+
+        .. code-block:: python
+
+            def decomposition_chooser(cmd, decomp_list):
+                return decomp_list[0]
+            repl = AutoReplacer(decomposition_chooser)
+        """
+        BasicEngine.__init__(self)
+        self._decomp_chooser = decomposition_chooser
+
+    def _process_command(self, cmd):
+        """
+        Check whether a command cmd can be handled by further engines and, if not,
+        replace it using the decomposition rules loaded with the setup
+        (e.g., setups.default).
+
+        Args:
+            cmd (Command): Command to process.
+
+        Raises:
+            Exception if no replacement is available in the loaded setup.
+        """
+        if self.is_available(cmd):
+            self.send([cmd])
+        else:
+            # check for decomposition rules
+            decomp_list = []
+            potential_decomps = []
+            inv_list = []
+
+            # check for forward rules
+            cls = cmd.gate.__class__.__name__
+            try:
+                potential_decomps = [d for d in dh.decompositions[cls]]
+            except KeyError:
+                pass
+            # check for rules implementing the inverse gate and run them in reverse
+            inv_cls = get_inverse(cmd.gate).__class__.__name__
+            try:
+                potential_decomps += [d.get_inverse_decomposition()
+                                      for d in dh.decompositions[inv_cls]]
+            except KeyError:
+                pass
+            # throw out the ones which don't recognize the command
+            for d in potential_decomps:
+                if d.check(cmd):
+                    decomp_list.append(d)
+
+            if len(decomp_list) == 0:
+                raise NoGateDecompositionError("\nNo replacement found for "
+                                                + str(cmd) + "!")
+
+            # use decomposition chooser to determine the best decomposition
+            chosen_decomp = self._decomp_chooser(cmd, decomp_list)
+
+            # the decomposed command must have the same tags (plus the ones it gets
+            # from meta-statements inside the decomposition rule).
+            # --> use a CommandModifier with a ForwarderEngine to achieve this.
+            old_tags = cmd.tags[:]
+            def cmd_mod_fun(cmd):  # Adds the tags
+                cmd.tags = old_tags[:] + cmd.tags
+                cmd.engine = self.main_engine
+                return cmd
+            # the CommandModifier calls cmd_mod_fun for each command --> commands
+            # get the right tags.
+            cmod_eng = CommandModifier(cmd_mod_fun)
+            cmod_eng.next_engine = self  # send modified commands back here
+            cmod_eng.main_engine = self.main_engine
+            # forward everything to cmod_eng using the ForwarderEngine
+            # which behaves just like MainEngine (--> meta functions still work)
+            forwarder_eng = ForwarderEngine(cmod_eng)
+            cmd.engine = forwarder_eng  # gates will be sent directly to forwarder
+            # (and not to main engine, which would screw up the ordering).
+
+            chosen_decomp.decompose(cmd)  # run the decomposition
+
+    def receive(self, command_list):
+        """
+        Receive a list of commands from the previous compiler engine and, if
+        necessary, replace/decompose the gates according to the decomposition
+        rules in the loaded setup.
+
+        Args:
+            command_list (list<Command>): List of commands to handle.
+        """
+        for cmd in command_list:
+            if not isinstance(cmd.gate, FlushGate):
+                self._process_command(cmd)
+            else:
+                self.send([cmd])

--- a/projectq/cengines/_tagremover.py
+++ b/projectq/cengines/_tagremover.py
@@ -20,37 +20,37 @@ from projectq.meta import ComputeTag, UncomputeTag
 
 
 class TagRemover(BasicEngine):
-	"""
-	TagRemover is a compiler engine which removes temporary command tags (see
-	the tag classes such as LoopTag in projectq.meta._loop).
-	
-	Removing tags is important (after having handled them if necessary) in order
-	to enable optimizations across meta-function boundaries (compute/action/
-	uncompute or loops after unrolling)
-	"""
-	def __init__(self, tags=[ComputeTag, UncomputeTag]):
-		"""
-		Construct the TagRemover.
-		
-		Args:
-			tags: A list of meta tag classes (e.g., [ComputeTag, UncomputeTag])
-				denoting the tags to remove
-		"""
-		BasicEngine.__init__(self)
-		assert isinstance(tags, list)
-		self._tags = tags
-	
-	def receive(self, command_list):
-		"""
-		Receive a list of commands from the previous engine, remove all tags which
-		are an instance of at least one of the meta tags provided in the
-		constructor, and then send them on to the next compiler engine.
-		
-		Args:
-			command_list (list<Command>): List of commands to receive and then
-				(after removing tags) send on.
-		"""
-		for cmd in command_list:
-			for tag in self._tags:
-				cmd.tags = [t for t in cmd.tags if not isinstance(t, tag)]
-			self.send([cmd])
+    """
+    TagRemover is a compiler engine which removes temporary command tags (see
+    the tag classes such as LoopTag in projectq.meta._loop).
+
+    Removing tags is important (after having handled them if necessary) in order
+    to enable optimizations across meta-function boundaries (compute/action/
+    uncompute or loops after unrolling)
+    """
+    def __init__(self, tags=[ComputeTag, UncomputeTag]):
+        """
+        Construct the TagRemover.
+
+        Args:
+            tags: A list of meta tag classes (e.g., [ComputeTag, UncomputeTag])
+                denoting the tags to remove
+        """
+        BasicEngine.__init__(self)
+        assert isinstance(tags, list)
+        self._tags = tags
+
+    def receive(self, command_list):
+        """
+        Receive a list of commands from the previous engine, remove all tags which
+        are an instance of at least one of the meta tags provided in the
+        constructor, and then send them on to the next compiler engine.
+
+        Args:
+            command_list (list<Command>): List of commands to receive and then
+                (after removing tags) send on.
+        """
+        for cmd in command_list:
+            for tag in self._tags:
+                cmd.tags = [t for t in cmd.tags if not isinstance(t, tag)]
+            self.send([cmd])

--- a/projectq/cengines/_tagremover_test.py
+++ b/projectq/cengines/_tagremover_test.py
@@ -21,23 +21,23 @@ from projectq.cengines import _tagremover
 
 
 def test_tagremover_default():
-	tag_remover = _tagremover.TagRemover()
-	assert tag_remover._tags == [ComputeTag, UncomputeTag]
+    tag_remover = _tagremover.TagRemover()
+    assert tag_remover._tags == [ComputeTag, UncomputeTag]
 
 
 def test_tagremover():
-	backend = DummyEngine(save_commands=True)
-	tag_remover = _tagremover.TagRemover([type("")])
-	eng = MainEngine(backend=backend, engine_list=[tag_remover])
-	# Create a command_list and check if "NewTag" is removed
-	qubit = eng.allocate_qubit()
-	cmd0 = Command(eng, H, (qubit,))
-	cmd0.tags = ["NewTag"]
-	cmd1 = Command(eng, H, (qubit,))
-	cmd1.tags = [1,2,"NewTag", 3]
-	cmd_list = [cmd0, cmd1, cmd0]
-	assert len(backend.received_commands) == 1 # AllocateQubitGate
-	tag_remover.receive(cmd_list)
-	assert len(backend.received_commands) == 4
-	assert backend.received_commands[1].tags == []
-	assert backend.received_commands[2].tags == [1,2,3]
+    backend = DummyEngine(save_commands=True)
+    tag_remover = _tagremover.TagRemover([type("")])
+    eng = MainEngine(backend=backend, engine_list=[tag_remover])
+    # Create a command_list and check if "NewTag" is removed
+    qubit = eng.allocate_qubit()
+    cmd0 = Command(eng, H, (qubit,))
+    cmd0.tags = ["NewTag"]
+    cmd1 = Command(eng, H, (qubit,))
+    cmd1.tags = [1,2,"NewTag", 3]
+    cmd_list = [cmd0, cmd1, cmd0]
+    assert len(backend.received_commands) == 1 # AllocateQubitGate
+    tag_remover.receive(cmd_list)
+    assert len(backend.received_commands) == 4
+    assert backend.received_commands[1].tags == []
+    assert backend.received_commands[2].tags == [1,2,3]

--- a/projectq/cengines/_testengine.py
+++ b/projectq/cengines/_testengine.py
@@ -18,100 +18,100 @@ from projectq.cengines import BasicEngine
 from projectq.ops import FlushGate, Allocate, Deallocate
 
 class CompareEngine(BasicEngine):
-	"""
-	CompareEngine is an engine which saves all commands. It is only intended
-	for testing purposes. Two CompareEngine backends can be compared and
-	return True if they contain the same commmands.
-	"""
-	def __init__(self):
-		BasicEngine.__init__(self)
-		self._l = [[]]
+    """
+    CompareEngine is an engine which saves all commands. It is only intended
+    for testing purposes. Two CompareEngine backends can be compared and
+    return True if they contain the same commmands.
+    """
+    def __init__(self):
+        BasicEngine.__init__(self)
+        self._l = [[]]
 
-	def is_available(self, cmd):
-		return True
+    def is_available(self, cmd):
+        return True
 
-	def cache_cmd(self, cmd):    
-		# are there qubit ids that haven't been added to the list?
-		all_qubit_id_list = [qubit.id for qureg in cmd.all_qubits for qubit in qureg]
-		maxidx = int(0)
-		for qubit_id in all_qubit_id_list:
-			maxidx = max(maxidx, qubit_id)
-		
-		# if so, increase size of list to account for these qubits
-		add = maxidx+1-len(self._l)
-		if add > 0:
-			for i in range(add):
-				self._l += [[]]
-		
-		# add gate command to each of the qubits involved
-		for qubit_id in all_qubit_id_list:
-			self._l[qubit_id] += [cmd]
-		
-	def receive(self, command_list):
-		for cmd in command_list:
-			if not cmd.gate == FlushGate():
-				self.cache_cmd(cmd)
-		if not self.is_last_engine:
-			self.send(command_list)
-				
-	def compare_cmds(self, c1, c2):
-		c2 = deepcopy(c2)
-		c2.engine = c1.engine
-		return c1 == c2
-	
-	def __eq__(self, other):
-		if not isinstance(other, CompareEngine) or len(self._l) != len(other._l):
-			return False
-		for i in range(len(self._l)):
-			if len(self._l[i]) != len(other._l[i]):
-				return False
-			for j in range(len(self._l[i])):
-				if self.compare_cmds(self._l[i][j], other._l[i][j]) == False:
-					return False
-		return True
-		
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def cache_cmd(self, cmd):
+        # are there qubit ids that haven't been added to the list?
+        all_qubit_id_list = [qubit.id for qureg in cmd.all_qubits for qubit in qureg]
+        maxidx = int(0)
+        for qubit_id in all_qubit_id_list:
+            maxidx = max(maxidx, qubit_id)
 
-	def __str__(self):
-		string = ""
-		for qubit_id in range(len(self._l)):
-			string += "Qubit {0} : ".format(qubit_id)
-			for command in self._l[qubit_id]:
-				string += str(command) + ", "
-			string = string[:-2] + "\n"
-		return string
+        # if so, increase size of list to account for these qubits
+        add = maxidx+1-len(self._l)
+        if add > 0:
+            for i in range(add):
+                self._l += [[]]
+
+        # add gate command to each of the qubits involved
+        for qubit_id in all_qubit_id_list:
+            self._l[qubit_id] += [cmd]
+
+    def receive(self, command_list):
+        for cmd in command_list:
+            if not cmd.gate == FlushGate():
+                self.cache_cmd(cmd)
+        if not self.is_last_engine:
+            self.send(command_list)
+
+    def compare_cmds(self, c1, c2):
+        c2 = deepcopy(c2)
+        c2.engine = c1.engine
+        return c1 == c2
+
+    def __eq__(self, other):
+        if not isinstance(other, CompareEngine) or len(self._l) != len(other._l):
+            return False
+        for i in range(len(self._l)):
+            if len(self._l[i]) != len(other._l[i]):
+                return False
+            for j in range(len(self._l[i])):
+                if self.compare_cmds(self._l[i][j], other._l[i][j]) == False:
+                    return False
+        return True
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __str__(self):
+        string = ""
+        for qubit_id in range(len(self._l)):
+            string += "Qubit {0} : ".format(qubit_id)
+            for command in self._l[qubit_id]:
+                string += str(command) + ", "
+            string = string[:-2] + "\n"
+        return string
 
 
 class DummyEngine(BasicEngine):
-	"""
-	DummyEngine used for testing.
+    """
+    DummyEngine used for testing.
 
-	The DummyEngine forwards all commands directly to next engine.
-	If self.is_last_engine == True it just discards all gates.
-	By setting save_commands == True all commands get saved as a
-	list in self.received_commands. Elements are appended to this
-	list so they are ordered according to when they are received.
-	"""
-	def __init__(self, save_commands = False):
-		"""
-		Initialize DummyEngine
+    The DummyEngine forwards all commands directly to next engine.
+    If self.is_last_engine == True it just discards all gates.
+    By setting save_commands == True all commands get saved as a
+    list in self.received_commands. Elements are appended to this
+    list so they are ordered according to when they are received.
+    """
+    def __init__(self, save_commands = False):
+        """
+        Initialize DummyEngine
 
-		Args:
-			save_commands (default = False): If True, commands are saved in
-			                                 self.received_commands.
-		"""
-		BasicEngine.__init__(self)
-		self.save_commands = save_commands
-		self.received_commands = []
+        Args:
+            save_commands (default = False): If True, commands are saved in
+                                             self.received_commands.
+        """
+        BasicEngine.__init__(self)
+        self.save_commands = save_commands
+        self.received_commands = []
 
-	def is_available(self, cmd):
-		return True
+    def is_available(self, cmd):
+        return True
 
-	def receive(self, command_list):
-		if self.save_commands:
-			self.received_commands.extend(command_list)
-		if not self.is_last_engine:
-			self.send(command_list)
-		else:
-			pass
+    def receive(self, command_list):
+        if self.save_commands:
+            self.received_commands.extend(command_list)
+        if not self.is_last_engine:
+            self.send(command_list)
+        else:
+            pass

--- a/projectq/cengines/_testengine_test.py
+++ b/projectq/cengines/_testengine_test.py
@@ -20,99 +20,99 @@ from projectq.cengines import _testengine
 
 
 def test_compare_engine_str():
-	compare_engine = _testengine.CompareEngine()
-	eng = MainEngine(backend=compare_engine, engine_list=[DummyEngine()])
-	qb0 = eng.allocate_qubit()
-	qb1 = eng.allocate_qubit()
-	H | qb0
-	CNOT | (qb0,qb1)
-	eng.flush()
-	expected = ("Qubit 0 : Allocate | Qubit[0], H | Qubit[0], " +
-	            "CX | ( Qubit[0], Qubit[1] )\nQubit 1 : Allocate | Qubit[1]," +
-	            " CX | ( Qubit[0], Qubit[1] )\n")
-	assert str(compare_engine) == expected
+    compare_engine = _testengine.CompareEngine()
+    eng = MainEngine(backend=compare_engine, engine_list=[DummyEngine()])
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+    H | qb0
+    CNOT | (qb0,qb1)
+    eng.flush()
+    expected = ("Qubit 0 : Allocate | Qubit[0], H | Qubit[0], " +
+                "CX | ( Qubit[0], Qubit[1] )\nQubit 1 : Allocate | Qubit[1]," +
+                " CX | ( Qubit[0], Qubit[1] )\n")
+    assert str(compare_engine) == expected
 
 
 def test_compare_engine_is_available():
-	compare_engine = _testengine.CompareEngine()
-	assert compare_engine.is_available("Anything")
+    compare_engine = _testengine.CompareEngine()
+    assert compare_engine.is_available("Anything")
 
 
 def test_compare_engine_receive():
-	# Test that CompareEngine would forward commands
-	backend = DummyEngine(save_commands=True)
-	compare_engine = _testengine.CompareEngine()
-	eng = MainEngine(backend=backend, engine_list=[compare_engine])
-	qubit = eng.allocate_qubit()
-	H | qubit
-	eng.flush()
-	assert len(backend.received_commands) == 3
+    # Test that CompareEngine would forward commands
+    backend = DummyEngine(save_commands=True)
+    compare_engine = _testengine.CompareEngine()
+    eng = MainEngine(backend=backend, engine_list=[compare_engine])
+    qubit = eng.allocate_qubit()
+    H | qubit
+    eng.flush()
+    assert len(backend.received_commands) == 3
 
 
 def test_compare_engine():
-	compare_engine0 = _testengine.CompareEngine()
-	compare_engine1 = _testengine.CompareEngine()
-	compare_engine2 = _testengine.CompareEngine()
-	compare_engine3 = _testengine.CompareEngine()
-	eng0 = MainEngine(backend=compare_engine0, engine_list=[DummyEngine()])
-	eng1 = MainEngine(backend=compare_engine1, engine_list=[DummyEngine()])
-	eng2 = MainEngine(backend=compare_engine2, engine_list=[DummyEngine()])
-	eng3 = MainEngine(backend=compare_engine3, engine_list=[DummyEngine()])
-	# reference circuit
-	qb00 = eng0.allocate_qubit()
-	qb01 = eng0.allocate_qubit()
-	qb02 = eng0.allocate_qubit()
-	H | qb00
-	CNOT | (qb00, qb01)
-	CNOT | (qb01, qb00)
-	H | qb00
-	Rx(0.5) | qb01
-	CNOT | (qb00, qb01)
-	Rx(0.6) | qb02
-	eng0.flush()
-	# identical circuit:
-	qb10 = eng1.allocate_qubit()
-	qb11 = eng1.allocate_qubit()
-	qb12 = eng1.allocate_qubit()
-	H | qb10
-	Rx(0.6) | qb12
-	CNOT | (qb10, qb11)
-	CNOT | (qb11, qb10)
-	Rx(0.5) | qb11
-	H | qb10
-	CNOT | (qb10, qb11)
-	eng1.flush()
-	# mistake in CNOT circuit:
-	qb20 = eng2.allocate_qubit()
-	qb21 = eng2.allocate_qubit()
-	qb22 = eng2.allocate_qubit()
-	H | qb20
-	Rx(0.6) | qb22
-	CNOT | (qb21, qb20)
-	CNOT | (qb20, qb21)
-	Rx(0.5) | qb21
-	H | qb20
-	CNOT | (qb20, qb21)
-	eng2.flush()
-	# test other branch to fail
-	qb30 = eng3.allocate_qubit()
-	qb31 = eng3.allocate_qubit()
-	qb32 = eng3.allocate_qubit()
-	eng3.flush()
-	assert compare_engine0 == compare_engine1
-	assert compare_engine1 != compare_engine2
-	assert compare_engine1 != compare_engine3
-	assert not compare_engine0 == DummyEngine()
+    compare_engine0 = _testengine.CompareEngine()
+    compare_engine1 = _testengine.CompareEngine()
+    compare_engine2 = _testengine.CompareEngine()
+    compare_engine3 = _testengine.CompareEngine()
+    eng0 = MainEngine(backend=compare_engine0, engine_list=[DummyEngine()])
+    eng1 = MainEngine(backend=compare_engine1, engine_list=[DummyEngine()])
+    eng2 = MainEngine(backend=compare_engine2, engine_list=[DummyEngine()])
+    eng3 = MainEngine(backend=compare_engine3, engine_list=[DummyEngine()])
+    # reference circuit
+    qb00 = eng0.allocate_qubit()
+    qb01 = eng0.allocate_qubit()
+    qb02 = eng0.allocate_qubit()
+    H | qb00
+    CNOT | (qb00, qb01)
+    CNOT | (qb01, qb00)
+    H | qb00
+    Rx(0.5) | qb01
+    CNOT | (qb00, qb01)
+    Rx(0.6) | qb02
+    eng0.flush()
+    # identical circuit:
+    qb10 = eng1.allocate_qubit()
+    qb11 = eng1.allocate_qubit()
+    qb12 = eng1.allocate_qubit()
+    H | qb10
+    Rx(0.6) | qb12
+    CNOT | (qb10, qb11)
+    CNOT | (qb11, qb10)
+    Rx(0.5) | qb11
+    H | qb10
+    CNOT | (qb10, qb11)
+    eng1.flush()
+    # mistake in CNOT circuit:
+    qb20 = eng2.allocate_qubit()
+    qb21 = eng2.allocate_qubit()
+    qb22 = eng2.allocate_qubit()
+    H | qb20
+    Rx(0.6) | qb22
+    CNOT | (qb21, qb20)
+    CNOT | (qb20, qb21)
+    Rx(0.5) | qb21
+    H | qb20
+    CNOT | (qb20, qb21)
+    eng2.flush()
+    # test other branch to fail
+    qb30 = eng3.allocate_qubit()
+    qb31 = eng3.allocate_qubit()
+    qb32 = eng3.allocate_qubit()
+    eng3.flush()
+    assert compare_engine0 == compare_engine1
+    assert compare_engine1 != compare_engine2
+    assert compare_engine1 != compare_engine3
+    assert not compare_engine0 == DummyEngine()
 
 
 def test_dummy_engine():
-	dummy_eng = _testengine.DummyEngine(save_commands=True)
-	eng = MainEngine(backend=dummy_eng, engine_list=[])
-	assert dummy_eng.is_available("Anything")
-	qubit = eng.allocate_qubit()
-	H | qubit
-	eng.flush()
-	assert len(dummy_eng.received_commands) == 3
-	assert dummy_eng.received_commands[0].gate == Allocate
-	assert dummy_eng.received_commands[1].gate == H
-	assert dummy_eng.received_commands[2].gate == FlushGate()
+    dummy_eng = _testengine.DummyEngine(save_commands=True)
+    eng = MainEngine(backend=dummy_eng, engine_list=[])
+    assert dummy_eng.is_available("Anything")
+    qubit = eng.allocate_qubit()
+    H | qubit
+    eng.flush()
+    assert len(dummy_eng.received_commands) == 3
+    assert dummy_eng.received_commands[0].gate == Allocate
+    assert dummy_eng.received_commands[1].gate == H
+    assert dummy_eng.received_commands[2].gate == FlushGate()

--- a/projectq/libs/math/_constantmath.py
+++ b/projectq/libs/math/_constantmath.py
@@ -20,98 +20,98 @@ from ._gates import AddConstant, SubConstant, AddConstantModN, SubConstantModN
 
 # Draper's addition by constant https://arxiv.org/abs/quant-ph/0008033
 def add_constant(eng, c, quint):
-	"""
-	Adds a classical constant c to the quantum integer (qureg) quint using
-	Draper addition.
+    """
+    Adds a classical constant c to the quantum integer (qureg) quint using
+    Draper addition.
 
-	Note: Uses the Fourier-transform adder from
-	      https://arxiv.org/abs/quant-ph/0008033.
-	"""
+    Note: Uses the Fourier-transform adder from
+          https://arxiv.org/abs/quant-ph/0008033.
+    """
 
-	with Compute(eng):
-		QFT | quint
+    with Compute(eng):
+        QFT | quint
 
-	for i in range(len(quint)):
-		for j in range(i, -1, -1):
-			if ((c >> j) & 1):
-				R(math.pi / (1 << (i - j))) | quint[i]
+    for i in range(len(quint)):
+        for j in range(i, -1, -1):
+            if ((c >> j) & 1):
+                R(math.pi / (1 << (i - j))) | quint[i]
 
-	Uncompute(eng)
+    Uncompute(eng)
 
 
 # Modular adder by Beauregard https://arxiv.org/abs/quant-ph/0205095
 def add_constant_modN(eng, c, N, quint):
-	"""
-	Adds a classical constant c to a quantum integer (qureg) quint modulo N
-	using Draper addition and the construction from
-	https://arxiv.org/abs/quant-ph/0205095.
-	"""
-	assert(c < N and c >= 0)
+    """
+    Adds a classical constant c to a quantum integer (qureg) quint modulo N
+    using Draper addition and the construction from
+    https://arxiv.org/abs/quant-ph/0205095.
+    """
+    assert(c < N and c >= 0)
 
-	AddConstant(c) | quint
+    AddConstant(c) | quint
 
-	with Compute(eng):
-		SubConstant(N) | quint
-		ancilla = eng.allocate_qubit()
-		CNOT | (quint[-1], ancilla)
-		with Control(eng, ancilla):
-			AddConstant(N) | quint
+    with Compute(eng):
+        SubConstant(N) | quint
+        ancilla = eng.allocate_qubit()
+        CNOT | (quint[-1], ancilla)
+        with Control(eng, ancilla):
+            AddConstant(N) | quint
 
-	SubConstant(c) | quint
+    SubConstant(c) | quint
 
-	with CustomUncompute(eng):
-		X | quint[-1]
-		CNOT | (quint[-1], ancilla)
-		X | quint[-1]
-		del ancilla
+    with CustomUncompute(eng):
+        X | quint[-1]
+        CNOT | (quint[-1], ancilla)
+        X | quint[-1]
+        del ancilla
 
-	AddConstant(c) | quint
+    AddConstant(c) | quint
 
 
 # Modular multiplication by modular addition & shift, followed by uncompute
 # from https://arxiv.org/abs/quant-ph/0205095
 def mul_by_constant_modN(eng, c, N, quint_in):
-	"""
-	Multiplies a quantum integer by a classical number a modulo N, i.e.,
+    """
+    Multiplies a quantum integer by a classical number a modulo N, i.e.,
 
-	|x> -> |a*x mod N>
+    |x> -> |a*x mod N>
 
-	(only works if a and N are relative primes, otherwise the modular inverse
-	does not exist).
-	"""
-	assert(c < N and c >= 0)
-	assert(gcd(c, N) == 1)
+    (only works if a and N are relative primes, otherwise the modular inverse
+    does not exist).
+    """
+    assert(c < N and c >= 0)
+    assert(gcd(c, N) == 1)
 
-	n = len(quint_in)
-	quint_out = eng.allocate_qureg(n + 1)
+    n = len(quint_in)
+    quint_out = eng.allocate_qureg(n + 1)
 
-	for i in range(n):
-		with Control(eng, quint_in[i]):
-			AddConstantModN((c << i) % N, N) | quint_out
+    for i in range(n):
+        with Control(eng, quint_in[i]):
+            AddConstantModN((c << i) % N, N) | quint_out
 
-	for i in range(n):
-		Swap | (quint_out[i], quint_in[i])
+    for i in range(n):
+        Swap | (quint_out[i], quint_in[i])
 
-	cinv = inv_mod_N(c, N)
+    cinv = inv_mod_N(c, N)
 
-	for i in range(n):
-		with Control(eng, quint_in[i]):
-			SubConstantModN((cinv << i) % N, N) | quint_out
-	del quint_out
+    for i in range(n):
+        with Control(eng, quint_in[i]):
+            SubConstantModN((cinv << i) % N, N) | quint_out
+    del quint_out
 
 
 # calculates the inverse of a modulo N
 def inv_mod_N(a, N):
-	s = 0
-	old_s = 1
-	r = N
-	old_r = a
-	while r != 0:
-		q = int(old_r / r)
-		tmp = r
-		r = old_r - q * r
-		old_r = tmp
-		tmp = s
-		s = old_s - q * s
-		old_s = tmp
-	return (old_s + N) % N
+    s = 0
+    old_s = 1
+    r = N
+    old_r = a
+    while r != 0:
+        q = int(old_r / r)
+        tmp = r
+        r = old_r - q * r
+        old_r = tmp
+        tmp = s
+        s = old_s - q * s
+        old_s = tmp
+    return (old_s + N) % N

--- a/projectq/libs/math/_constantmath_test.py
+++ b/projectq/libs/math/_constantmath_test.py
@@ -25,79 +25,79 @@ from projectq.libs.math import (AddConstant,
 
 
 def init(engine, quint, value):
-	for i in range(len(quint)):
-		if ((value >> i)&1) == 1:
-			X | quint[i]
+    for i in range(len(quint)):
+        if ((value >> i)&1) == 1:
+            X | quint[i]
 
 
 def no_math_emulation(eng, cmd):
-	if isinstance(cmd.gate, BasicMathGate):
-		return False
-	if isinstance(cmd.gate, ClassicalInstructionGate):
-		return True
-	try:
-		return len(cmd.gate.matrix) == 2
-	except:
-		return False
+    if isinstance(cmd.gate, BasicMathGate):
+        return False
+    if isinstance(cmd.gate, ClassicalInstructionGate):
+        return True
+    try:
+        return len(cmd.gate.matrix) == 2
+    except:
+        return False
 
 
 def test_adder():
-	sim = Simulator()
-	eng = MainEngine(sim, [AutoReplacer(),
-	                       InstructionFilter(no_math_emulation)])
-	qureg = eng.allocate_qureg(4)
-	init(eng, qureg, 4)
-	
-	AddConstant(3) | qureg
-	
-	assert 1. == pytest.approx(abs(sim.cheat()[1][7]))
-	
-	init(eng, qureg, 7)  # reset
-	init(eng, qureg, 2)
-	
-	AddConstant(15) | qureg  # check for overflow -> should be 15+2 = 1 (mod 16)
-	assert 1. == pytest.approx(abs(sim.cheat()[1][1]))
-	
-	Measure | qureg
+    sim = Simulator()
+    eng = MainEngine(sim, [AutoReplacer(),
+                           InstructionFilter(no_math_emulation)])
+    qureg = eng.allocate_qureg(4)
+    init(eng, qureg, 4)
+
+    AddConstant(3) | qureg
+
+    assert 1. == pytest.approx(abs(sim.cheat()[1][7]))
+
+    init(eng, qureg, 7)  # reset
+    init(eng, qureg, 2)
+
+    AddConstant(15) | qureg  # check for overflow -> should be 15+2 = 1 (mod 16)
+    assert 1. == pytest.approx(abs(sim.cheat()[1][1]))
+
+    Measure | qureg
 
 
 def test_modadder():
-	sim = Simulator()
-	eng = MainEngine(sim, [AutoReplacer(),
-	                       InstructionFilter(no_math_emulation)])
-	
-	qureg = eng.allocate_qureg(4)
-	init(eng, qureg, 4)
-	
-	AddConstantModN(3, 6) | qureg
-	
-	assert 1. == pytest.approx(abs(sim.cheat()[1][1]))
-	
-	init(eng, qureg, 1)  # reset
-	init(eng, qureg, 7)
-	
-	AddConstantModN(10, 13) | qureg
-	assert 1. == pytest.approx(abs(sim.cheat()[1][4]))
-	
-	Measure | qureg
+    sim = Simulator()
+    eng = MainEngine(sim, [AutoReplacer(),
+                           InstructionFilter(no_math_emulation)])
+
+    qureg = eng.allocate_qureg(4)
+    init(eng, qureg, 4)
+
+    AddConstantModN(3, 6) | qureg
+
+    assert 1. == pytest.approx(abs(sim.cheat()[1][1]))
+
+    init(eng, qureg, 1)  # reset
+    init(eng, qureg, 7)
+
+    AddConstantModN(10, 13) | qureg
+    assert 1. == pytest.approx(abs(sim.cheat()[1][4]))
+
+    Measure | qureg
 
 
 def test_modmultiplier():
-	sim = Simulator()
-	eng = MainEngine(sim, [AutoReplacer(),
-	                       InstructionFilter(no_math_emulation)])
-	
-	qureg = eng.allocate_qureg(4)
-	init(eng, qureg, 4)
-	
-	MultiplyByConstantModN(3, 7) | qureg
-	
-	assert 1. == pytest.approx(abs(sim.cheat()[1][5]))
-	
-	init(eng, qureg, 5)  # reset
-	init(eng, qureg, 7)
-	
-	MultiplyByConstantModN(4, 13) | qureg
-	assert 1. == pytest.approx(abs(sim.cheat()[1][2]))
-	
-	Measure | qureg
+    sim = Simulator()
+    eng = MainEngine(sim, [AutoReplacer(),
+                           InstructionFilter(no_math_emulation)])
+
+    qureg = eng.allocate_qureg(4)
+    init(eng, qureg, 4)
+
+    MultiplyByConstantModN(3, 7) | qureg
+
+    assert 1. == pytest.approx(abs(sim.cheat()[1][5]))
+
+    init(eng, qureg, 5)  # reset
+    init(eng, qureg, 7)
+
+    MultiplyByConstantModN(4, 13) | qureg
+    assert 1. == pytest.approx(abs(sim.cheat()[1][2]))
+
+    Measure | qureg

--- a/projectq/libs/math/_default_rules.py
+++ b/projectq/libs/math/_default_rules.py
@@ -29,38 +29,38 @@ from ._constantmath import (add_constant,
 
 
 def _replace_addconstant(cmd):
-	eng = cmd.engine
-	c = cmd.gate.a
-	quint = cmd.qubits[0]
+    eng = cmd.engine
+    c = cmd.gate.a
+    quint = cmd.qubits[0]
 
-	with Control(eng, cmd.control_qubits):
-		add_constant(eng, c, quint)
+    with Control(eng, cmd.control_qubits):
+        add_constant(eng, c, quint)
 
 
 register_decomposition(AddConstant, _replace_addconstant)
 
 
 def _replace_addconstmodN(cmd):
-	eng = cmd.engine
-	c = cmd.gate.a
-	N = cmd.gate.N
-	quint = cmd.qubits[0]
+    eng = cmd.engine
+    c = cmd.gate.a
+    N = cmd.gate.N
+    quint = cmd.qubits[0]
 
-	with Control(eng, cmd.control_qubits):
-		add_constant_modN(eng, c, N, quint)
+    with Control(eng, cmd.control_qubits):
+        add_constant_modN(eng, c, N, quint)
 
 
 register_decomposition(AddConstantModN, _replace_addconstmodN)
 
 
 def _replace_multiplybyconstantmodN(cmd):
-	eng = cmd.engine
-	c = cmd.gate.a
-	N = cmd.gate.N
-	quint = cmd.qubits[0]
+    eng = cmd.engine
+    c = cmd.gate.a
+    N = cmd.gate.N
+    quint = cmd.qubits[0]
 
-	with Control(eng, cmd.control_qubits):
-		mul_by_constant_modN(eng, c, N, quint)
+    with Control(eng, cmd.control_qubits):
+        mul_by_constant_modN(eng, c, N, quint)
 
 
 register_decomposition(MultiplyByConstantModN,

--- a/projectq/libs/math/_gates.py
+++ b/projectq/libs/math/_gates.py
@@ -14,166 +14,166 @@ from projectq.ops import BasicMathGate
 
 
 class AddConstant(BasicMathGate):
-	"""
-	Add a constant to a quantum number represented by a quantum register, stored
-	from low- to high-bit.
-	
-	Example:
-		.. code-block:: python
-		
-			qunum = eng.allocate_qureg(5) # 5-qubit number
-			X | qunum[1] # qunum is now equal to 2
-			AddConstant(3) | qunum # qunum is now equal to 5
-	"""
-	def __init__(self, a):
-		"""
-		Initializes the gate to the number to add.
-		
-		Args:
-			a (int): Number to add to a quantum register.
-			
-		It also initializes its base class, BasicMathGate, with the corresponding
-		function, so it can be emulated efficiently.
-		"""
-		BasicMathGate.__init__(self, lambda x: ((x + a),))
-		self.a = a
+    """
+    Add a constant to a quantum number represented by a quantum register, stored
+    from low- to high-bit.
 
-	def get_inverse(self):
-		"""
-		Return the inverse gate (subtraction of the same constant).
-		"""
-		return SubConstant(self.a)
+    Example:
+        .. code-block:: python
 
-	def __str__(self):
-		return "AddConstant(" + str(self.a) + ")"
+            qunum = eng.allocate_qureg(5) # 5-qubit number
+            X | qunum[1] # qunum is now equal to 2
+            AddConstant(3) | qunum # qunum is now equal to 5
+    """
+    def __init__(self, a):
+        """
+        Initializes the gate to the number to add.
 
-	def __eq__(self, other):
-		return isinstance(other, AddConstant) and self.a == other.a
+        Args:
+            a (int): Number to add to a quantum register.
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+        It also initializes its base class, BasicMathGate, with the corresponding
+        function, so it can be emulated efficiently.
+        """
+        BasicMathGate.__init__(self, lambda x: ((x + a),))
+        self.a = a
+
+    def get_inverse(self):
+        """
+        Return the inverse gate (subtraction of the same constant).
+        """
+        return SubConstant(self.a)
+
+    def __str__(self):
+        return "AddConstant(" + str(self.a) + ")"
+
+    def __eq__(self, other):
+        return isinstance(other, AddConstant) and self.a == other.a
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 def SubConstant(a):
-	"""
-	Subtract a constant from a quantum number represented by a quantum register,
-	stored from low- to high-bit.
-	
-	Args:
-		a (int): Constant to subtract
-		
-	Example:
-		.. code-block:: python
-		
-			qunum = eng.allocate_qureg(5) # 5-qubit number
-			X | qunum[2] # qunum is now equal to 4
-			SubConstant(3) | qunum # qunum is now equal to 1
-	"""
-	return AddConstant(-a)
+    """
+    Subtract a constant from a quantum number represented by a quantum register,
+    stored from low- to high-bit.
+
+    Args:
+        a (int): Constant to subtract
+
+    Example:
+        .. code-block:: python
+
+            qunum = eng.allocate_qureg(5) # 5-qubit number
+            X | qunum[2] # qunum is now equal to 4
+            SubConstant(3) | qunum # qunum is now equal to 1
+    """
+    return AddConstant(-a)
 
 
 class AddConstantModN(BasicMathGate):
-	"""
-	Add a constant to a quantum number represented by a quantum register modulo N.
-	
-	The number is stored from low- to high-bit, i.e., qunum[0] is the LSB.
-	
-	Example:
-		.. code-block:: python
-		
-			qunum = eng.allocate_qureg(5) # 5-qubit number
-			X | qunum[1] # qunum is now equal to 2
-			AddConstantModN(3, 4) | qunum # qunum is now equal to 1
-	"""
-	def __init__(self, a, N):
-		"""
-		Initializes the gate to the number to add modulo N.
-		
-		Args:
-			a (int): Number to add to a quantum register (0 <= a < N).
-			N (int): Number modulo which the addition is carried out.
-			
-		It also initializes its base class, BasicMathGate, with the corresponding
-		function, so it can be emulated efficiently.
-		"""
-		BasicMathGate.__init__(self, lambda x: ((x + a) % N,))
-		self.a = a
-		self.N = N
+    """
+    Add a constant to a quantum number represented by a quantum register modulo N.
 
-	def __str__(self):
-		return "AddConstantModN(" + str(self.a) + ", " + str(self.N) + ")"
+    The number is stored from low- to high-bit, i.e., qunum[0] is the LSB.
 
-	def get_inverse(self):
-		"""
-		Return the inverse gate (subtraction of the same number a modulo the same
-		number N).
-		"""
-		return SubConstantModN(self.a, self.N)
-		
-	def __eq__(self, other):
-		return (isinstance(other, AddConstantModN) and self.a == other.a and
-		        self.N == other.N)
+    Example:
+        .. code-block:: python
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+            qunum = eng.allocate_qureg(5) # 5-qubit number
+            X | qunum[1] # qunum is now equal to 2
+            AddConstantModN(3, 4) | qunum # qunum is now equal to 1
+    """
+    def __init__(self, a, N):
+        """
+        Initializes the gate to the number to add modulo N.
+
+        Args:
+            a (int): Number to add to a quantum register (0 <= a < N).
+            N (int): Number modulo which the addition is carried out.
+
+        It also initializes its base class, BasicMathGate, with the corresponding
+        function, so it can be emulated efficiently.
+        """
+        BasicMathGate.__init__(self, lambda x: ((x + a) % N,))
+        self.a = a
+        self.N = N
+
+    def __str__(self):
+        return "AddConstantModN(" + str(self.a) + ", " + str(self.N) + ")"
+
+    def get_inverse(self):
+        """
+        Return the inverse gate (subtraction of the same number a modulo the same
+        number N).
+        """
+        return SubConstantModN(self.a, self.N)
+
+    def __eq__(self, other):
+        return (isinstance(other, AddConstantModN) and self.a == other.a and
+                self.N == other.N)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 def SubConstantModN(a, N):
-	"""
-	Subtract a constant from a quantum number represented by a quantum register
-	modulo N.
-	
-	The number is stored from low- to high-bit, i.e., qunum[0] is the LSB.
-	
-	Args:
-		a (int): Constant to add
-		N (int): Constant modulo which the addition of a should be carried out.
-	
-	Example:
-		.. code-block:: python
-		
-			qunum = eng.allocate_qureg(3) # 3-qubit number
-			X | qunum[1] # qunum is now equal to 2
-			SubConstantModN(4,5) | qunum # qunum is now equal to -2 = 6 = 1 (mod 5)
-	"""
-	return AddConstantModN(N - a, N)
+    """
+    Subtract a constant from a quantum number represented by a quantum register
+    modulo N.
+
+    The number is stored from low- to high-bit, i.e., qunum[0] is the LSB.
+
+    Args:
+        a (int): Constant to add
+        N (int): Constant modulo which the addition of a should be carried out.
+
+    Example:
+        .. code-block:: python
+
+            qunum = eng.allocate_qureg(3) # 3-qubit number
+            X | qunum[1] # qunum is now equal to 2
+            SubConstantModN(4,5) | qunum # qunum is now equal to -2 = 6 = 1 (mod 5)
+    """
+    return AddConstantModN(N - a, N)
 
 
 class MultiplyByConstantModN(BasicMathGate):
-	"""
-	Multiply a quantum number represented by a quantum register by a constant
-	modulo N.
-	
-	The number is stored from low- to high-bit, i.e., qunum[0] is the LSB.
-	
-	Example:
-		.. code-block:: python
-		
-			qunum = eng.allocate_qureg(5) # 5-qubit number
-			X | qunum[2] # qunum is now equal to 4
-			MultiplyByConstantModN(3,5) | qunum # qunum is now equal to 2 (mod 5)
-	"""
-	def __init__(self, a, N):
-		"""
-		Initializes the gate to the number to multiply with modulo N.
-		
-		Args:
-			a (int): Number by which to multiply a quantum register (0 <= a < N).
-			N (int): Number modulo which the multiplication is carried out.
-			
-		It also initializes its base class, BasicMathGate, with the corresponding
-		function, so it can be emulated efficiently.
-		"""
-		BasicMathGate.__init__(self, lambda x: ((a * x) % N,))
-		self.a = a
-		self.N = N
+    """
+    Multiply a quantum number represented by a quantum register by a constant
+    modulo N.
 
-	def __str__(self):
-		return "MultiplyByConstantModN(" + str(self.a) + ", " + str(self.N) + ")"
+    The number is stored from low- to high-bit, i.e., qunum[0] is the LSB.
 
-	def __eq__(self, other):
-		return (isinstance(other, MultiplyByConstantModN) and
-		        self.a == other.a and self.N == other.N)
+    Example:
+        .. code-block:: python
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+            qunum = eng.allocate_qureg(5) # 5-qubit number
+            X | qunum[2] # qunum is now equal to 4
+            MultiplyByConstantModN(3,5) | qunum # qunum is now equal to 2 (mod 5)
+    """
+    def __init__(self, a, N):
+        """
+        Initializes the gate to the number to multiply with modulo N.
+
+        Args:
+            a (int): Number by which to multiply a quantum register (0 <= a < N).
+            N (int): Number modulo which the multiplication is carried out.
+
+        It also initializes its base class, BasicMathGate, with the corresponding
+        function, so it can be emulated efficiently.
+        """
+        BasicMathGate.__init__(self, lambda x: ((a * x) % N,))
+        self.a = a
+        self.N = N
+
+    def __str__(self):
+        return "MultiplyByConstantModN(" + str(self.a) + ", " + str(self.N) + ")"
+
+    def __eq__(self, other):
+        return (isinstance(other, MultiplyByConstantModN) and
+                self.a == other.a and self.N == other.N)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/projectq/libs/math/_gates_test.py
+++ b/projectq/libs/math/_gates_test.py
@@ -20,28 +20,28 @@ from projectq.libs.math import (AddConstant,
 
 
 def test_addconstant():
-	assert AddConstant(3) == AddConstant(3)
-	assert not AddConstant(3) == AddConstant(4)
-	assert AddConstant(7) != AddConstant(3)
-	
-	assert str(AddConstant(3)) == "AddConstant(3)"
+    assert AddConstant(3) == AddConstant(3)
+    assert not AddConstant(3) == AddConstant(4)
+    assert AddConstant(7) != AddConstant(3)
+
+    assert str(AddConstant(3)) == "AddConstant(3)"
 
 
 def test_addconstantmodn():
-	assert AddConstantModN(3,4) == AddConstantModN(3,4)
-	assert not AddConstantModN(3,4) == AddConstantModN(4,4)
-	assert not AddConstantModN(3,5) == AddConstantModN(3,4)
-	assert AddConstantModN(7,4) != AddConstantModN(3,4)
-	assert AddConstantModN(3,5) != AddConstantModN(3,4)
-	
-	assert str(AddConstantModN(3,4)) == "AddConstantModN(3, 4)"
+    assert AddConstantModN(3,4) == AddConstantModN(3,4)
+    assert not AddConstantModN(3,4) == AddConstantModN(4,4)
+    assert not AddConstantModN(3,5) == AddConstantModN(3,4)
+    assert AddConstantModN(7,4) != AddConstantModN(3,4)
+    assert AddConstantModN(3,5) != AddConstantModN(3,4)
+
+    assert str(AddConstantModN(3,4)) == "AddConstantModN(3, 4)"
 
 
 def test_multiplybyconstmodn():
-	assert MultiplyByConstantModN(3,4) == MultiplyByConstantModN(3,4)
-	assert not MultiplyByConstantModN(3,4) == MultiplyByConstantModN(4,4)
-	assert not MultiplyByConstantModN(3,5) == MultiplyByConstantModN(3,4)
-	assert MultiplyByConstantModN(7,4) != MultiplyByConstantModN(3,4)
-	assert MultiplyByConstantModN(3,5) != MultiplyByConstantModN(3,4)
-	
-	assert str(MultiplyByConstantModN(3,4)) == "MultiplyByConstantModN(3, 4)"
+    assert MultiplyByConstantModN(3,4) == MultiplyByConstantModN(3,4)
+    assert not MultiplyByConstantModN(3,4) == MultiplyByConstantModN(4,4)
+    assert not MultiplyByConstantModN(3,5) == MultiplyByConstantModN(3,4)
+    assert MultiplyByConstantModN(7,4) != MultiplyByConstantModN(3,4)
+    assert MultiplyByConstantModN(3,5) != MultiplyByConstantModN(3,4)
+
+    assert str(MultiplyByConstantModN(3,4)) == "MultiplyByConstantModN(3, 4)"

--- a/projectq/meta/_compute.py
+++ b/projectq/meta/_compute.py
@@ -26,421 +26,421 @@ from projectq.ops import Allocate, Deallocate
 
 
 class QubitManagementError(Exception):
-	pass
+    pass
 
 class NoComputeSectionError(Exception):
-	""" Exception raised if uncompute is called but no compute section found."""
-	pass
+    """ Exception raised if uncompute is called but no compute section found."""
+    pass
 
 
 class ComputeTag(object):
-	"""
-	Compute meta tag.
-	"""
+    """
+    Compute meta tag.
+    """
 
-	def __eq__(self, other):
-		return isinstance(other, ComputeTag)
+    def __eq__(self, other):
+        return isinstance(other, ComputeTag)
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class UncomputeTag(object):
-	"""
-	Uncompute meta tag.
-	"""
+    """
+    Uncompute meta tag.
+    """
 
-	def __eq__(self, other):
-		return isinstance(other, UncomputeTag)
+    def __eq__(self, other):
+        return isinstance(other, UncomputeTag)
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class ComputeEngine(BasicEngine):
-	"""
-	Adds Compute-tags to all commands and stores them (to later uncompute them
-	automatically)
-	"""
+    """
+    Adds Compute-tags to all commands and stores them (to later uncompute them
+    automatically)
+    """
 
-	def __init__(self):
-		"""
-		Initialize a ComputeEngine.
-		"""
-		BasicEngine.__init__(self)
-		self._l = []
-		self._compute = True
-		# Save all qubit ids from qubits which are created or destroyed.
-		self._allocated_qubit_ids = set()
-		self._deallocated_qubit_ids = set()
+    def __init__(self):
+        """
+        Initialize a ComputeEngine.
+        """
+        BasicEngine.__init__(self)
+        self._l = []
+        self._compute = True
+        # Save all qubit ids from qubits which are created or destroyed.
+        self._allocated_qubit_ids = set()
+        self._deallocated_qubit_ids = set()
 
-	def _add_uncompute_tag(self, cmd):
-		"""
-		Modify the command tags, inserting an UncomputeTag.
-		
-		Args:
-			cmd (Command): Command to modify.
-		"""
-		cmd.tags.append(UncomputeTag())
-		return cmd
+    def _add_uncompute_tag(self, cmd):
+        """
+        Modify the command tags, inserting an UncomputeTag.
 
-	def run_uncompute(self):
-		"""
-		Send uncomputing gates.
-		
-		Sends the inverse of the stored commands in reverse order down to the
-		next engine. And also deals with allocated qubits in Compute section.
-		If a qubit has been allocated during compute, it will be deallocated
-		during uncompute. If a qubit has been allocated and deallocated during
-		compute, then a new qubit is allocated and deallocated during
-		uncompute.
-		"""
+        Args:
+            cmd (Command): Command to modify.
+        """
+        cmd.tags.append(UncomputeTag())
+        return cmd
 
-		# No qubits allocated during Compute section -> do standard uncompute
-		if len(self._allocated_qubit_ids) == 0:
-			self.send([self._add_uncompute_tag(cmd.get_inverse()) 
-			           for cmd in reversed(self._l)])
-			return
+    def run_uncompute(self):
+        """
+        Send uncomputing gates.
 
-		# qubits ids which were allocated and deallocated in Compute section
-		ids_local_to_compute = self._allocated_qubit_ids.intersection(
-		                            self._deallocated_qubit_ids)
-		# qubit ids which were allocated but not yet deallocated in Compute section
-		ids_still_alive = self._allocated_qubit_ids.difference(
-		                       self._deallocated_qubit_ids)
+        Sends the inverse of the stored commands in reverse order down to the
+        next engine. And also deals with allocated qubits in Compute section.
+        If a qubit has been allocated during compute, it will be deallocated
+        during uncompute. If a qubit has been allocated and deallocated during
+        compute, then a new qubit is allocated and deallocated during
+        uncompute.
+        """
 
-		# No qubits allocated and already deallocated during compute.
-		# Don't inspect each command as below -> faster uncompute
-		# Just find qubits which have been allocated and deallocate them
-		if len(ids_local_to_compute) == 0:
-			for cmd in reversed(self._l):
-				if cmd.gate == Allocate:
-					qubit_id = cmd.qubits[0][0].id
-					# Remove this qubit from MainEngine.active_qubits and
-					# set qubit.id to = -1 in Qubit object such that it won't
-					# send another deallocate when it goes out of scope
-					qubit_found = False
-					for active_qubit in self.main_engine.active_qubits:
-						if active_qubit.id == qubit_id:
-							active_qubit.id = -1
-							del active_qubit
-							qubit_found = True
-							break
-					if not qubit_found:
-						raise QubitManagementError(
-						    "\nQubit was not found in " +
-						    "MainEngine.active_qubits.\n")
-					self.send([self._add_uncompute_tag(cmd.get_inverse())])
-				else:
-					self.send([self._add_uncompute_tag(cmd.get_inverse())])
-			return
-		# There was at least one qubit allocated and deallocated within
-		# compute section. Handle uncompute in most general case
-		new_local_id = dict()
-		for cmd in reversed(self._l):
-			if cmd.gate == Deallocate:
-				assert (cmd.qubits[0][0].id) in ids_local_to_compute
-				# Create new local qubit which lives within uncompute section
-				# Allocate needs to have old tags + uncompute tag
-				oldnext = self.next_engine
-				def add_uncompute(command, old_tags=deepcopy(cmd.tags)):
-					command.tags = old_tags + [UncomputeTag()]
-					return command
-				self.next_engine = projectq.cengines.CommandModifier(add_uncompute)
-				self.next_engine.next_engine = oldnext
-				new_local_qb = self.allocate_qubit()
-				self.next_engine = oldnext
-				new_local_id[cmd.qubits[0][0].id] = deepcopy(new_local_qb[0].id)
-				# Set id of new_local_qb to -1 such that it doesn't send a 
-				# deallocate gate
-				new_local_qb[0].id = -1
+        # No qubits allocated during Compute section -> do standard uncompute
+        if len(self._allocated_qubit_ids) == 0:
+            self.send([self._add_uncompute_tag(cmd.get_inverse())
+                       for cmd in reversed(self._l)])
+            return
 
-			elif cmd.gate == Allocate:
-				# Deallocate qubit
-				if cmd.qubits[0][0].id in ids_local_to_compute:
-					# Deallocate local qubit and remove id from new_local_id
-					old_id = deepcopy(cmd.qubits[0][0].id)
-					cmd.qubits[0][0].id = new_local_id[cmd.qubits[0][0].id]
-					del new_local_id[old_id]
-					self.send([self._add_uncompute_tag(cmd.get_inverse())])
+        # qubits ids which were allocated and deallocated in Compute section
+        ids_local_to_compute = self._allocated_qubit_ids.intersection(
+                                    self._deallocated_qubit_ids)
+        # qubit ids which were allocated but not yet deallocated in Compute section
+        ids_still_alive = self._allocated_qubit_ids.difference(
+                               self._deallocated_qubit_ids)
 
-				else:
-					# Deallocate qubit which was allocated in compute section:
-					qubit_id = cmd.qubits[0][0].id
-					# Remove this qubit from MainEngine.active_qubits and
-					# set qubit.id to = -1 in Qubit object such that it won't
-					# send another deallocate when it goes out of scope
-					qubit_found = False
-					for active_qubit in self.main_engine.active_qubits:
-						if active_qubit.id == qubit_id:
-							active_qubit.id = -1
-							del active_qubit
-							qubit_found = True
-							break
-					if not qubit_found:
-						raise QubitManagementError(
-						    "\nQubit was not found in " +
-						    "MainEngine.active_qubits.\n")
-					self.send([self._add_uncompute_tag(cmd.get_inverse())])
+        # No qubits allocated and already deallocated during compute.
+        # Don't inspect each command as below -> faster uncompute
+        # Just find qubits which have been allocated and deallocate them
+        if len(ids_local_to_compute) == 0:
+            for cmd in reversed(self._l):
+                if cmd.gate == Allocate:
+                    qubit_id = cmd.qubits[0][0].id
+                    # Remove this qubit from MainEngine.active_qubits and
+                    # set qubit.id to = -1 in Qubit object such that it won't
+                    # send another deallocate when it goes out of scope
+                    qubit_found = False
+                    for active_qubit in self.main_engine.active_qubits:
+                        if active_qubit.id == qubit_id:
+                            active_qubit.id = -1
+                            del active_qubit
+                            qubit_found = True
+                            break
+                    if not qubit_found:
+                        raise QubitManagementError(
+                            "\nQubit was not found in " +
+                            "MainEngine.active_qubits.\n")
+                    self.send([self._add_uncompute_tag(cmd.get_inverse())])
+                else:
+                    self.send([self._add_uncompute_tag(cmd.get_inverse())])
+            return
+        # There was at least one qubit allocated and deallocated within
+        # compute section. Handle uncompute in most general case
+        new_local_id = dict()
+        for cmd in reversed(self._l):
+            if cmd.gate == Deallocate:
+                assert (cmd.qubits[0][0].id) in ids_local_to_compute
+                # Create new local qubit which lives within uncompute section
+                # Allocate needs to have old tags + uncompute tag
+                oldnext = self.next_engine
+                def add_uncompute(command, old_tags=deepcopy(cmd.tags)):
+                    command.tags = old_tags + [UncomputeTag()]
+                    return command
+                self.next_engine = projectq.cengines.CommandModifier(add_uncompute)
+                self.next_engine.next_engine = oldnext
+                new_local_qb = self.allocate_qubit()
+                self.next_engine = oldnext
+                new_local_id[cmd.qubits[0][0].id] = deepcopy(new_local_qb[0].id)
+                # Set id of new_local_qb to -1 such that it doesn't send a
+                # deallocate gate
+                new_local_qb[0].id = -1
 
-			else:
-				if len(new_local_id) == 0:
-					# No local qubits are active currently -> do standard uncompute
-					self.send([self._add_uncompute_tag(cmd.get_inverse())])
-				else:
-					# Process commands by replacing each local qubit from compute
-					# section with new local qubit from the uncompute section
-					tmp_control_qubits = cmd.control_qubits
-					changed = False
-					for control_qubit in tmp_control_qubits:
-						if control_qubit.id in new_local_id:
-							control_qubit.id = new_local_id[control_qubit.id]
-							changed = True
-					if changed:
-						cmd.control_qubits = tmp_control_qubits
-					tmp_qubits = cmd.qubits
-					changed = False
-					for qureg in tmp_qubits:
-						for qubit in qureg:
-							if qubit.id in new_local_id:
-								qubit.id = new_local_id[qubit.id]
-								changed = True
-					if changed:
-						cmd.qubits = tmp_qubits
-					self.send([self._add_uncompute_tag(cmd.get_inverse())])
+            elif cmd.gate == Allocate:
+                # Deallocate qubit
+                if cmd.qubits[0][0].id in ids_local_to_compute:
+                    # Deallocate local qubit and remove id from new_local_id
+                    old_id = deepcopy(cmd.qubits[0][0].id)
+                    cmd.qubits[0][0].id = new_local_id[cmd.qubits[0][0].id]
+                    del new_local_id[old_id]
+                    self.send([self._add_uncompute_tag(cmd.get_inverse())])
+
+                else:
+                    # Deallocate qubit which was allocated in compute section:
+                    qubit_id = cmd.qubits[0][0].id
+                    # Remove this qubit from MainEngine.active_qubits and
+                    # set qubit.id to = -1 in Qubit object such that it won't
+                    # send another deallocate when it goes out of scope
+                    qubit_found = False
+                    for active_qubit in self.main_engine.active_qubits:
+                        if active_qubit.id == qubit_id:
+                            active_qubit.id = -1
+                            del active_qubit
+                            qubit_found = True
+                            break
+                    if not qubit_found:
+                        raise QubitManagementError(
+                            "\nQubit was not found in " +
+                            "MainEngine.active_qubits.\n")
+                    self.send([self._add_uncompute_tag(cmd.get_inverse())])
+
+            else:
+                if len(new_local_id) == 0:
+                    # No local qubits are active currently -> do standard uncompute
+                    self.send([self._add_uncompute_tag(cmd.get_inverse())])
+                else:
+                    # Process commands by replacing each local qubit from compute
+                    # section with new local qubit from the uncompute section
+                    tmp_control_qubits = cmd.control_qubits
+                    changed = False
+                    for control_qubit in tmp_control_qubits:
+                        if control_qubit.id in new_local_id:
+                            control_qubit.id = new_local_id[control_qubit.id]
+                            changed = True
+                    if changed:
+                        cmd.control_qubits = tmp_control_qubits
+                    tmp_qubits = cmd.qubits
+                    changed = False
+                    for qureg in tmp_qubits:
+                        for qubit in qureg:
+                            if qubit.id in new_local_id:
+                                qubit.id = new_local_id[qubit.id]
+                                changed = True
+                    if changed:
+                        cmd.qubits = tmp_qubits
+                    self.send([self._add_uncompute_tag(cmd.get_inverse())])
 
 
-	def end_compute(self):
-		"""
-		End the compute step (exit the with Compute() - statement).
-		
-		Will tell the Compute-engine to stop caching. It then waits for the
-		uncompute instruction, which is when it sends all cached commands inverted
-		and in reverse order down to the next compiler engine.
+    def end_compute(self):
+        """
+        End the compute step (exit the with Compute() - statement).
 
-		Raises:
-			QubitManagementError: If qubit has been deallocated in Compute section
-			                      which has not been allocated in Compute section
-		"""
-		self._compute = False
-		if not self._allocated_qubit_ids.issuperset(self._deallocated_qubit_ids):
-			raise QubitManagementError(
-				"\nQubit has been deallocated in with Compute(eng) context \n" +
-				"which has not been allocated within this Compute section")
+        Will tell the Compute-engine to stop caching. It then waits for the
+        uncompute instruction, which is when it sends all cached commands inverted
+        and in reverse order down to the next compiler engine.
 
-	def receive(self, command_list):
-		"""
-		If in compute-mode: Receive commands and store deepcopy of each cmd.
-		                    Add ComputeTag to received cmd and send it on. 
-		Otherwise: send all received commands directly to next_engine.
-		
-		Args:
-			command_list (list<Command>): List of commands to receive.
-		"""
-		if self._compute:
-			for cmd in command_list:
-				if cmd.gate == Allocate:
-					self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
-				elif cmd.gate == Deallocate:
-					self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
-				self._l.append(deepcopy(cmd))
-				tags = cmd.tags
-				tags.append(ComputeTag())
-			self.send(command_list)
-		else:
-			self.send(command_list)
+        Raises:
+            QubitManagementError: If qubit has been deallocated in Compute section
+                                  which has not been allocated in Compute section
+        """
+        self._compute = False
+        if not self._allocated_qubit_ids.issuperset(self._deallocated_qubit_ids):
+            raise QubitManagementError(
+                "\nQubit has been deallocated in with Compute(eng) context \n" +
+                "which has not been allocated within this Compute section")
+
+    def receive(self, command_list):
+        """
+        If in compute-mode: Receive commands and store deepcopy of each cmd.
+                            Add ComputeTag to received cmd and send it on.
+        Otherwise: send all received commands directly to next_engine.
+
+        Args:
+            command_list (list<Command>): List of commands to receive.
+        """
+        if self._compute:
+            for cmd in command_list:
+                if cmd.gate == Allocate:
+                    self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
+                elif cmd.gate == Deallocate:
+                    self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
+                self._l.append(deepcopy(cmd))
+                tags = cmd.tags
+                tags.append(ComputeTag())
+            self.send(command_list)
+        else:
+            self.send(command_list)
 
 
 class UncomputeEngine(BasicEngine):
-	"""
-	Adds Uncompute-tags to all commands.
-	"""
-	def __init__(self):
-		"""
-		Initialize a UncomputeEngine.
-		"""
-		BasicEngine.__init__(self)
-		# Save all qubit ids from qubits which are created or destroyed.
-		self._allocated_qubit_ids = set()
-		self._deallocated_qubit_ids = set()
+    """
+    Adds Uncompute-tags to all commands.
+    """
+    def __init__(self):
+        """
+        Initialize a UncomputeEngine.
+        """
+        BasicEngine.__init__(self)
+        # Save all qubit ids from qubits which are created or destroyed.
+        self._allocated_qubit_ids = set()
+        self._deallocated_qubit_ids = set()
 
-	def receive(self, command_list):
-		"""
-		Receive commands and add an UncomputeTag to their tags.
-		
-		Args:
-			command_list (list<Command>): List of commands to handle.
-		"""
-		for cmd in command_list:
-			if cmd.gate == Allocate:
-				self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
-			elif cmd.gate == Deallocate:
-				self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
-			tags = cmd.tags
-			tags.append(UncomputeTag())
-			self.send([cmd])
+    def receive(self, command_list):
+        """
+        Receive commands and add an UncomputeTag to their tags.
+
+        Args:
+            command_list (list<Command>): List of commands to handle.
+        """
+        for cmd in command_list:
+            if cmd.gate == Allocate:
+                self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
+            elif cmd.gate == Deallocate:
+                self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
+            tags = cmd.tags
+            tags.append(UncomputeTag())
+            self.send([cmd])
 
 
 class Compute(object):
-	"""
-	Start a compute-section.
+    """
+    Start a compute-section.
 
-	Example:
-		.. code-block:: python
-		
-			with Compute(eng):
-				do_something(qubits)
-			action(qubits)
-			Uncompute(eng) # runs inverse of the compute section
-	
-	Warning:
-		If qubits are allocated within the compute section, they must either be
-		uncomputed and deallocated within that section or, alternatively,
-		uncomputed and deallocated in the following uncompute section.
-		
-		This means that the following examples are valid:
-		
-		.. code-block:: python
-		
-			with Compute(eng):
-				anc = eng.allocate_qubit()
-				do_something_with_ancilla(anc)
-				...
-				uncompute_ancilla(anc)
-				del anc
-			
-			do_something_else(qubits)
-			
-			Uncompute(eng)  # will allocate a new ancilla (with a different id)
-			                # and then deallocate it again
-		
-		.. code-block:: python
-			
-			with Compute(eng):
-				anc = eng.allocate_qubit()
-				do_something_with_ancilla(anc)
-				...
-			
-			do_something_else(qubits)
-			
-			Uncompute(eng)  # will deallocate the ancilla!
-		
-		After the uncompute section, ancilla qubits allocated within the compute
-		section will be invalid (and deallocated). The same holds when using
-		CustomUncompute.
-		
-		Failure to comply with these rules results in an exception being thrown.
-	"""
+    Example:
+        .. code-block:: python
 
-	def __init__(self, engine):
-		"""
-		Initialize a Compute context.
-		
-		Args:
-			engine (BasicEngine): Engine which is the first to receive all commands
-				(normally: MainEngine).
-		"""
-		self.engine = engine
+            with Compute(eng):
+                do_something(qubits)
+            action(qubits)
+            Uncompute(eng) # runs inverse of the compute section
 
-	def __enter__(self):
-		compute_eng = ComputeEngine()
-		compute_eng.main_engine = self.engine.main_engine
-		oldnext = self.engine.next_engine
-		self.engine.next_engine = compute_eng
-		compute_eng.next_engine = oldnext
-		self._compute_eng = compute_eng
+    Warning:
+        If qubits are allocated within the compute section, they must either be
+        uncomputed and deallocated within that section or, alternatively,
+        uncomputed and deallocated in the following uncompute section.
 
-	def __exit__(self, type, value, traceback):
-		# notify ComputeEngine that the compute section is done
-		self._compute_eng.end_compute()
+        This means that the following examples are valid:
+
+        .. code-block:: python
+
+            with Compute(eng):
+                anc = eng.allocate_qubit()
+                do_something_with_ancilla(anc)
+                ...
+                uncompute_ancilla(anc)
+                del anc
+
+            do_something_else(qubits)
+
+            Uncompute(eng)  # will allocate a new ancilla (with a different id)
+                            # and then deallocate it again
+
+        .. code-block:: python
+
+            with Compute(eng):
+                anc = eng.allocate_qubit()
+                do_something_with_ancilla(anc)
+                ...
+
+            do_something_else(qubits)
+
+            Uncompute(eng)  # will deallocate the ancilla!
+
+        After the uncompute section, ancilla qubits allocated within the compute
+        section will be invalid (and deallocated). The same holds when using
+        CustomUncompute.
+
+        Failure to comply with these rules results in an exception being thrown.
+    """
+
+    def __init__(self, engine):
+        """
+        Initialize a Compute context.
+
+        Args:
+            engine (BasicEngine): Engine which is the first to receive all commands
+                (normally: MainEngine).
+        """
+        self.engine = engine
+
+    def __enter__(self):
+        compute_eng = ComputeEngine()
+        compute_eng.main_engine = self.engine.main_engine
+        oldnext = self.engine.next_engine
+        self.engine.next_engine = compute_eng
+        compute_eng.next_engine = oldnext
+        self._compute_eng = compute_eng
+
+    def __exit__(self, type, value, traceback):
+        # notify ComputeEngine that the compute section is done
+        self._compute_eng.end_compute()
 
 
 class CustomUncompute(object):
-	"""
-	Start a custom uncompute-section.
+    """
+    Start a custom uncompute-section.
 
-	Example:
-		.. code-block:: python
-		
-			with Compute(eng):
-				do_something(qubits)
-			action(qubits)
-			with CustomUncompute(eng):
-				do_something_inverse(qubits)
+    Example:
+        .. code-block:: python
 
-	Raises:
-		QubitManagementError: If qubits are allocated within Compute or within
-		                      CustomUncompute context but are not deallocated.
-	"""
+            with Compute(eng):
+                do_something(qubits)
+            action(qubits)
+            with CustomUncompute(eng):
+                do_something_inverse(qubits)
 
-	def __init__(self, engine):
-		"""
-		Initialize a CustomUncompute context.
-		
-		Args:
-			engine (BasicEngine): Engine which is the first to receive all commands
-				(normally: MainEngine).
-		"""
-		self.engine = engine
-		# Save all qubit ids from qubits which are created or destroyed.
-		self._allocated_qubit_ids = set()
-		self._deallocated_qubit_ids = set()
+    Raises:
+        QubitManagementError: If qubits are allocated within Compute or within
+                              CustomUncompute context but are not deallocated.
+    """
 
-	def __enter__(self):
-		# first, remove the compute engine
-		compute_eng = self.engine.next_engine
-		if not isinstance(compute_eng, ComputeEngine):
-			raise NoComputeSectionError(
-			      "Invalid call to CustomUncompute: No corresponding" +
-			      "'with Compute' statement found.")
-		# Make copy so there is not reference to compute_eng anymore 
-		# after __enter__
-		self._allocated_qubit_ids = compute_eng._allocated_qubit_ids.copy()
-		self._deallocated_qubit_ids = compute_eng._deallocated_qubit_ids.copy()
-		oldnext = compute_eng.next_engine
-		self.engine.next_engine = oldnext
+    def __init__(self, engine):
+        """
+        Initialize a CustomUncompute context.
 
-		# Now add uncompute engine
-		uncompute_eng = UncomputeEngine()
-		uncompute_eng.main_engine = self.engine.main_engine
-		oldnext = self.engine.next_engine
-		self.engine.next_engine = uncompute_eng
-		uncompute_eng.next_engine = oldnext
-		self._uncompute_eng = uncompute_eng
+        Args:
+            engine (BasicEngine): Engine which is the first to receive all commands
+                (normally: MainEngine).
+        """
+        self.engine = engine
+        # Save all qubit ids from qubits which are created or destroyed.
+        self._allocated_qubit_ids = set()
+        self._deallocated_qubit_ids = set()
 
-	def __exit__(self, type, value, traceback):
-		# Check that all qubits allocated within Compute or within
-		# CustomUncompute have been deallocated.
-		all_allocated_qubits = self._allocated_qubit_ids.union(
-		                           self._uncompute_eng._allocated_qubit_ids)
-		all_deallocated_qubits = self._deallocated_qubit_ids.union(
-		                           self._uncompute_eng._deallocated_qubit_ids)
-		if len(all_allocated_qubits.difference(all_deallocated_qubits)) != 0:
-			raise QubitManagementError(
-				"\nError. Not all qubits have been deallocated which have \n" +
-				"been allocated in the with Compute(eng) or with " +
-				"CustomUncompute(eng) context.")
-		# remove uncompute engine
-		oldnext = self._uncompute_eng.next_engine
-		self.engine.next_engine = oldnext
+    def __enter__(self):
+        # first, remove the compute engine
+        compute_eng = self.engine.next_engine
+        if not isinstance(compute_eng, ComputeEngine):
+            raise NoComputeSectionError(
+                  "Invalid call to CustomUncompute: No corresponding" +
+                  "'with Compute' statement found.")
+        # Make copy so there is not reference to compute_eng anymore
+        # after __enter__
+        self._allocated_qubit_ids = compute_eng._allocated_qubit_ids.copy()
+        self._deallocated_qubit_ids = compute_eng._deallocated_qubit_ids.copy()
+        oldnext = compute_eng.next_engine
+        self.engine.next_engine = oldnext
+
+        # Now add uncompute engine
+        uncompute_eng = UncomputeEngine()
+        uncompute_eng.main_engine = self.engine.main_engine
+        oldnext = self.engine.next_engine
+        self.engine.next_engine = uncompute_eng
+        uncompute_eng.next_engine = oldnext
+        self._uncompute_eng = uncompute_eng
+
+    def __exit__(self, type, value, traceback):
+        # Check that all qubits allocated within Compute or within
+        # CustomUncompute have been deallocated.
+        all_allocated_qubits = self._allocated_qubit_ids.union(
+                                   self._uncompute_eng._allocated_qubit_ids)
+        all_deallocated_qubits = self._deallocated_qubit_ids.union(
+                                   self._uncompute_eng._deallocated_qubit_ids)
+        if len(all_allocated_qubits.difference(all_deallocated_qubits)) != 0:
+            raise QubitManagementError(
+                "\nError. Not all qubits have been deallocated which have \n" +
+                "been allocated in the with Compute(eng) or with " +
+                "CustomUncompute(eng) context.")
+        # remove uncompute engine
+        oldnext = self._uncompute_eng.next_engine
+        self.engine.next_engine = oldnext
 
 
 def Uncompute(engine):
-	"""
-	Uncompute automatically.
+    """
+    Uncompute automatically.
 
-	Example:
-		.. code-block:: python
-		
-			with Compute(eng):
-				do_something(qubits)
-			action(qubits)
-			Uncompute(eng) # runs inverse of the compute section
-	"""
-	compute_eng = engine.next_engine
-	if not isinstance(compute_eng, ComputeEngine):
-		raise NoComputeSectionError("Invalid call to Uncompute: No " +
-		                  "corresponding 'with Compute' statement found.")
-	compute_eng.run_uncompute()
-	oldnext = compute_eng.next_engine
-	engine.next_engine = oldnext
+    Example:
+        .. code-block:: python
+
+            with Compute(eng):
+                do_something(qubits)
+            action(qubits)
+            Uncompute(eng) # runs inverse of the compute section
+    """
+    compute_eng = engine.next_engine
+    if not isinstance(compute_eng, ComputeEngine):
+        raise NoComputeSectionError("Invalid call to Uncompute: No " +
+                          "corresponding 'with Compute' statement found.")
+    compute_eng.run_uncompute()
+    oldnext = compute_eng.next_engine
+    engine.next_engine = oldnext

--- a/projectq/meta/_compute_test.py
+++ b/projectq/meta/_compute_test.py
@@ -26,355 +26,355 @@ from projectq.meta import _compute
 
 
 def test_compute_tag():
-	tag0 = _compute.ComputeTag()
-	tag1 = _compute.ComputeTag()
-	
-	class MyTag(object):
-		pass
-	
-	assert not tag0 == MyTag()
-	assert not tag0 != tag1
-	assert tag0 == tag1
+    tag0 = _compute.ComputeTag()
+    tag1 = _compute.ComputeTag()
+
+    class MyTag(object):
+        pass
+
+    assert not tag0 == MyTag()
+    assert not tag0 != tag1
+    assert tag0 == tag1
 
 
 def test_uncompute_tag():
-	tag0 = _compute.UncomputeTag()
-	tag1 = _compute.UncomputeTag()
-	
-	class MyTag(object):
-		pass
-	
-	assert not tag0 == MyTag()
-	assert not tag0 != tag1
-	assert tag0 == tag1
+    tag0 = _compute.UncomputeTag()
+    tag1 = _compute.UncomputeTag()
+
+    class MyTag(object):
+        pass
+
+    assert not tag0 == MyTag()
+    assert not tag0 != tag1
+    assert tag0 == tag1
 
 
 def test_compute_engine():
-	backend = DummyEngine(save_commands=True)
-	compute_engine = _compute.ComputeEngine()
-	eng = MainEngine(backend=backend, engine_list=[compute_engine])
-	ancilla = eng.allocate_qubit() # Ancilla
-	H | ancilla
-	Rx(0.6) | ancilla
-	ancilla[0].__del__()
-	# Test that adding later a new tag to one of the previous commands
-	# does not add this tags to cmds saved in compute_engine because
-	# this one does need to make a deepcopy and not store a reference.
-	assert backend.received_commands[1].gate == H
-	backend.received_commands[1].tags.append("TagAddedLater")
-	assert backend.received_commands[1].tags[-1] == "TagAddedLater"
-	compute_engine.end_compute()
-	new_qubit = eng.allocate_qubit()
-	Ry(0.5) | new_qubit
-	compute_engine.run_uncompute()
-	eng.flush()
-	assert backend.received_commands[0].gate == Allocate
-	assert backend.received_commands[0].tags == [_compute.ComputeTag()]
-	assert backend.received_commands[1].gate == H
-	assert backend.received_commands[1].tags == [_compute.ComputeTag(),
-	                                             "TagAddedLater"]
-	assert backend.received_commands[2].gate == Rx(0.6)
-	assert backend.received_commands[2].tags == [_compute.ComputeTag()]
-	assert backend.received_commands[3].gate == Deallocate
-	assert backend.received_commands[3].tags == [_compute.ComputeTag()]
-	assert backend.received_commands[4].gate == Allocate
-	assert backend.received_commands[4].tags == []
-	assert backend.received_commands[5].gate == Ry(0.5)
-	assert backend.received_commands[5].tags == []
-	assert backend.received_commands[6].gate == Allocate
-	assert backend.received_commands[6].tags == [_compute.UncomputeTag()]
-	assert backend.received_commands[7].gate == Rx(-0.6)
-	assert backend.received_commands[7].tags == [_compute.UncomputeTag()]
-	assert backend.received_commands[8].gate == H
-	assert backend.received_commands[8].tags == [_compute.UncomputeTag()]
-	assert backend.received_commands[9].gate == Deallocate
-	assert backend.received_commands[9].tags == [_compute.UncomputeTag()]
+    backend = DummyEngine(save_commands=True)
+    compute_engine = _compute.ComputeEngine()
+    eng = MainEngine(backend=backend, engine_list=[compute_engine])
+    ancilla = eng.allocate_qubit() # Ancilla
+    H | ancilla
+    Rx(0.6) | ancilla
+    ancilla[0].__del__()
+    # Test that adding later a new tag to one of the previous commands
+    # does not add this tags to cmds saved in compute_engine because
+    # this one does need to make a deepcopy and not store a reference.
+    assert backend.received_commands[1].gate == H
+    backend.received_commands[1].tags.append("TagAddedLater")
+    assert backend.received_commands[1].tags[-1] == "TagAddedLater"
+    compute_engine.end_compute()
+    new_qubit = eng.allocate_qubit()
+    Ry(0.5) | new_qubit
+    compute_engine.run_uncompute()
+    eng.flush()
+    assert backend.received_commands[0].gate == Allocate
+    assert backend.received_commands[0].tags == [_compute.ComputeTag()]
+    assert backend.received_commands[1].gate == H
+    assert backend.received_commands[1].tags == [_compute.ComputeTag(),
+                                                 "TagAddedLater"]
+    assert backend.received_commands[2].gate == Rx(0.6)
+    assert backend.received_commands[2].tags == [_compute.ComputeTag()]
+    assert backend.received_commands[3].gate == Deallocate
+    assert backend.received_commands[3].tags == [_compute.ComputeTag()]
+    assert backend.received_commands[4].gate == Allocate
+    assert backend.received_commands[4].tags == []
+    assert backend.received_commands[5].gate == Ry(0.5)
+    assert backend.received_commands[5].tags == []
+    assert backend.received_commands[6].gate == Allocate
+    assert backend.received_commands[6].tags == [_compute.UncomputeTag()]
+    assert backend.received_commands[7].gate == Rx(-0.6)
+    assert backend.received_commands[7].tags == [_compute.UncomputeTag()]
+    assert backend.received_commands[8].gate == H
+    assert backend.received_commands[8].tags == [_compute.UncomputeTag()]
+    assert backend.received_commands[9].gate == Deallocate
+    assert backend.received_commands[9].tags == [_compute.UncomputeTag()]
 
 
 def test_uncompute_engine():
-	backend = DummyEngine(save_commands=True)
-	uncompute_engine = _compute.UncomputeEngine()
-	eng = MainEngine(backend=backend, engine_list=[uncompute_engine])
-	qubit = eng.allocate_qubit()
-	H | qubit
-	assert backend.received_commands[0].gate == Allocate
-	assert backend.received_commands[0].tags == [_compute.UncomputeTag()]
-	assert backend.received_commands[1].gate == H
-	assert backend.received_commands[1].tags == [_compute.UncomputeTag()]
+    backend = DummyEngine(save_commands=True)
+    uncompute_engine = _compute.UncomputeEngine()
+    eng = MainEngine(backend=backend, engine_list=[uncompute_engine])
+    qubit = eng.allocate_qubit()
+    H | qubit
+    assert backend.received_commands[0].gate == Allocate
+    assert backend.received_commands[0].tags == [_compute.UncomputeTag()]
+    assert backend.received_commands[1].gate == H
+    assert backend.received_commands[1].tags == [_compute.UncomputeTag()]
 
 def test_outside_qubit_deallocated_in_compute():
-	# Test that there is an error if a qubit is deallocated which has
-	# not been allocated within the with Compute(eng) context
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	qubit = eng.allocate_qubit()
-	with pytest.raises(_compute.QubitManagementError):
-		with _compute.Compute(eng):
-			qubit[0].__del__()
+    # Test that there is an error if a qubit is deallocated which has
+    # not been allocated within the with Compute(eng) context
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    qubit = eng.allocate_qubit()
+    with pytest.raises(_compute.QubitManagementError):
+        with _compute.Compute(eng):
+            qubit[0].__del__()
 
 
 def test_deallocation_using_custom_uncompute():
-	# Test that qubits allocated within Compute and Uncompute
-	# section have all been deallocated
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	# Allowed versions:
-	with _compute.Compute(eng):
-		ancilla = eng.allocate_qubit()
-		ancilla[0].__del__()
-	with _compute.CustomUncompute(eng):
-		ancilla2 = eng.allocate_qubit()
-		ancilla2[0].__del__()
-	with _compute.Compute(eng):
-		ancilla3 = eng.allocate_qubit()
-	with _compute.CustomUncompute(eng):
-		ancilla3[0].__del__()
+    # Test that qubits allocated within Compute and Uncompute
+    # section have all been deallocated
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    # Allowed versions:
+    with _compute.Compute(eng):
+        ancilla = eng.allocate_qubit()
+        ancilla[0].__del__()
+    with _compute.CustomUncompute(eng):
+        ancilla2 = eng.allocate_qubit()
+        ancilla2[0].__del__()
+    with _compute.Compute(eng):
+        ancilla3 = eng.allocate_qubit()
+    with _compute.CustomUncompute(eng):
+        ancilla3[0].__del__()
 
 
 def test_deallocation_using_custom_uncompute2():
-	# Test not allowed version:
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	with _compute.Compute(eng):
-		ancilla = eng.allocate_qubit()
-	with pytest.raises(_compute.QubitManagementError):
-		with _compute.CustomUncompute(eng):
-			pass
-	H | ancilla
+    # Test not allowed version:
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    with _compute.Compute(eng):
+        ancilla = eng.allocate_qubit()
+    with pytest.raises(_compute.QubitManagementError):
+        with _compute.CustomUncompute(eng):
+            pass
+    H | ancilla
 
 
 def test_deallocation_using_custom_uncompute3():
-	# Test not allowed version:
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	with _compute.Compute(eng):
-		pass
-	with pytest.raises(_compute.QubitManagementError):
-		with _compute.CustomUncompute(eng):
-			ancilla = eng.allocate_qubit()
-	H | ancilla
+    # Test not allowed version:
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    with _compute.Compute(eng):
+        pass
+    with pytest.raises(_compute.QubitManagementError):
+        with _compute.CustomUncompute(eng):
+            ancilla = eng.allocate_qubit()
+    H | ancilla
 
 
 def test_automatic_deallocation_of_qubit_in_uncompute():
-	# Test that automatic uncomputation deallocates qubit
-	# which was created during compute context.
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	with _compute.Compute(eng):
-		ancilla = eng.allocate_qubit()
-		assert ancilla[0].id != -1
-		Rx(0.6) | ancilla
-	# Test that ancilla qubit has been register in MainEngine.active_qubits
-	assert ancilla[0] in eng.active_qubits
-	_compute.Uncompute(eng)
-	# Test that ancilla id has been set to -1
-	assert ancilla[0].id == -1
-	# Test that ancilla is not anymore in active qubits
-	assert not ancilla[0] in eng.active_qubits
-	assert backend.received_commands[1].gate == Rx(0.6)
-	assert backend.received_commands[2].gate == Rx(-0.6)
+    # Test that automatic uncomputation deallocates qubit
+    # which was created during compute context.
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+    with _compute.Compute(eng):
+        ancilla = eng.allocate_qubit()
+        assert ancilla[0].id != -1
+        Rx(0.6) | ancilla
+    # Test that ancilla qubit has been register in MainEngine.active_qubits
+    assert ancilla[0] in eng.active_qubits
+    _compute.Uncompute(eng)
+    # Test that ancilla id has been set to -1
+    assert ancilla[0].id == -1
+    # Test that ancilla is not anymore in active qubits
+    assert not ancilla[0] in eng.active_qubits
+    assert backend.received_commands[1].gate == Rx(0.6)
+    assert backend.received_commands[2].gate == Rx(-0.6)
 
- 
+
 def test_compute_uncompute_no_additional_qubits():
-	# No ancilla qubit created in compute section
-	backend0 = DummyEngine(save_commands=True)
-	compare_engine0 = CompareEngine()
-	eng0 = MainEngine(backend=backend0, engine_list=[compare_engine0])
-	qubit = eng0.allocate_qubit()
-	with _compute.Compute(eng0):
-		Rx(0.5) | qubit
-	H | qubit
-	_compute.Uncompute(eng0)
-	eng0.flush(deallocate_qubits=True)
-	assert backend0.received_commands[0].gate == Allocate
-	assert backend0.received_commands[1].gate == Rx(0.5)
-	assert backend0.received_commands[2].gate == H
-	assert backend0.received_commands[3].gate == Rx(-0.5)
-	assert backend0.received_commands[4].gate == Deallocate
-	assert backend0.received_commands[0].tags == []
-	assert backend0.received_commands[1].tags == [_compute.ComputeTag()]
-	assert backend0.received_commands[2].tags == []
-	assert backend0.received_commands[3].tags == [_compute.UncomputeTag()]
-	assert backend0.received_commands[4].tags == []
-	# Same using CustomUncompute and test using CompareEngine
-	backend1 = DummyEngine(save_commands = True)
-	compare_engine1 = CompareEngine()
-	eng1 = MainEngine(backend=backend1, engine_list=[compare_engine1])
-	qubit = eng1.allocate_qubit()
-	with _compute.Compute(eng1):
-		Rx(0.5) | qubit
-	H | qubit
-	with _compute.CustomUncompute(eng1):
-		Rx(-0.5) | qubit
-	eng1.flush(deallocate_qubits=True)
-	assert compare_engine0 == compare_engine1
+    # No ancilla qubit created in compute section
+    backend0 = DummyEngine(save_commands=True)
+    compare_engine0 = CompareEngine()
+    eng0 = MainEngine(backend=backend0, engine_list=[compare_engine0])
+    qubit = eng0.allocate_qubit()
+    with _compute.Compute(eng0):
+        Rx(0.5) | qubit
+    H | qubit
+    _compute.Uncompute(eng0)
+    eng0.flush(deallocate_qubits=True)
+    assert backend0.received_commands[0].gate == Allocate
+    assert backend0.received_commands[1].gate == Rx(0.5)
+    assert backend0.received_commands[2].gate == H
+    assert backend0.received_commands[3].gate == Rx(-0.5)
+    assert backend0.received_commands[4].gate == Deallocate
+    assert backend0.received_commands[0].tags == []
+    assert backend0.received_commands[1].tags == [_compute.ComputeTag()]
+    assert backend0.received_commands[2].tags == []
+    assert backend0.received_commands[3].tags == [_compute.UncomputeTag()]
+    assert backend0.received_commands[4].tags == []
+    # Same using CustomUncompute and test using CompareEngine
+    backend1 = DummyEngine(save_commands = True)
+    compare_engine1 = CompareEngine()
+    eng1 = MainEngine(backend=backend1, engine_list=[compare_engine1])
+    qubit = eng1.allocate_qubit()
+    with _compute.Compute(eng1):
+        Rx(0.5) | qubit
+    H | qubit
+    with _compute.CustomUncompute(eng1):
+        Rx(-0.5) | qubit
+    eng1.flush(deallocate_qubits=True)
+    assert compare_engine0 == compare_engine1
 
 
 def test_compute_uncompute_with_statement():
-	# Allocating and deallocating qubit within Compute
-	backend = DummyEngine(save_commands=True)
-	compare_engine0 = CompareEngine()
-	# Allow dirty qubits
-	dummy_cengine = DummyEngine()
-	def allow_dirty_qubits(self, meta_tag):
-		return meta_tag == DirtyQubitTag
-	dummy_cengine.is_meta_tag_handler = types.MethodType(allow_dirty_qubits,
-	                                                     dummy_cengine)
-	eng = MainEngine(backend=backend, 
-	                 engine_list=[compare_engine0, dummy_cengine])
-	qubit = eng.allocate_qubit()
-	with _compute.Compute(eng):
-		Rx(0.9) | qubit
-		ancilla = eng.allocate_qubit(dirty=True)
-		ancilla2 = eng.allocate_qubit() # will be deallocated in Uncompute section
-		# Test that ancilla is registered in MainEngine.active_qubits:
-		assert ancilla[0] in eng.active_qubits
-		H | qubit
-		Rx(0.5) | ancilla
-		CNOT | (ancilla, qubit)
-		Rx(0.7) | qubit
-		Rx(-0.5) | ancilla
-		ancilla[0].__del__()
-	H | qubit
-	_compute.Uncompute(eng)
-	eng.flush(deallocate_qubits=True)
-	assert len(backend.received_commands) == 22
-	# Test each Command has correct gate
-	assert backend.received_commands[0].gate == Allocate
-	assert backend.received_commands[1].gate == Rx(0.9)
-	assert backend.received_commands[2].gate == Allocate
-	assert backend.received_commands[3].gate == Allocate
-	assert backend.received_commands[4].gate == H
-	assert backend.received_commands[5].gate == Rx(0.5)
-	assert backend.received_commands[6].gate == NOT
-	assert backend.received_commands[7].gate == Rx(0.7)
-	assert backend.received_commands[8].gate == Rx(-0.5)
-	assert backend.received_commands[9].gate == Deallocate
-	assert backend.received_commands[10].gate == H
-	assert backend.received_commands[11].gate == Allocate
-	assert backend.received_commands[12].gate == Rx(0.5)
-	assert backend.received_commands[13].gate == Rx(-0.7)
-	assert backend.received_commands[14].gate == NOT
-	assert backend.received_commands[15].gate == Rx(-0.5)
-	assert backend.received_commands[16].gate == H
-	assert backend.received_commands[17].gate == Deallocate	
-	assert backend.received_commands[18].gate == Deallocate
-	assert backend.received_commands[19].gate == Rx(-0.9)
-	assert backend.received_commands[20].gate == Deallocate
-	assert backend.received_commands[21].gate == FlushGate()
-	# Test that each command has correct tags
-	assert backend.received_commands[0].tags == []
-	assert backend.received_commands[1].tags == [_compute.ComputeTag()]	
-	assert backend.received_commands[2].tags == [DirtyQubitTag(),
-	                                             _compute.ComputeTag()]
-	for cmd in backend.received_commands[3:9]:
-		assert cmd.tags == [_compute.ComputeTag()]
-	assert backend.received_commands[9].tags == [DirtyQubitTag(),
-	                                             _compute.ComputeTag()]
-	assert backend.received_commands[10].tags == []
-	assert backend.received_commands[11].tags == [DirtyQubitTag(),
-	                                              _compute.UncomputeTag()]
-	for cmd in backend.received_commands[12:18]:
-		assert cmd.tags == [_compute.UncomputeTag()]
-	assert backend.received_commands[18].tags == [DirtyQubitTag(),
-	                                              _compute.UncomputeTag()]
-	assert backend.received_commands[19].tags == [_compute.UncomputeTag()]
-	assert backend.received_commands[20].tags == []
-	assert backend.received_commands[21].tags == []
-	# Test that each command has correct qubits
-	# Note that ancilla qubit in compute should be
-	# different from ancilla qubit in uncompute section
-	qubit_id = backend.received_commands[0].qubits[0][0].id
-	ancilla_compt_id = backend.received_commands[2].qubits[0][0].id
-	ancilla_uncompt_id = backend.received_commands[11].qubits[0][0].id
-	ancilla2_id = backend.received_commands[3].qubits[0][0].id
-	assert backend.received_commands[1].qubits[0][0].id == qubit_id
-	assert backend.received_commands[4].qubits[0][0].id == qubit_id
-	assert backend.received_commands[5].qubits[0][0].id == ancilla_compt_id
-	assert backend.received_commands[6].qubits[0][0].id == qubit_id
-	assert backend.received_commands[6].control_qubits[0].id == ancilla_compt_id
-	assert backend.received_commands[7].qubits[0][0].id == qubit_id
-	assert backend.received_commands[8].qubits[0][0].id == ancilla_compt_id
-	assert backend.received_commands[9].qubits[0][0].id == ancilla_compt_id
-	assert backend.received_commands[10].qubits[0][0].id == qubit_id
-	assert backend.received_commands[12].qubits[0][0].id == ancilla_uncompt_id
-	assert backend.received_commands[13].qubits[0][0].id == qubit_id
-	assert backend.received_commands[14].qubits[0][0].id == qubit_id
-	assert (backend.received_commands[14].control_qubits[0].id
-	        == ancilla_uncompt_id)
-	assert backend.received_commands[15].qubits[0][0].id == ancilla_uncompt_id
-	assert backend.received_commands[16].qubits[0][0].id == qubit_id
-	assert backend.received_commands[17].qubits[0][0].id == ancilla2_id
-	assert backend.received_commands[18].qubits[0][0].id == ancilla_uncompt_id
-	assert backend.received_commands[19].qubits[0][0].id == qubit_id
-	assert backend.received_commands[20].qubits[0][0].id == qubit_id
-	# Test that ancilla qubits should have seperate ids
-	assert ancilla_uncompt_id != ancilla_compt_id
+    # Allocating and deallocating qubit within Compute
+    backend = DummyEngine(save_commands=True)
+    compare_engine0 = CompareEngine()
+    # Allow dirty qubits
+    dummy_cengine = DummyEngine()
+    def allow_dirty_qubits(self, meta_tag):
+        return meta_tag == DirtyQubitTag
+    dummy_cengine.is_meta_tag_handler = types.MethodType(allow_dirty_qubits,
+                                                         dummy_cengine)
+    eng = MainEngine(backend=backend,
+                     engine_list=[compare_engine0, dummy_cengine])
+    qubit = eng.allocate_qubit()
+    with _compute.Compute(eng):
+        Rx(0.9) | qubit
+        ancilla = eng.allocate_qubit(dirty=True)
+        ancilla2 = eng.allocate_qubit() # will be deallocated in Uncompute section
+        # Test that ancilla is registered in MainEngine.active_qubits:
+        assert ancilla[0] in eng.active_qubits
+        H | qubit
+        Rx(0.5) | ancilla
+        CNOT | (ancilla, qubit)
+        Rx(0.7) | qubit
+        Rx(-0.5) | ancilla
+        ancilla[0].__del__()
+    H | qubit
+    _compute.Uncompute(eng)
+    eng.flush(deallocate_qubits=True)
+    assert len(backend.received_commands) == 22
+    # Test each Command has correct gate
+    assert backend.received_commands[0].gate == Allocate
+    assert backend.received_commands[1].gate == Rx(0.9)
+    assert backend.received_commands[2].gate == Allocate
+    assert backend.received_commands[3].gate == Allocate
+    assert backend.received_commands[4].gate == H
+    assert backend.received_commands[5].gate == Rx(0.5)
+    assert backend.received_commands[6].gate == NOT
+    assert backend.received_commands[7].gate == Rx(0.7)
+    assert backend.received_commands[8].gate == Rx(-0.5)
+    assert backend.received_commands[9].gate == Deallocate
+    assert backend.received_commands[10].gate == H
+    assert backend.received_commands[11].gate == Allocate
+    assert backend.received_commands[12].gate == Rx(0.5)
+    assert backend.received_commands[13].gate == Rx(-0.7)
+    assert backend.received_commands[14].gate == NOT
+    assert backend.received_commands[15].gate == Rx(-0.5)
+    assert backend.received_commands[16].gate == H
+    assert backend.received_commands[17].gate == Deallocate
+    assert backend.received_commands[18].gate == Deallocate
+    assert backend.received_commands[19].gate == Rx(-0.9)
+    assert backend.received_commands[20].gate == Deallocate
+    assert backend.received_commands[21].gate == FlushGate()
+    # Test that each command has correct tags
+    assert backend.received_commands[0].tags == []
+    assert backend.received_commands[1].tags == [_compute.ComputeTag()]
+    assert backend.received_commands[2].tags == [DirtyQubitTag(),
+                                                 _compute.ComputeTag()]
+    for cmd in backend.received_commands[3:9]:
+        assert cmd.tags == [_compute.ComputeTag()]
+    assert backend.received_commands[9].tags == [DirtyQubitTag(),
+                                                 _compute.ComputeTag()]
+    assert backend.received_commands[10].tags == []
+    assert backend.received_commands[11].tags == [DirtyQubitTag(),
+                                                  _compute.UncomputeTag()]
+    for cmd in backend.received_commands[12:18]:
+        assert cmd.tags == [_compute.UncomputeTag()]
+    assert backend.received_commands[18].tags == [DirtyQubitTag(),
+                                                  _compute.UncomputeTag()]
+    assert backend.received_commands[19].tags == [_compute.UncomputeTag()]
+    assert backend.received_commands[20].tags == []
+    assert backend.received_commands[21].tags == []
+    # Test that each command has correct qubits
+    # Note that ancilla qubit in compute should be
+    # different from ancilla qubit in uncompute section
+    qubit_id = backend.received_commands[0].qubits[0][0].id
+    ancilla_compt_id = backend.received_commands[2].qubits[0][0].id
+    ancilla_uncompt_id = backend.received_commands[11].qubits[0][0].id
+    ancilla2_id = backend.received_commands[3].qubits[0][0].id
+    assert backend.received_commands[1].qubits[0][0].id == qubit_id
+    assert backend.received_commands[4].qubits[0][0].id == qubit_id
+    assert backend.received_commands[5].qubits[0][0].id == ancilla_compt_id
+    assert backend.received_commands[6].qubits[0][0].id == qubit_id
+    assert backend.received_commands[6].control_qubits[0].id == ancilla_compt_id
+    assert backend.received_commands[7].qubits[0][0].id == qubit_id
+    assert backend.received_commands[8].qubits[0][0].id == ancilla_compt_id
+    assert backend.received_commands[9].qubits[0][0].id == ancilla_compt_id
+    assert backend.received_commands[10].qubits[0][0].id == qubit_id
+    assert backend.received_commands[12].qubits[0][0].id == ancilla_uncompt_id
+    assert backend.received_commands[13].qubits[0][0].id == qubit_id
+    assert backend.received_commands[14].qubits[0][0].id == qubit_id
+    assert (backend.received_commands[14].control_qubits[0].id
+            == ancilla_uncompt_id)
+    assert backend.received_commands[15].qubits[0][0].id == ancilla_uncompt_id
+    assert backend.received_commands[16].qubits[0][0].id == qubit_id
+    assert backend.received_commands[17].qubits[0][0].id == ancilla2_id
+    assert backend.received_commands[18].qubits[0][0].id == ancilla_uncompt_id
+    assert backend.received_commands[19].qubits[0][0].id == qubit_id
+    assert backend.received_commands[20].qubits[0][0].id == qubit_id
+    # Test that ancilla qubits should have seperate ids
+    assert ancilla_uncompt_id != ancilla_compt_id
 
-	# Do the same thing with CustomUncompute and compare using the CompareEngine:
-	backend1 = DummyEngine(save_commands=True)
-	compare_engine1 = CompareEngine()
-	# Allow dirty qubits
-	dummy_cengine1 = DummyEngine()
-	def allow_dirty_qubits(self, meta_tag):
-		return meta_tag == DirtyQubitTag
-	dummy_cengine1.is_meta_tag_handler = types.MethodType(allow_dirty_qubits,
-	                                                      dummy_cengine1)
-	eng1 = MainEngine(backend=backend1, 
-	                 engine_list=[compare_engine1, dummy_cengine1])
-	qubit = eng1.allocate_qubit()
-	with _compute.Compute(eng1):
-		Rx(0.9) | qubit
-		ancilla = eng1.allocate_qubit(dirty=True)
-		ancilla2 = eng1.allocate_qubit() # will be deallocated in Uncompute section
-		# Test that ancilla is registered in MainEngine.active_qubits:
-		assert ancilla[0] in eng1.active_qubits
-		H | qubit
-		Rx(0.5) | ancilla
-		CNOT | (ancilla, qubit)
-		Rx(0.7) | qubit
-		Rx(-0.5) | ancilla
-		ancilla[0].__del__()
-	H | qubit
-	with _compute.CustomUncompute(eng1):
-		ancilla = eng1.allocate_qubit(dirty=True)
-		Rx(0.5) | ancilla
-		Rx(-0.7) | qubit
-		CNOT | (ancilla, qubit)
-		Rx(-0.5) | ancilla
-		H | qubit
-		assert ancilla[0] in eng1.active_qubits
-		ancilla2[0].__del__()
-		ancilla[0].__del__()
-		Rx(-0.9) | qubit
-	eng1.flush(deallocate_qubits=True)
-	assert compare_engine0 == compare_engine1
+    # Do the same thing with CustomUncompute and compare using the CompareEngine:
+    backend1 = DummyEngine(save_commands=True)
+    compare_engine1 = CompareEngine()
+    # Allow dirty qubits
+    dummy_cengine1 = DummyEngine()
+    def allow_dirty_qubits(self, meta_tag):
+        return meta_tag == DirtyQubitTag
+    dummy_cengine1.is_meta_tag_handler = types.MethodType(allow_dirty_qubits,
+                                                          dummy_cengine1)
+    eng1 = MainEngine(backend=backend1,
+                     engine_list=[compare_engine1, dummy_cengine1])
+    qubit = eng1.allocate_qubit()
+    with _compute.Compute(eng1):
+        Rx(0.9) | qubit
+        ancilla = eng1.allocate_qubit(dirty=True)
+        ancilla2 = eng1.allocate_qubit() # will be deallocated in Uncompute section
+        # Test that ancilla is registered in MainEngine.active_qubits:
+        assert ancilla[0] in eng1.active_qubits
+        H | qubit
+        Rx(0.5) | ancilla
+        CNOT | (ancilla, qubit)
+        Rx(0.7) | qubit
+        Rx(-0.5) | ancilla
+        ancilla[0].__del__()
+    H | qubit
+    with _compute.CustomUncompute(eng1):
+        ancilla = eng1.allocate_qubit(dirty=True)
+        Rx(0.5) | ancilla
+        Rx(-0.7) | qubit
+        CNOT | (ancilla, qubit)
+        Rx(-0.5) | ancilla
+        H | qubit
+        assert ancilla[0] in eng1.active_qubits
+        ancilla2[0].__del__()
+        ancilla[0].__del__()
+        Rx(-0.9) | qubit
+    eng1.flush(deallocate_qubits=True)
+    assert compare_engine0 == compare_engine1
 
 
 def test_exception_if_no_compute_but_uncompute():
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	with pytest.raises(_compute.NoComputeSectionError):
-		with _compute.CustomUncompute(eng):
-			pass
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    with pytest.raises(_compute.NoComputeSectionError):
+        with _compute.CustomUncompute(eng):
+            pass
 
 
 def test_exception_if_no_compute_but_uncompute2():
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	with pytest.raises(_compute.NoComputeSectionError):
-		_compute.Uncompute(eng)
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    with pytest.raises(_compute.NoComputeSectionError):
+        _compute.Uncompute(eng)
 
 
 def test_qubit_management_error():
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	with _compute.Compute(eng):
-		ancilla = eng.allocate_qubit()
-	eng.active_qubits = weakref.WeakSet()
-	with pytest.raises(_compute.QubitManagementError):
-		_compute.Uncompute(eng)
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    with _compute.Compute(eng):
+        ancilla = eng.allocate_qubit()
+    eng.active_qubits = weakref.WeakSet()
+    with pytest.raises(_compute.QubitManagementError):
+        _compute.Uncompute(eng)
 
 
 def test_qubit_management_error2():
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	with _compute.Compute(eng):
-		ancilla = eng.allocate_qubit()
-		local_ancilla = eng.allocate_qubit()
-		local_ancilla[0].__del__()
-	eng.active_qubits = weakref.WeakSet()
-	with pytest.raises(_compute.QubitManagementError):
-		_compute.Uncompute(eng)
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    with _compute.Compute(eng):
+        ancilla = eng.allocate_qubit()
+        local_ancilla = eng.allocate_qubit()
+        local_ancilla[0].__del__()
+    eng.active_qubits = weakref.WeakSet()
+    with pytest.raises(_compute.QubitManagementError):
+        _compute.Uncompute(eng)

--- a/projectq/meta/_control.py
+++ b/projectq/meta/_control.py
@@ -14,11 +14,11 @@
 Contains the tools to make an entire section of operations controlled.
 
 Example:
-	.. code-block:: python
-	
-		with Control(eng, qubit1):
-			H | qubit2
-			X | qubit3
+    .. code-block:: python
+
+        with Control(eng, qubit1):
+            H | qubit2
+            X | qubit3
 """
 
 from projectq.cengines import BasicEngine
@@ -28,94 +28,94 @@ from projectq.types import BasicQubit
 
 
 class ControlEngine(BasicEngine):
-	"""
-	Adds control qubits to all commands that have no compute / uncompute tags.
-	"""
+    """
+    Adds control qubits to all commands that have no compute / uncompute tags.
+    """
 
-	def __init__(self, qubits):
-		"""
-		Initialize the control engine.
+    def __init__(self, qubits):
+        """
+        Initialize the control engine.
 
-		Args:
-			qubits (list of Qubit objects): qubits conditional on which the following
-			operations are executed.
-		"""
-		BasicEngine.__init__(self)
-		self._qubits = qubits
+        Args:
+            qubits (list of Qubit objects): qubits conditional on which the following
+            operations are executed.
+        """
+        BasicEngine.__init__(self)
+        self._qubits = qubits
 
-	def _has_compute_uncompute_tag(self, cmd):
-		"""
-		Return True if command cmd has a compute/uncompute tag.
+    def _has_compute_uncompute_tag(self, cmd):
+        """
+        Return True if command cmd has a compute/uncompute tag.
 
-		Args:
-			cmd (Command object): a command object.
-		"""
-		for t in cmd.tags:
-			if t in [UncomputeTag(), ComputeTag()]:
-				return True
-		return False
+        Args:
+            cmd (Command object): a command object.
+        """
+        for t in cmd.tags:
+            if t in [UncomputeTag(), ComputeTag()]:
+                return True
+        return False
 
-	def _handle_command(self, cmd):
-		if (not self._has_compute_uncompute_tag(cmd) and not
-					isinstance(cmd.gate, ClassicalInstructionGate)):
-			cmd.add_control_qubits(self._qubits)
-		self.send([cmd])
+    def _handle_command(self, cmd):
+        if (not self._has_compute_uncompute_tag(cmd) and not
+                    isinstance(cmd.gate, ClassicalInstructionGate)):
+            cmd.add_control_qubits(self._qubits)
+        self.send([cmd])
 
-	def receive(self, command_list):
-		for cmd in command_list:
-			self._handle_command(cmd)
+    def receive(self, command_list):
+        for cmd in command_list:
+            self._handle_command(cmd)
 
 
 class Control(object):
-	"""
-	Condition an entire code block on the value of qubits being 1.
+    """
+    Condition an entire code block on the value of qubits being 1.
 
-	Example:
-		.. code-block:: python
-		
-			with Control(eng, ctrlqubits):
-				do_something(otherqubits)
-	"""
+    Example:
+        .. code-block:: python
 
-	def __init__(self, engine, qubits):
-		"""
-		Enter a controlled section.
+            with Control(eng, ctrlqubits):
+                do_something(otherqubits)
+    """
 
-		Args:
-			engine: Engine which handles the commands (usually MainEngine)
-			qubits (list of Qubit objects): Qubits to condition on
+    def __init__(self, engine, qubits):
+        """
+        Enter a controlled section.
 
-		Enter the section using a with-statement:
-		
-		.. code-block:: python
-		
-			with Control(eng, ctrlqubits):
-				...
-		"""
-		self.engine = engine
-		assert(not isinstance(qubits, tuple))
-		if isinstance(qubits, BasicQubit):
-			qubits = [qubits]
-		self._qubits = qubits
+        Args:
+            engine: Engine which handles the commands (usually MainEngine)
+            qubits (list of Qubit objects): Qubits to condition on
 
-	def __enter__(self):
-		if len(self._qubits) > 0:
-			ce = ControlEngine(self._qubits)
-			ce.main_engine = self.engine.main_engine
-			oldnext = self.engine.next_engine
-			self.engine.next_engine = ce
-			ce.next_engine = oldnext
-			self._ce = ce
+        Enter the section using a with-statement:
 
-	def __exit__(self, type, value, traceback):
-		# remove control handler from engine list (i.e. skip it)
-		if len(self._qubits) > 0:
-			oldnext = self._ce.next_engine
-			self.engine.next_engine = oldnext
+        .. code-block:: python
+
+            with Control(eng, ctrlqubits):
+                ...
+        """
+        self.engine = engine
+        assert(not isinstance(qubits, tuple))
+        if isinstance(qubits, BasicQubit):
+            qubits = [qubits]
+        self._qubits = qubits
+
+    def __enter__(self):
+        if len(self._qubits) > 0:
+            ce = ControlEngine(self._qubits)
+            ce.main_engine = self.engine.main_engine
+            oldnext = self.engine.next_engine
+            self.engine.next_engine = ce
+            ce.next_engine = oldnext
+            self._ce = ce
+
+    def __exit__(self, type, value, traceback):
+        # remove control handler from engine list (i.e. skip it)
+        if len(self._qubits) > 0:
+            oldnext = self._ce.next_engine
+            self.engine.next_engine = oldnext
 
 
 def get_control_count(cmd):
-	"""
-	Return the number of control qubits of the command object cmd
-	"""
-	return len(cmd.control_qubits)
+    """
+    Return the number of control qubits of the command object cmd
+    """
+    return len(cmd.control_qubits)

--- a/projectq/meta/_control_test.py
+++ b/projectq/meta/_control_test.py
@@ -15,52 +15,52 @@
 from projectq import MainEngine
 from projectq.cengines import DummyEngine
 from projectq.ops import Command, H, Rx
-from projectq.meta import (DirtyQubitTag, 
-                           ComputeTag, 
-                           UncomputeTag, 
-                           Compute, 
+from projectq.meta import (DirtyQubitTag,
+                           ComputeTag,
+                           UncomputeTag,
+                           Compute,
                            Uncompute)
 
 from projectq.meta import _control
 
 
 def test_control_engine_has_compute_tag():
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	qubit = eng.allocate_qubit()
-	test_cmd0 = Command(eng, H, (qubit,))
-	test_cmd1 = Command(eng, H, (qubit,))
-	test_cmd2 = Command(eng, H, (qubit,))
-	test_cmd0.tags = [DirtyQubitTag(), ComputeTag(), DirtyQubitTag()]
-	test_cmd1.tags = [DirtyQubitTag(), UncomputeTag(), DirtyQubitTag()]
-	test_cmd2.tags = [DirtyQubitTag()]
-	control_eng = _control.ControlEngine("MockEng")
-	assert control_eng._has_compute_uncompute_tag(test_cmd0)
-	assert control_eng._has_compute_uncompute_tag(test_cmd1)
-	assert not control_eng._has_compute_uncompute_tag(test_cmd2)
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    qubit = eng.allocate_qubit()
+    test_cmd0 = Command(eng, H, (qubit,))
+    test_cmd1 = Command(eng, H, (qubit,))
+    test_cmd2 = Command(eng, H, (qubit,))
+    test_cmd0.tags = [DirtyQubitTag(), ComputeTag(), DirtyQubitTag()]
+    test_cmd1.tags = [DirtyQubitTag(), UncomputeTag(), DirtyQubitTag()]
+    test_cmd2.tags = [DirtyQubitTag()]
+    control_eng = _control.ControlEngine("MockEng")
+    assert control_eng._has_compute_uncompute_tag(test_cmd0)
+    assert control_eng._has_compute_uncompute_tag(test_cmd1)
+    assert not control_eng._has_compute_uncompute_tag(test_cmd2)
 
 
 def test_control():
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	qureg = eng.allocate_qureg(2)
-	with _control.Control(eng, qureg):
-		qubit = eng.allocate_qubit()
-		with Compute(eng):
-			Rx(0.5) | qubit
-		H | qubit
-		Uncompute(eng)
-	with _control.Control(eng, qureg[0]):
-		H | qubit
-	eng.flush()
-	assert len(backend.received_commands) == 8
-	assert len(backend.received_commands[0].control_qubits) == 0
-	assert len(backend.received_commands[1].control_qubits) == 0
-	assert len(backend.received_commands[2].control_qubits) == 0
-	assert len(backend.received_commands[3].control_qubits) == 0
-	assert len(backend.received_commands[4].control_qubits) == 2
-	assert len(backend.received_commands[5].control_qubits) == 0
-	assert len(backend.received_commands[6].control_qubits) == 1
-	assert len(backend.received_commands[7].control_qubits) == 0
-	assert backend.received_commands[4].control_qubits[0].id == qureg[0].id
-	assert backend.received_commands[4].control_qubits[1].id == qureg[1].id
-	assert backend.received_commands[6].control_qubits[0].id == qureg[0].id
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+    qureg = eng.allocate_qureg(2)
+    with _control.Control(eng, qureg):
+        qubit = eng.allocate_qubit()
+        with Compute(eng):
+            Rx(0.5) | qubit
+        H | qubit
+        Uncompute(eng)
+    with _control.Control(eng, qureg[0]):
+        H | qubit
+    eng.flush()
+    assert len(backend.received_commands) == 8
+    assert len(backend.received_commands[0].control_qubits) == 0
+    assert len(backend.received_commands[1].control_qubits) == 0
+    assert len(backend.received_commands[2].control_qubits) == 0
+    assert len(backend.received_commands[3].control_qubits) == 0
+    assert len(backend.received_commands[4].control_qubits) == 2
+    assert len(backend.received_commands[5].control_qubits) == 0
+    assert len(backend.received_commands[6].control_qubits) == 1
+    assert len(backend.received_commands[7].control_qubits) == 0
+    assert backend.received_commands[4].control_qubits[0].id == qureg[0].id
+    assert backend.received_commands[4].control_qubits[1].id == qureg[1].id
+    assert backend.received_commands[6].control_qubits[0].id == qureg[0].id

--- a/projectq/meta/_dagger.py
+++ b/projectq/meta/_dagger.py
@@ -15,9 +15,9 @@ Tools to easily invert a sequence of gates.
 
 .. code-block:: python
 
-	with Dagger(eng):
-		H | qubit1
-		Rz(0.5) | qubit2
+    with Dagger(eng):
+        H | qubit1
+        Rz(0.5) | qubit2
 """
 
 from projectq.cengines import BasicEngine
@@ -26,114 +26,114 @@ from projectq.meta import DirtyQubitTag
 
 
 class QubitManagementError(Exception):
-	pass
+    pass
 
 
 class DaggerEngine(BasicEngine):
-	"""
-	Stores all commands and, when done, inverts the circuit & runs it.
-	"""
+    """
+    Stores all commands and, when done, inverts the circuit & runs it.
+    """
 
-	def __init__(self):
-		BasicEngine.__init__(self)
-		self._commands = []
-		self._allocated_qubit_ids = set()
-		self._deallocated_qubit_ids = set()
+    def __init__(self):
+        BasicEngine.__init__(self)
+        self._commands = []
+        self._allocated_qubit_ids = set()
+        self._deallocated_qubit_ids = set()
 
-	def run(self):
-		"""
-		Run the stored circuit in reverse and check that local qubits
-		have been deallocated.
-		"""
-		if self._deallocated_qubit_ids != self._allocated_qubit_ids:
-				raise QubitManagementError(
-				    "\n Error. Qubits have been allocated in 'with " +
-				    "Dagger(eng)' context,\n which have not explicitely " +
-				    "been deallocated.\n" +
-				    "Correct usage:\n" +
-				    "with Dagger(eng):\n" +
-				    "    qubit = eng.allocate_qubit()\n" +
-				    "    ...\n" +
-				    "    del qubit[0]\n")
+    def run(self):
+        """
+        Run the stored circuit in reverse and check that local qubits
+        have been deallocated.
+        """
+        if self._deallocated_qubit_ids != self._allocated_qubit_ids:
+                raise QubitManagementError(
+                    "\n Error. Qubits have been allocated in 'with " +
+                    "Dagger(eng)' context,\n which have not explicitely " +
+                    "been deallocated.\n" +
+                    "Correct usage:\n" +
+                    "with Dagger(eng):\n" +
+                    "    qubit = eng.allocate_qubit()\n" +
+                    "    ...\n" +
+                    "    del qubit[0]\n")
 
-		for cmd in reversed(self._commands):
-				self.send([cmd.get_inverse()])
+        for cmd in reversed(self._commands):
+                self.send([cmd.get_inverse()])
 
-	def receive(self, command_list):
-		"""
-		Receive a list of commands and store them for later inversion.
-		
-		Args:
-			command_list (list<Command>): List of commands to temporarily store.
-		"""
-		for cmd in command_list:
-			if cmd.gate == Allocate:
-				self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
-			elif cmd.gate == Deallocate:
-				self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
-		self._commands.extend(command_list)
+    def receive(self, command_list):
+        """
+        Receive a list of commands and store them for later inversion.
+
+        Args:
+            command_list (list<Command>): List of commands to temporarily store.
+        """
+        for cmd in command_list:
+            if cmd.gate == Allocate:
+                self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
+            elif cmd.gate == Deallocate:
+                self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
+        self._commands.extend(command_list)
 
 
 class Dagger(object):
-	"""
-	Invert an entire code block.
+    """
+    Invert an entire code block.
 
-	Use it with a with-statement, i.e.,
-	
-	.. code-block:: python
-	
-		with Dagger(eng):
-			[code to invert]
-	
-	Warning:
-		If the code to invert contains allocation of qubits, those qubits have
-		to be deleted prior to exiting the 'with Dagger()' context.
-		
-		This code is **NOT VALID**:
-		
-		.. code-block:: python
-		
-			with Dagger(eng):
-				qb = eng.allocate_qubit()
-				H | qb # qb is still available!!!
-		
-		The **correct way** of handling qubit (de-)allocation is as follows:
-		
-		.. code-block:: python
-		
-			with Dagger(eng):
-				qb = eng.allocate_qubit()
-				...
-				del qb # sends deallocate gate (which becomes an allocate)
-	"""
+    Use it with a with-statement, i.e.,
 
-	def __init__(self, engine):
-		"""
-		Enter an inverted section.
+    .. code-block:: python
 
-		Args:
-			engine: Engine which handles the commands (usually MainEngine)
+        with Dagger(eng):
+            [code to invert]
 
-		Example (executes an inverse QFT):
-		
-		.. code-block:: python
-		
-			with Dagger(eng):
-				QFT | qubits
-		"""
-		self.engine = engine
+    Warning:
+        If the code to invert contains allocation of qubits, those qubits have
+        to be deleted prior to exiting the 'with Dagger()' context.
 
-	def __enter__(self):
-		dagger_eng = DaggerEngine()
-		dagger_eng.main_engine = self.engine.main_engine
-		oldnext = self.engine.next_engine
-		self.engine.next_engine = dagger_eng
-		dagger_eng.next_engine = oldnext
-		self._dagger_eng = dagger_eng
+        This code is **NOT VALID**:
 
-	def __exit__(self, type, value, traceback):
-		# run dagger engine
-		self._dagger_eng.run()
-		# remove dagger handler from engine list (i.e. skip it)
-		oldnext = self._dagger_eng.next_engine
-		self.engine.next_engine = oldnext
+        .. code-block:: python
+
+            with Dagger(eng):
+                qb = eng.allocate_qubit()
+                H | qb # qb is still available!!!
+
+        The **correct way** of handling qubit (de-)allocation is as follows:
+
+        .. code-block:: python
+
+            with Dagger(eng):
+                qb = eng.allocate_qubit()
+                ...
+                del qb # sends deallocate gate (which becomes an allocate)
+    """
+
+    def __init__(self, engine):
+        """
+        Enter an inverted section.
+
+        Args:
+            engine: Engine which handles the commands (usually MainEngine)
+
+        Example (executes an inverse QFT):
+
+        .. code-block:: python
+
+            with Dagger(eng):
+                QFT | qubits
+        """
+        self.engine = engine
+
+    def __enter__(self):
+        dagger_eng = DaggerEngine()
+        dagger_eng.main_engine = self.engine.main_engine
+        oldnext = self.engine.next_engine
+        self.engine.next_engine = dagger_eng
+        dagger_eng.next_engine = oldnext
+        self._dagger_eng = dagger_eng
+
+    def __exit__(self, type, value, traceback):
+        # run dagger engine
+        self._dagger_eng.run()
+        # remove dagger handler from engine list (i.e. skip it)
+        oldnext = self._dagger_eng.next_engine
+        self.engine.next_engine = oldnext

--- a/projectq/meta/_dagger_test.py
+++ b/projectq/meta/_dagger_test.py
@@ -24,37 +24,37 @@ from projectq.meta import _dagger
 
 
 def test_dagger_with_dirty_qubits():
-	backend = DummyEngine(save_commands=True)
-	
-	def allow_dirty_qubits(self, meta_tag):
-		return meta_tag == DirtyQubitTag
-	
-	backend.is_meta_tag_handler = types.MethodType(allow_dirty_qubits, backend)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	qubit = eng.allocate_qubit()
-	with _dagger.Dagger(eng):
-		ancilla = eng.allocate_qubit(dirty=True)
-		Rx(0.6) | ancilla
-		CNOT | (ancilla, qubit)
-		H | qubit
-		Rx(-0.6) | ancilla
-		del ancilla[0]
-	eng.flush(deallocate_qubits=True)
-	assert len(backend.received_commands) == 9
-	assert backend.received_commands[0].gate == Allocate
-	assert backend.received_commands[1].gate == Allocate
-	assert backend.received_commands[2].gate == Rx(0.6)
-	assert backend.received_commands[3].gate == H
-	assert backend.received_commands[4].gate == X
-	assert backend.received_commands[5].gate == Rx(-0.6)
-	assert backend.received_commands[6].gate == Deallocate
-	assert backend.received_commands[7].gate == Deallocate
-	assert backend.received_commands[1].tags == [DirtyQubitTag()]
-	assert backend.received_commands[6].tags == [DirtyQubitTag()]
+    backend = DummyEngine(save_commands=True)
+
+    def allow_dirty_qubits(self, meta_tag):
+        return meta_tag == DirtyQubitTag
+
+    backend.is_meta_tag_handler = types.MethodType(allow_dirty_qubits, backend)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+    qubit = eng.allocate_qubit()
+    with _dagger.Dagger(eng):
+        ancilla = eng.allocate_qubit(dirty=True)
+        Rx(0.6) | ancilla
+        CNOT | (ancilla, qubit)
+        H | qubit
+        Rx(-0.6) | ancilla
+        del ancilla[0]
+    eng.flush(deallocate_qubits=True)
+    assert len(backend.received_commands) == 9
+    assert backend.received_commands[0].gate == Allocate
+    assert backend.received_commands[1].gate == Allocate
+    assert backend.received_commands[2].gate == Rx(0.6)
+    assert backend.received_commands[3].gate == H
+    assert backend.received_commands[4].gate == X
+    assert backend.received_commands[5].gate == Rx(-0.6)
+    assert backend.received_commands[6].gate == Deallocate
+    assert backend.received_commands[7].gate == Deallocate
+    assert backend.received_commands[1].tags == [DirtyQubitTag()]
+    assert backend.received_commands[6].tags == [DirtyQubitTag()]
 
 
 def test_dagger_qubit_management_error():
-	eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-	with pytest.raises(_dagger.QubitManagementError):
-		with _dagger.Dagger(eng):
-			ancilla = eng.allocate_qubit()
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    with pytest.raises(_dagger.QubitManagementError):
+        with _dagger.Dagger(eng):
+            ancilla = eng.allocate_qubit()

--- a/projectq/meta/_dirtyqubit.py
+++ b/projectq/meta/_dirtyqubit.py
@@ -16,11 +16,11 @@ Defines the DirtyQubitTag meta tag.
 
 
 class DirtyQubitTag(object):
-	"""
-	Dirty qubit meta tag
-	"""
-	def __eq__(self, other):
-		return isinstance(other, DirtyQubitTag)
+    """
+    Dirty qubit meta tag
+    """
+    def __eq__(self, other):
+        return isinstance(other, DirtyQubitTag)
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __ne__(self, other):
+        return not self.__eq__(other)

--- a/projectq/meta/_dirtyqubit_test.py
+++ b/projectq/meta/_dirtyqubit_test.py
@@ -18,9 +18,9 @@ from projectq.meta import _dirtyqubit
 
 
 def test_dirty_qubit_tag():
-	tag0 = _dirtyqubit.DirtyQubitTag()
-	tag1 = _dirtyqubit.DirtyQubitTag()
-	tag2 = ComputeTag()
-	assert tag0 == tag1
-	assert not tag0 != tag1
-	assert not tag0 == tag2
+    tag0 = _dirtyqubit.DirtyQubitTag()
+    tag1 = _dirtyqubit.DirtyQubitTag()
+    tag2 = ComputeTag()
+    assert tag0 == tag1
+    assert not tag0 != tag1
+    assert not tag0 == tag2

--- a/projectq/meta/_loop.py
+++ b/projectq/meta/_loop.py
@@ -14,11 +14,11 @@
 Tools to implement loops.
 
 Example:
-	.. code-block:: python
-	
-		with Loop(eng, 4):
-			H | qb
-		Rz(M_PI/3.) | qb
+    .. code-block:: python
+
+        with Loop(eng, 4):
+            H | qb
+        Rz(M_PI/3.) | qb
 """
 
 from copy import deepcopy
@@ -29,222 +29,222 @@ from projectq.cengines import BasicEngine
 
 
 class QubitManagementError(Exception):
-	pass
+    pass
 
 
 class LoopTag(object):
-	"""
-	Loop meta tag
-	"""
-	def __init__(self, num):
-		self.num = num
-		self.id = LoopTag.loop_tag_id
-		LoopTag.loop_tag_id += 1
+    """
+    Loop meta tag
+    """
+    def __init__(self, num):
+        self.num = num
+        self.id = LoopTag.loop_tag_id
+        LoopTag.loop_tag_id += 1
 
-	def __eq__(self, other):
-		return (isinstance(other, LoopTag) and self.id == other.id
-		        and self.num == other.num)
+    def __eq__(self, other):
+        return (isinstance(other, LoopTag) and self.id == other.id
+                and self.num == other.num)
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
-	loop_tag_id = 0
+    loop_tag_id = 0
 
 
 class LoopEngine(BasicEngine):
-	"""
-	Stores all commands and, when done, executes them num times if no loop tag
-	handler engine is available.
-	If there is one, it adds a loop_tag to the commands and sends them on.
-	"""
+    """
+    Stores all commands and, when done, executes them num times if no loop tag
+    handler engine is available.
+    If there is one, it adds a loop_tag to the commands and sends them on.
+    """
 
-	def __init__(self, num):
-		"""
-		Initialize a LoopEngine.
-		
-		Args:
-			num (int): Number of loop iterations.
-		"""
-		BasicEngine.__init__(self)
-		self._tag = LoopTag(num)
-		self._cmd_list = []
-		self._allocated_qubit_ids = set()
-		self._deallocated_qubit_ids = set()
-		# key: qubit id of a local qubit, i.e. a qubit which has been allocated
-		#      and deallocated within the loop body.
-		# value: list contain reference to each weakref qubit with this qubit id
-		#        either within control_qubits or qubits.
-		self._refs_to_local_qb = dict()
-		self._next_engines_support_loop_tag = False
+    def __init__(self, num):
+        """
+        Initialize a LoopEngine.
 
-	def run(self):
-		"""
-		Apply the loop statements to all stored commands.
-		
-		Unrolls the loop if LoopTag is not supported by any of the following
-		engines, i.e., if
-		
-		.. code-block:: python
-			is_meta_tag_supported(next_engine, LoopTag) == False
-		"""
-		error_message = ("\n Error. Qubits have been allocated in with " +
-					"Loop(eng, num) context,\n which have not explicitely " +
-					"been deallocated in the Loop context.\n" +
-					"Correct usage:\n" +
-					"with Loop(eng, 5):\n" +
-					"    qubit = eng.allocate_qubit()\n" +
-					"    ...\n" +
-					"    del qubit[0]\n")
-		if not self._next_engines_support_loop_tag:
-			# Unroll the loop
-			# Check that local qubits have been deallocated:
-			if self._deallocated_qubit_ids != self._allocated_qubit_ids:
-				raise QubitManagementError(error_message)
+        Args:
+            num (int): Number of loop iterations.
+        """
+        BasicEngine.__init__(self)
+        self._tag = LoopTag(num)
+        self._cmd_list = []
+        self._allocated_qubit_ids = set()
+        self._deallocated_qubit_ids = set()
+        # key: qubit id of a local qubit, i.e. a qubit which has been allocated
+        #      and deallocated within the loop body.
+        # value: list contain reference to each weakref qubit with this qubit id
+        #        either within control_qubits or qubits.
+        self._refs_to_local_qb = dict()
+        self._next_engines_support_loop_tag = False
 
-			if len(self._allocated_qubit_ids) == 0:
-				# No local qubits, just send the circuit num times
-				for i in range(self._tag.num):
-					self.send(deepcopy(self._cmd_list))
-			else:
-				# Ancilla qubits have been allocated in loop body
-				# For each iteration, allocate and deallocate a new qubit and
-				# replace the qubit id in all commands using it.
-				for i in range(self._tag.num):
-					if i == 0: # Don't change local qubit ids
-						self.send(deepcopy(self._cmd_list))
-					else:
-						# Change local qubit ids before sending them
-						for refs_loc_qubit in self._refs_to_local_qb.values():
-							new_qb_id = self.main_engine.get_new_qubit_id()
-							for qubit_ref in refs_loc_qubit:
-								qubit_ref.id = new_qb_id
-						self.send(deepcopy(self._cmd_list))
-		else:
-			# Next engines support loop tag so no unrolling needed only
-			# check that all qubits have been deallocated which have been
-			# allocated in the loop body
-			if self._deallocated_qubit_ids != self._allocated_qubit_ids:
-				raise QubitManagementError(error_message)
-	
-	def receive(self, command_list):
-		"""
-		Receive (and potentially temporarily store) all commands.
+    def run(self):
+        """
+        Apply the loop statements to all stored commands.
 
-		Add LoopTag to all receiving commands and send to the next engine if
-		a further engine is a LoopTag-handling engine. Otherwise store all
-		commands (to later unroll them). Check that within the loop body,
-		all allocated qubits have also been deallocated. If loop needs to be
-		unrolled and ancilla qubits have been allocated within the loop body, 
-		then store a reference all these qubit ids (to change them when 
-		unrolling the loop)
-		
-		Args:
-			command_list (list<Command>): List of commands to store and later unroll
-				or, if there is a LoopTag-handling engine, add the LoopTag.
-		"""
-		if (self._next_engines_support_loop_tag or 
-			self.next_engine.is_meta_tag_supported(LoopTag)):
-			# Loop tag is supported, send everything with a LoopTag
-			# Don't check is_meta_tag_supported anymore
-			self._next_engines_support_loop_tag = True
-			for cmd in command_list:
-				if cmd.gate == Allocate:
-					self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
-				elif cmd.gate == Deallocate:
-					self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
-				cmd.tags.append(self._tag)
-				self.send([cmd])
-		else:
-			# LoopTag is not supported, save the full loop body
-			self._cmd_list += command_list
-			# Check for all local qubits allocated and deallocated in loop body
-			for cmd in command_list:
-				if cmd.gate == Allocate:
-					self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
-					# Save reference to this local qubit
-					self._refs_to_local_qb[cmd.qubits[0][0].id] = (
-						                                [cmd.qubits[0][0]])
-				elif cmd.gate == Deallocate:
-					self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
-					# Save reference to this local qubit
-					self._refs_to_local_qb[cmd.qubits[0][0].id].append(
-						                                cmd.qubits[0][0])
-				else:
-					# Add a reference to each place a local qubit id is
-					# used as within either control_qubit or qubits
-					for control_qubit in cmd.control_qubits:
-						if control_qubit.id in self._allocated_qubit_ids:
-							self._refs_to_local_qb[control_qubit.id].append(
-						                                      control_qubit)
-					for qureg in cmd.qubits:
-						for qubit in qureg:
-							if qubit.id in self._allocated_qubit_ids:
-								self._refs_to_local_qb[qubit.id].append(
-						                                              qubit)
+        Unrolls the loop if LoopTag is not supported by any of the following
+        engines, i.e., if
+
+        .. code-block:: python
+            is_meta_tag_supported(next_engine, LoopTag) == False
+        """
+        error_message = ("\n Error. Qubits have been allocated in with " +
+                    "Loop(eng, num) context,\n which have not explicitely " +
+                    "been deallocated in the Loop context.\n" +
+                    "Correct usage:\n" +
+                    "with Loop(eng, 5):\n" +
+                    "    qubit = eng.allocate_qubit()\n" +
+                    "    ...\n" +
+                    "    del qubit[0]\n")
+        if not self._next_engines_support_loop_tag:
+            # Unroll the loop
+            # Check that local qubits have been deallocated:
+            if self._deallocated_qubit_ids != self._allocated_qubit_ids:
+                raise QubitManagementError(error_message)
+
+            if len(self._allocated_qubit_ids) == 0:
+                # No local qubits, just send the circuit num times
+                for i in range(self._tag.num):
+                    self.send(deepcopy(self._cmd_list))
+            else:
+                # Ancilla qubits have been allocated in loop body
+                # For each iteration, allocate and deallocate a new qubit and
+                # replace the qubit id in all commands using it.
+                for i in range(self._tag.num):
+                    if i == 0: # Don't change local qubit ids
+                        self.send(deepcopy(self._cmd_list))
+                    else:
+                        # Change local qubit ids before sending them
+                        for refs_loc_qubit in self._refs_to_local_qb.values():
+                            new_qb_id = self.main_engine.get_new_qubit_id()
+                            for qubit_ref in refs_loc_qubit:
+                                qubit_ref.id = new_qb_id
+                        self.send(deepcopy(self._cmd_list))
+        else:
+            # Next engines support loop tag so no unrolling needed only
+            # check that all qubits have been deallocated which have been
+            # allocated in the loop body
+            if self._deallocated_qubit_ids != self._allocated_qubit_ids:
+                raise QubitManagementError(error_message)
+
+    def receive(self, command_list):
+        """
+        Receive (and potentially temporarily store) all commands.
+
+        Add LoopTag to all receiving commands and send to the next engine if
+        a further engine is a LoopTag-handling engine. Otherwise store all
+        commands (to later unroll them). Check that within the loop body,
+        all allocated qubits have also been deallocated. If loop needs to be
+        unrolled and ancilla qubits have been allocated within the loop body,
+        then store a reference all these qubit ids (to change them when
+        unrolling the loop)
+
+        Args:
+            command_list (list<Command>): List of commands to store and later unroll
+                or, if there is a LoopTag-handling engine, add the LoopTag.
+        """
+        if (self._next_engines_support_loop_tag or
+            self.next_engine.is_meta_tag_supported(LoopTag)):
+            # Loop tag is supported, send everything with a LoopTag
+            # Don't check is_meta_tag_supported anymore
+            self._next_engines_support_loop_tag = True
+            for cmd in command_list:
+                if cmd.gate == Allocate:
+                    self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
+                elif cmd.gate == Deallocate:
+                    self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
+                cmd.tags.append(self._tag)
+                self.send([cmd])
+        else:
+            # LoopTag is not supported, save the full loop body
+            self._cmd_list += command_list
+            # Check for all local qubits allocated and deallocated in loop body
+            for cmd in command_list:
+                if cmd.gate == Allocate:
+                    self._allocated_qubit_ids.add(cmd.qubits[0][0].id)
+                    # Save reference to this local qubit
+                    self._refs_to_local_qb[cmd.qubits[0][0].id] = (
+                                                        [cmd.qubits[0][0]])
+                elif cmd.gate == Deallocate:
+                    self._deallocated_qubit_ids.add(cmd.qubits[0][0].id)
+                    # Save reference to this local qubit
+                    self._refs_to_local_qb[cmd.qubits[0][0].id].append(
+                                                        cmd.qubits[0][0])
+                else:
+                    # Add a reference to each place a local qubit id is
+                    # used as within either control_qubit or qubits
+                    for control_qubit in cmd.control_qubits:
+                        if control_qubit.id in self._allocated_qubit_ids:
+                            self._refs_to_local_qb[control_qubit.id].append(
+                                                              control_qubit)
+                    for qureg in cmd.qubits:
+                        for qubit in qureg:
+                            if qubit.id in self._allocated_qubit_ids:
+                                self._refs_to_local_qb[qubit.id].append(
+                                                                      qubit)
 
 
 class Loop(object):
-	"""
-	Loop n times over an entire code block.
+    """
+    Loop n times over an entire code block.
 
-	Example:
-		.. code-block:: python
-		
-			with Loop(eng, 4):
-				# [quantum gates to be executed 4 times]
+    Example:
+        .. code-block:: python
 
-	Warning:
-		If the code in the loop contains allocation of qubits, those qubits 
-		have to be deleted prior to exiting the 'with Loop()' context.
-		
-		This code is **NOT VALID**:
-		
-		.. code-block:: python
-		
-			with Loop(eng, 4):
-				qb = eng.allocate_qubit()
-				H | qb # qb is still available!!!
-		
-		The **correct way** of handling qubit (de-)allocation is as follows:
-		
-		.. code-block:: python
-		
-			with Loop(eng, 4):
-				qb = eng.allocate_qubit()
-				...
-				del qb # sends deallocate gate
-	"""
+            with Loop(eng, 4):
+                # [quantum gates to be executed 4 times]
 
-	def __init__(self, engine, num):
-		"""
-		Enter a looped section.
+    Warning:
+        If the code in the loop contains allocation of qubits, those qubits
+        have to be deleted prior to exiting the 'with Loop()' context.
 
-		Args:
-			engine: Engine handling the commands (usually MainEngine)
-			num (int): Number of loop iterations
+        This code is **NOT VALID**:
 
-		Example:
-			.. code-block:: python
-			
-				with Loop(eng, 4):
-					H | qb
-					Rz(M_PI/3.) | qb
-		"""
-		self.engine = engine
-		self.num = num
+        .. code-block:: python
 
-	def __enter__(self):
-		if self.num > 1:
-			loop_eng = LoopEngine(self.num)
-			loop_eng.main_engine = self.engine.main_engine
-			oldnext = self.engine.next_engine
-			self.engine.next_engine = loop_eng
-			loop_eng.next_engine = oldnext
-			self._loop_eng = loop_eng
+            with Loop(eng, 4):
+                qb = eng.allocate_qubit()
+                H | qb # qb is still available!!!
 
-	def __exit__(self, type, value, traceback):
-		if self.num > 1:
-			# remove loop handler from engine list (i.e. skip it)
-			self._loop_eng.run()
-			oldnext = self._loop_eng.next_engine
-			self.engine.next_engine = oldnext
+        The **correct way** of handling qubit (de-)allocation is as follows:
+
+        .. code-block:: python
+
+            with Loop(eng, 4):
+                qb = eng.allocate_qubit()
+                ...
+                del qb # sends deallocate gate
+    """
+
+    def __init__(self, engine, num):
+        """
+        Enter a looped section.
+
+        Args:
+            engine: Engine handling the commands (usually MainEngine)
+            num (int): Number of loop iterations
+
+        Example:
+            .. code-block:: python
+
+                with Loop(eng, 4):
+                    H | qb
+                    Rz(M_PI/3.) | qb
+        """
+        self.engine = engine
+        self.num = num
+
+    def __enter__(self):
+        if self.num > 1:
+            loop_eng = LoopEngine(self.num)
+            loop_eng.main_engine = self.engine.main_engine
+            oldnext = self.engine.next_engine
+            self.engine.next_engine = loop_eng
+            loop_eng.next_engine = oldnext
+            self._loop_eng = loop_eng
+
+    def __exit__(self, type, value, traceback):
+        if self.num > 1:
+            # remove loop handler from engine list (i.e. skip it)
+            self._loop_eng.run()
+            oldnext = self._loop_eng.next_engine
+            self.engine.next_engine = oldnext

--- a/projectq/meta/_loop_test.py
+++ b/projectq/meta/_loop_test.py
@@ -25,187 +25,187 @@ from projectq.meta import _loop
 
 
 def test_loop_tag():
-	tag0 = _loop.LoopTag(10)
-	tag1 = _loop.LoopTag(10)
-	tag2 = tag0
-	tag3 = deepcopy(tag0)
-	tag3.num = 9
-	other_tag = ComputeTag()
-	assert tag0 == tag2
-	assert tag0 != tag1
-	assert not tag0 == tag3
-	assert not tag0 == other_tag
+    tag0 = _loop.LoopTag(10)
+    tag1 = _loop.LoopTag(10)
+    tag2 = tag0
+    tag3 = deepcopy(tag0)
+    tag3.num = 9
+    other_tag = ComputeTag()
+    assert tag0 == tag2
+    assert tag0 != tag1
+    assert not tag0 == tag3
+    assert not tag0 == other_tag
 
 
 def test_loop_with_supported_loop_tag_and_local_qubits():
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	
-	def allow_loop_tags(self, meta_tag):
-			return meta_tag == _loop.LoopTag
-	
-	backend.is_meta_tag_handler = types.MethodType(allow_loop_tags, backend)
-	qubit = eng.allocate_qubit()
-	H | qubit
-	with _loop.Loop(eng, 6):
-		ancilla = eng.allocate_qubit()
-		ancilla2 = eng.allocate_qubit()
-		H | ancilla2
-		H | ancilla
-		CNOT | (ancilla, qubit)
-		H | ancilla
-		H | ancilla2
-		del ancilla2
-		del ancilla
-	H | qubit
-	eng.flush(deallocate_qubits=True)
-	assert len(backend.received_commands) == 14
-	assert backend.received_commands[0].gate == Allocate
-	assert backend.received_commands[1].gate == H
-	assert backend.received_commands[2].gate == Allocate
-	assert backend.received_commands[3].gate == Allocate
-	assert backend.received_commands[4].gate == H
-	assert backend.received_commands[5].gate == H
-	assert backend.received_commands[6].gate == X
-	assert backend.received_commands[7].gate == H
-	assert backend.received_commands[8].gate == H
-	assert backend.received_commands[9].gate == Deallocate
-	assert backend.received_commands[10].gate == Deallocate
-	assert backend.received_commands[11].gate == H
-	assert backend.received_commands[12].gate == Deallocate
-	assert backend.received_commands[13].gate == FlushGate()
-	# Test qubit ids
-	qubit_id = backend.received_commands[0].qubits[0][0].id
-	ancilla_id = backend.received_commands[2].qubits[0][0].id
-	ancilla2_id = backend.received_commands[3].qubits[0][0].id
-	assert qubit_id != ancilla_id
-	assert qubit_id != ancilla2_id
-	assert ancilla_id != ancilla2_id
-	assert backend.received_commands[1].qubits[0][0].id == qubit_id
-	assert backend.received_commands[4].qubits[0][0].id == ancilla2_id
-	assert backend.received_commands[5].qubits[0][0].id == ancilla_id
-	assert backend.received_commands[6].qubits[0][0].id == qubit_id
-	assert backend.received_commands[6].control_qubits[0].id == ancilla_id
-	assert backend.received_commands[7].qubits[0][0].id == ancilla_id
-	assert backend.received_commands[8].qubits[0][0].id == ancilla2_id
-	assert backend.received_commands[9].qubits[0][0].id == ancilla2_id
-	assert backend.received_commands[10].qubits[0][0].id == ancilla_id
-	assert backend.received_commands[11].qubits[0][0].id == qubit_id
-	assert backend.received_commands[12].qubits[0][0].id == qubit_id
-	# Tags
-	assert len(backend.received_commands[3].tags) == 1
-	loop_tag = backend.received_commands[3].tags[0]
-	assert isinstance(loop_tag, _loop.LoopTag)
-	assert loop_tag.num == 6
-	for ii in [0, 1, 11, 12, 13]:
-		assert backend.received_commands[ii].tags == []
-	for ii in range(2,9):
-		assert backend.received_commands[ii].tags == [loop_tag]
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+
+    def allow_loop_tags(self, meta_tag):
+            return meta_tag == _loop.LoopTag
+
+    backend.is_meta_tag_handler = types.MethodType(allow_loop_tags, backend)
+    qubit = eng.allocate_qubit()
+    H | qubit
+    with _loop.Loop(eng, 6):
+        ancilla = eng.allocate_qubit()
+        ancilla2 = eng.allocate_qubit()
+        H | ancilla2
+        H | ancilla
+        CNOT | (ancilla, qubit)
+        H | ancilla
+        H | ancilla2
+        del ancilla2
+        del ancilla
+    H | qubit
+    eng.flush(deallocate_qubits=True)
+    assert len(backend.received_commands) == 14
+    assert backend.received_commands[0].gate == Allocate
+    assert backend.received_commands[1].gate == H
+    assert backend.received_commands[2].gate == Allocate
+    assert backend.received_commands[3].gate == Allocate
+    assert backend.received_commands[4].gate == H
+    assert backend.received_commands[5].gate == H
+    assert backend.received_commands[6].gate == X
+    assert backend.received_commands[7].gate == H
+    assert backend.received_commands[8].gate == H
+    assert backend.received_commands[9].gate == Deallocate
+    assert backend.received_commands[10].gate == Deallocate
+    assert backend.received_commands[11].gate == H
+    assert backend.received_commands[12].gate == Deallocate
+    assert backend.received_commands[13].gate == FlushGate()
+    # Test qubit ids
+    qubit_id = backend.received_commands[0].qubits[0][0].id
+    ancilla_id = backend.received_commands[2].qubits[0][0].id
+    ancilla2_id = backend.received_commands[3].qubits[0][0].id
+    assert qubit_id != ancilla_id
+    assert qubit_id != ancilla2_id
+    assert ancilla_id != ancilla2_id
+    assert backend.received_commands[1].qubits[0][0].id == qubit_id
+    assert backend.received_commands[4].qubits[0][0].id == ancilla2_id
+    assert backend.received_commands[5].qubits[0][0].id == ancilla_id
+    assert backend.received_commands[6].qubits[0][0].id == qubit_id
+    assert backend.received_commands[6].control_qubits[0].id == ancilla_id
+    assert backend.received_commands[7].qubits[0][0].id == ancilla_id
+    assert backend.received_commands[8].qubits[0][0].id == ancilla2_id
+    assert backend.received_commands[9].qubits[0][0].id == ancilla2_id
+    assert backend.received_commands[10].qubits[0][0].id == ancilla_id
+    assert backend.received_commands[11].qubits[0][0].id == qubit_id
+    assert backend.received_commands[12].qubits[0][0].id == qubit_id
+    # Tags
+    assert len(backend.received_commands[3].tags) == 1
+    loop_tag = backend.received_commands[3].tags[0]
+    assert isinstance(loop_tag, _loop.LoopTag)
+    assert loop_tag.num == 6
+    for ii in [0, 1, 11, 12, 13]:
+        assert backend.received_commands[ii].tags == []
+    for ii in range(2,9):
+        assert backend.received_commands[ii].tags == [loop_tag]
 
 
 def test_loop_with_supported_loop_tag_depending_on_num():
-	# Test that if loop has only one iteration, there is no loop tag
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	
-	def allow_loop_tags(self, meta_tag):
-			return meta_tag == _loop.LoopTag
-	
-	backend.is_meta_tag_handler = types.MethodType(allow_loop_tags, backend)
-	qubit = eng.allocate_qubit()
-	with _loop.Loop(eng, 1):
-		H | qubit
-	with _loop.Loop(eng, 2):
-		H | qubit
-	assert len(backend.received_commands[1].tags) == 0
-	assert len(backend.received_commands[2].tags) == 1
+    # Test that if loop has only one iteration, there is no loop tag
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+
+    def allow_loop_tags(self, meta_tag):
+            return meta_tag == _loop.LoopTag
+
+    backend.is_meta_tag_handler = types.MethodType(allow_loop_tags, backend)
+    qubit = eng.allocate_qubit()
+    with _loop.Loop(eng, 1):
+        H | qubit
+    with _loop.Loop(eng, 2):
+        H | qubit
+    assert len(backend.received_commands[1].tags) == 0
+    assert len(backend.received_commands[2].tags) == 1
 
 
 def test_loop_unrolling():
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	qubit = eng.allocate_qubit()
-	with _loop.Loop(eng, 3):
-		H | qubit
-	eng.flush(deallocate_qubits=True)
-	assert len(backend.received_commands) == 6
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+    qubit = eng.allocate_qubit()
+    with _loop.Loop(eng, 3):
+        H | qubit
+    eng.flush(deallocate_qubits=True)
+    assert len(backend.received_commands) == 6
 
 
 def test_loop_unrolling_with_ancillas():
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	qubit = eng.allocate_qubit()
-	qubit_id = deepcopy(qubit[0].id)
-	with _loop.Loop(eng, 3):
-		ancilla = eng.allocate_qubit()
-		H | ancilla
-		CNOT | (ancilla, qubit)
-		del ancilla
-	eng.flush(deallocate_qubits=True)
-	assert len(backend.received_commands) == 15
-	assert backend.received_commands[0].gate == Allocate
-	for ii in range(3):
-		assert backend.received_commands[ii * 4 + 1].gate == Allocate
-		assert backend.received_commands[ii * 4 + 2].gate == H
-		assert backend.received_commands[ii * 4 + 3].gate == X
-		assert backend.received_commands[ii * 4 + 4].gate == Deallocate
-		# Check qubit ids
-		assert (backend.received_commands[ii * 4 + 1].qubits[0][0].id ==
-			backend.received_commands[ii * 4 + 2].qubits[0][0].id)
-		assert (backend.received_commands[ii * 4 + 1].qubits[0][0].id ==
-			backend.received_commands[ii * 4 + 3].control_qubits[0].id)
-		assert (backend.received_commands[ii * 4 + 3].qubits[0][0].id ==
-			qubit_id)
-		assert (backend.received_commands[ii * 4 + 1].qubits[0][0].id ==
-			backend.received_commands[ii * 4 + 4].qubits[0][0].id)
-	assert backend.received_commands[13].gate == Deallocate
-	assert backend.received_commands[14].gate == FlushGate()
-	assert (backend.received_commands[1].qubits[0][0].id !=
-		backend.received_commands[5].qubits[0][0].id)
-	assert (backend.received_commands[1].qubits[0][0].id !=
-		backend.received_commands[9].qubits[0][0].id)
-	assert (backend.received_commands[5].qubits[0][0].id !=
-		backend.received_commands[9].qubits[0][0].id)
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+    qubit = eng.allocate_qubit()
+    qubit_id = deepcopy(qubit[0].id)
+    with _loop.Loop(eng, 3):
+        ancilla = eng.allocate_qubit()
+        H | ancilla
+        CNOT | (ancilla, qubit)
+        del ancilla
+    eng.flush(deallocate_qubits=True)
+    assert len(backend.received_commands) == 15
+    assert backend.received_commands[0].gate == Allocate
+    for ii in range(3):
+        assert backend.received_commands[ii * 4 + 1].gate == Allocate
+        assert backend.received_commands[ii * 4 + 2].gate == H
+        assert backend.received_commands[ii * 4 + 3].gate == X
+        assert backend.received_commands[ii * 4 + 4].gate == Deallocate
+        # Check qubit ids
+        assert (backend.received_commands[ii * 4 + 1].qubits[0][0].id ==
+            backend.received_commands[ii * 4 + 2].qubits[0][0].id)
+        assert (backend.received_commands[ii * 4 + 1].qubits[0][0].id ==
+            backend.received_commands[ii * 4 + 3].control_qubits[0].id)
+        assert (backend.received_commands[ii * 4 + 3].qubits[0][0].id ==
+            qubit_id)
+        assert (backend.received_commands[ii * 4 + 1].qubits[0][0].id ==
+            backend.received_commands[ii * 4 + 4].qubits[0][0].id)
+    assert backend.received_commands[13].gate == Deallocate
+    assert backend.received_commands[14].gate == FlushGate()
+    assert (backend.received_commands[1].qubits[0][0].id !=
+        backend.received_commands[5].qubits[0][0].id)
+    assert (backend.received_commands[1].qubits[0][0].id !=
+        backend.received_commands[9].qubits[0][0].id)
+    assert (backend.received_commands[5].qubits[0][0].id !=
+        backend.received_commands[9].qubits[0][0].id)
 
 
 def test_nested_loop():
-	backend = DummyEngine(save_commands=True)
-	
-	def allow_loop_tags(self, meta_tag):
-			return meta_tag == _loop.LoopTag
-	
-	backend.is_meta_tag_handler = types.MethodType(allow_loop_tags, backend)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	qubit = eng.allocate_qubit()
-	with _loop.Loop(eng, 3):
-		with _loop.Loop(eng, 4):
-			H | qubit
-	eng.flush(deallocate_qubits=True)
-	assert len(backend.received_commands) == 4
-	assert backend.received_commands[1].gate == H
-	assert len(backend.received_commands[1].tags) == 2
-	assert backend.received_commands[1].tags[0].num == 4
-	assert backend.received_commands[1].tags[1].num == 3
-	assert (backend.received_commands[1].tags[0].id !=
-	              backend.received_commands[1].tags[1].id)
+    backend = DummyEngine(save_commands=True)
+
+    def allow_loop_tags(self, meta_tag):
+            return meta_tag == _loop.LoopTag
+
+    backend.is_meta_tag_handler = types.MethodType(allow_loop_tags, backend)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+    qubit = eng.allocate_qubit()
+    with _loop.Loop(eng, 3):
+        with _loop.Loop(eng, 4):
+            H | qubit
+    eng.flush(deallocate_qubits=True)
+    assert len(backend.received_commands) == 4
+    assert backend.received_commands[1].gate == H
+    assert len(backend.received_commands[1].tags) == 2
+    assert backend.received_commands[1].tags[0].num == 4
+    assert backend.received_commands[1].tags[1].num == 3
+    assert (backend.received_commands[1].tags[0].id !=
+                  backend.received_commands[1].tags[1].id)
 
 
 def test_qubit_management_error():
-	backend = DummyEngine(save_commands=True)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	with pytest.raises(_loop.QubitManagementError):
-		with _loop.Loop(eng, 3):
-			qb = eng.allocate_qubit()
+    backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+    with pytest.raises(_loop.QubitManagementError):
+        with _loop.Loop(eng, 3):
+            qb = eng.allocate_qubit()
 
 
 def test_qubit_management_error_when_loop_tag_supported():
-	backend = DummyEngine(save_commands=True)
-	
-	def allow_loop_tags(self, meta_tag):
-			return meta_tag == _loop.LoopTag
-	
-	backend.is_meta_tag_handler = types.MethodType(allow_loop_tags, backend)
-	eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
-	with pytest.raises(_loop.QubitManagementError):
-		with _loop.Loop(eng, 3):
-			qb = eng.allocate_qubit()
+    backend = DummyEngine(save_commands=True)
+
+    def allow_loop_tags(self, meta_tag):
+            return meta_tag == _loop.LoopTag
+
+    backend.is_meta_tag_handler = types.MethodType(allow_loop_tags, backend)
+    eng = MainEngine(backend=backend, engine_list=[DummyEngine()])
+    with pytest.raises(_loop.QubitManagementError):
+        with _loop.Loop(eng, 3):
+            qb = eng.allocate_qubit()

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -19,11 +19,11 @@ Gates overload the | operator to allow the following syntax:
 
 .. code-block:: python
 
-	Gate | (qreg1, qreg2, qreg2)
-	Gate | (qreg, qubit)
-	Gate | qreg
-	Gate | qubit
-	Gate | (qubit,)
+    Gate | (qreg1, qreg2, qreg2)
+    Gate | (qreg, qubit)
+    Gate | qreg
+    Gate | qubit
+    Gate | (qubit,)
 
 This means that for more than one quantum argument (right side of | ), a tuple
 needs to be made explicitely, while for one argument it is optional.
@@ -37,389 +37,389 @@ from ._command import Command, apply_command
 
 
 class NotMergeable(Exception):
-	"""
-	Exception thrown when trying to merge two gates which are not mergeable (or
-	where it is not	implemented (yet)).
-	"""
-	pass
+    """
+    Exception thrown when trying to merge two gates which are not mergeable (or
+    where it is not    implemented (yet)).
+    """
+    pass
 
 
 class NotInvertible(Exception):
-	"""
-	Exception thrown when trying to invert a gate which is not invertable (or
-	where the inverse is not  implemented (yet)).
-	"""
-	pass
+    """
+    Exception thrown when trying to invert a gate which is not invertable (or
+    where the inverse is not  implemented (yet)).
+    """
+    pass
 
 
 class BasicGate(object):
-	"""
-	Base class of all gates.
-	"""
-	def __init__(self):
-		"""
-		Initialize a basic gate.
+    """
+    Base class of all gates.
+    """
+    def __init__(self):
+        """
+        Initialize a basic gate.
 
-		Note:
-			Set interchangeable qubit indices! (gate.interchangeable_qubit_indices)
+        Note:
+            Set interchangeable qubit indices! (gate.interchangeable_qubit_indices)
 
-			As an example, consider
-			
-			.. code-block:: python
-			
-				ExampleGate | (a,b,c,d,e)
-			
-			where a and b are interchangeable. Then, call this function as follows
-			
-			.. code-block:: python
-			
-				self.set_interchangeable_qubit_indices([[0,1]])
-			
-			As another example, consider
-			
-			.. code-block:: python
-			
-				ExampleGate2 | (a,b,c,d,e)
-			
-			where a and b are interchangeable and, in addition, c, d, and e are
-			interchangeable among themselves. Then, call this function as
-			
-			.. code-block:: python
-			
-				self.set_interchangeable_qubit_indices([[0,1],[2,3,4]])
-		"""
-		self.interchangeable_qubit_indices = []
+            As an example, consider
 
-	def get_inverse(self):
-		"""
-		Return the inverse gate.
+            .. code-block:: python
 
-		Standard implementation of get_inverse:
+                ExampleGate | (a,b,c,d,e)
 
-		Raises:
-			NotInvertible: inverse is not implemented
-		"""
-		raise NotInvertible("BasicGate: No get_inverse() implemented.")
+            where a and b are interchangeable. Then, call this function as follows
 
-	def get_merged(self, other):
-		"""
-		Return this gate merged with another gate.
+            .. code-block:: python
 
-		Standard implementation of get_merged:
+                self.set_interchangeable_qubit_indices([[0,1]])
 
-		Raises:
-			NotMergeable: merging is not implemented
-		"""
-		raise NotMergeable("BasicGate: No get_merged() implemented.")
+            As another example, consider
 
-	@staticmethod
-	def make_tuple_of_qureg(qubits):
-		"""
-		Convert quantum input of "gate | quantum input" to internal formatting.
+            .. code-block:: python
 
-		A Command object only accepts tuples of Quregs (list of Qubit objects)
-		as qubits input parameter. However, with this function we allow the
-		user to use a more flexible syntax:
+                ExampleGate2 | (a,b,c,d,e)
 
-			1) Gate | qubit
-			2) Gate | [qubit0, qubit1]
-			3) Gate | qureg
-			4) Gate | (qubit, )
-			5) Gate | (qureg, qubit)
+            where a and b are interchangeable and, in addition, c, d, and e are
+            interchangeable among themselves. Then, call this function as
 
-		where qubit is a Qubit object and qureg is a Qureg object. This
-		function takes the right hand side of | and transforms it to the
-		correct input parameter of a Command object which is:
+            .. code-block:: python
 
-			1) -> Gate | ([qubit], )
-			2) -> Gate | ([qubit0, qubit1], )
-			3) -> Gate | (qureg, )
-			4) -> Gate | ([qubit], )
-			5) -> Gate | (qureg, [qubit])
+                self.set_interchangeable_qubit_indices([[0,1],[2,3,4]])
+        """
+        self.interchangeable_qubit_indices = []
 
-		Args:
-			qubits: a Qubit object, a list of Qubit objects, a Qureg object, or
-			        a tuple of Qubit or Qureg objects (can be mixed).
-		Returns:
-			Canonical representation (tuple<qureg>): A tuple containing Qureg (or
-			list of Qubits) objects.
-		"""
-		if not isinstance(qubits, tuple):
-			qubits = (qubits,)
+    def get_inverse(self):
+        """
+        Return the inverse gate.
 
-		qubits = list(qubits)
+        Standard implementation of get_inverse:
 
-		for i in range(len(qubits)):
-			if isinstance(qubits[i], BasicQubit):
-				qubits[i] = [qubits[i]]
+        Raises:
+            NotInvertible: inverse is not implemented
+        """
+        raise NotInvertible("BasicGate: No get_inverse() implemented.")
 
-		return tuple(qubits)
+    def get_merged(self, other):
+        """
+        Return this gate merged with another gate.
 
-	def generate_command(self, qubits):
-		"""
-		Return a Command object which represents the gate acting on qubits.
+        Standard implementation of get_merged:
 
-		Args:
-			qubits: see BasicGate.make_tuple_of_qureg(qubits)
+        Raises:
+            NotMergeable: merging is not implemented
+        """
+        raise NotMergeable("BasicGate: No get_merged() implemented.")
 
-		Returns:
-			A Command object which represents the gate acting on qubits.
-		"""
-		qubits = self.make_tuple_of_qureg(qubits)
+    @staticmethod
+    def make_tuple_of_qureg(qubits):
+        """
+        Convert quantum input of "gate | quantum input" to internal formatting.
 
-		for i in range(len(qubits)):
-			for j in range(len(qubits[i]) - 1):
-				assert(qubits[i][j].engine == qubits[i][j + 1].engine)
-			if i < len(qubits) - 1:
-				assert(qubits[i][-1].engine == qubits[i + 1][0].engine)
-		return Command(qubits[0][0].engine, self, qubits)
+        A Command object only accepts tuples of Quregs (list of Qubit objects)
+        as qubits input parameter. However, with this function we allow the
+        user to use a more flexible syntax:
 
-	def __or__(self, qubits):
-		""" Operator| overload which enables the syntax Gate | qubits.
-		
-		Example:
-			1) Gate | qubit
-			2) Gate | [qubit0, qubit1]
-			3) Gate | qureg
-			4) Gate | (qubit, )
-			5) Gate | (qureg, qubit)
+            1) Gate | qubit
+            2) Gate | [qubit0, qubit1]
+            3) Gate | qureg
+            4) Gate | (qubit, )
+            5) Gate | (qureg, qubit)
 
-		Args:
-			qubits: a Qubit object, a list of Qubit objects, a Qureg object, or
-			        a tuple of Qubit or Qureg objects (can be mixed).
-		"""
-		cmd = self.generate_command(qubits)
-		apply_command(cmd)
+        where qubit is a Qubit object and qureg is a Qureg object. This
+        function takes the right hand side of | and transforms it to the
+        correct input parameter of a Command object which is:
 
-	def __eq__(self, other):
-		""" Return True if equal (i.e., instance of same class). """
-		return isinstance(other, self.__class__)
+            1) -> Gate | ([qubit], )
+            2) -> Gate | ([qubit0, qubit1], )
+            3) -> Gate | (qureg, )
+            4) -> Gate | ([qubit], )
+            5) -> Gate | (qureg, [qubit])
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+        Args:
+            qubits: a Qubit object, a list of Qubit objects, a Qureg object, or
+                    a tuple of Qubit or Qureg objects (can be mixed).
+        Returns:
+            Canonical representation (tuple<qureg>): A tuple containing Qureg (or
+            list of Qubits) objects.
+        """
+        if not isinstance(qubits, tuple):
+            qubits = (qubits,)
+
+        qubits = list(qubits)
+
+        for i in range(len(qubits)):
+            if isinstance(qubits[i], BasicQubit):
+                qubits[i] = [qubits[i]]
+
+        return tuple(qubits)
+
+    def generate_command(self, qubits):
+        """
+        Return a Command object which represents the gate acting on qubits.
+
+        Args:
+            qubits: see BasicGate.make_tuple_of_qureg(qubits)
+
+        Returns:
+            A Command object which represents the gate acting on qubits.
+        """
+        qubits = self.make_tuple_of_qureg(qubits)
+
+        for i in range(len(qubits)):
+            for j in range(len(qubits[i]) - 1):
+                assert(qubits[i][j].engine == qubits[i][j + 1].engine)
+            if i < len(qubits) - 1:
+                assert(qubits[i][-1].engine == qubits[i + 1][0].engine)
+        return Command(qubits[0][0].engine, self, qubits)
+
+    def __or__(self, qubits):
+        """ Operator| overload which enables the syntax Gate | qubits.
+
+        Example:
+            1) Gate | qubit
+            2) Gate | [qubit0, qubit1]
+            3) Gate | qureg
+            4) Gate | (qubit, )
+            5) Gate | (qureg, qubit)
+
+        Args:
+            qubits: a Qubit object, a list of Qubit objects, a Qureg object, or
+                    a tuple of Qubit or Qureg objects (can be mixed).
+        """
+        cmd = self.generate_command(qubits)
+        apply_command(cmd)
+
+    def __eq__(self, other):
+        """ Return True if equal (i.e., instance of same class). """
+        return isinstance(other, self.__class__)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 class SelfInverseGate(BasicGate):
-	"""
-	Self-inverse basic gate class.
+    """
+    Self-inverse basic gate class.
 
-	Automatic implementation of the get_inverse-member function for self-inverse
-	gates.
+    Automatic implementation of the get_inverse-member function for self-inverse
+    gates.
 
-	Example:
-		.. code-block:: python
-	
-			get_inverse(H) | qubit # get_inverse(H) == H; it is a self-inverse gate
-	"""
-	def get_inverse(self):
-		return deepcopy(self)
+    Example:
+        .. code-block:: python
+
+            get_inverse(H) | qubit # get_inverse(H) == H; it is a self-inverse gate
+    """
+    def get_inverse(self):
+        return deepcopy(self)
 
 
 class BasicRotationGate(BasicGate):
-	"""
-	Defines a base class of a rotation gate.
+    """
+    Defines a base class of a rotation gate.
 
-	A rotation gate has a continuous parameter (the angle), labeled 'angle' /
-	self._angle. Its inverse is the same gate with the negated argument.
-	Rotation gates of the same class can be merged by adding the angles.
-	The continuous parameter is modulo 4 * pi, self._angle is in the interval
-	[0, 4 * pi).
-	"""
-	def __init__(self, angle):
-		"""
-		Initialize a basic rotation gate.
+    A rotation gate has a continuous parameter (the angle), labeled 'angle' /
+    self._angle. Its inverse is the same gate with the negated argument.
+    Rotation gates of the same class can be merged by adding the angles.
+    The continuous parameter is modulo 4 * pi, self._angle is in the interval
+    [0, 4 * pi).
+    """
+    def __init__(self, angle):
+        """
+        Initialize a basic rotation gate.
 
-		Args:
-			angle (float): Angle of rotation (saved modulo 4 * pi)
-		"""
-		BasicGate.__init__(self)
-		self._angle = float(angle) % (4. * math.pi)
+        Args:
+            angle (float): Angle of rotation (saved modulo 4 * pi)
+        """
+        BasicGate.__init__(self)
+        self._angle = float(angle) % (4. * math.pi)
 
-	def __str__(self):
-		"""
-		Return the string representation of a BasicRotationGate.
-		
-		Returns the class name and the angle as
-		
-		.. code-block:: python
-		
-			[CLASSNAME]([ANGLE])
-		"""
-		return str(self.__class__.__name__) + "(" + str(self._angle) + ")"
-		
-	def tex_str(self):
-		"""
-		Return the Latex string representation of a BasicRotationGate.
-		
-		Returns the class name and the angle as a subscript, i.e.
-		
-		.. code-block:: latex
-		
-			[CLASSNAME]$_[ANGLE]$
-		"""
-		return str(self.__class__.__name__) + "$_{" + str(self._angle) + "}$"
+    def __str__(self):
+        """
+        Return the string representation of a BasicRotationGate.
 
-	def get_inverse(self):
-		"""
-		Return the inverse of this rotation gate (negate the angle, return new
-		object).
-		"""
-		if self._angle == 0:
-			return self.__class__(0)
-		else:
-			return self.__class__(-self._angle + 4 * math.pi)
+        Returns the class name and the angle as
 
-	def get_merged(self, other):
-		"""
-		Return self merged with another gate.
+        .. code-block:: python
 
-		Default implementation handles rotation gate of the same type, where
-		angles are simply added.
+            [CLASSNAME]([ANGLE])
+        """
+        return str(self.__class__.__name__) + "(" + str(self._angle) + ")"
 
-		Args:
-			other: Rotation gate of same type.
+    def tex_str(self):
+        """
+        Return the Latex string representation of a BasicRotationGate.
 
-		Raises:
-			NotMergeable: For non-rotation gates or rotation gates of different type.
+        Returns the class name and the angle as a subscript, i.e.
 
-		Returns:
-			New object representing the merged gates.
-		"""
-		if isinstance(other, self.__class__):
-			return self.__class__(self._angle + other._angle)
-		raise NotMergeable("Can't merge different types of rotation gates.")
+        .. code-block:: latex
 
-	def __eq__(self, other):
-		""" Return True if same class and same rotation angle. """
-		tolerance = 1.e-12
-		if isinstance(other, self.__class__):
-			difference = abs(self._angle - other._angle)
-			if difference < tolerance:
-				return True
-			else:  # if one angle is close to 0 and the other one close to 4*pi:
-				if difference > 4 * math.pi - tolerance:
-					return True
-				else:
-					return False
-		else:
-			return False
+            [CLASSNAME]$_[ANGLE]$
+        """
+        return str(self.__class__.__name__) + "$_{" + str(self._angle) + "}$"
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def get_inverse(self):
+        """
+        Return the inverse of this rotation gate (negate the angle, return new
+        object).
+        """
+        if self._angle == 0:
+            return self.__class__(0)
+        else:
+            return self.__class__(-self._angle + 4 * math.pi)
+
+    def get_merged(self, other):
+        """
+        Return self merged with another gate.
+
+        Default implementation handles rotation gate of the same type, where
+        angles are simply added.
+
+        Args:
+            other: Rotation gate of same type.
+
+        Raises:
+            NotMergeable: For non-rotation gates or rotation gates of different type.
+
+        Returns:
+            New object representing the merged gates.
+        """
+        if isinstance(other, self.__class__):
+            return self.__class__(self._angle + other._angle)
+        raise NotMergeable("Can't merge different types of rotation gates.")
+
+    def __eq__(self, other):
+        """ Return True if same class and same rotation angle. """
+        tolerance = 1.e-12
+        if isinstance(other, self.__class__):
+            difference = abs(self._angle - other._angle)
+            if difference < tolerance:
+                return True
+            else:  # if one angle is close to 0 and the other one close to 4*pi:
+                if difference > 4 * math.pi - tolerance:
+                    return True
+                else:
+                    return False
+        else:
+            return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 # Classical instruction gates never have control qubits.
 class ClassicalInstructionGate(BasicGate):
-	"""
-	Classical instruction gate.
+    """
+    Classical instruction gate.
 
-	Base class for all gates which are not quantum gates in the typical sense,
-	e.g., measurement, allocation/deallocation, ...
-	"""
-	pass
+    Base class for all gates which are not quantum gates in the typical sense,
+    e.g., measurement, allocation/deallocation, ...
+    """
+    pass
 
 
 class FastForwardingGate(ClassicalInstructionGate):
-	"""
-	Base class for classical instruction gates which require a fast-forward
-	through compiler engines that cache / buffer gates. Examples include
-	Measure and Deallocate, which both should be executed asap, such
-	that Measurement results are available and resources are freed,
-	respectively.
-	
-	Note:
-		The only requirement is that FlushGate commands run the entire circuit.
-		FastForwardingGate objects can be used but the user cannot expect a
-		measurement result to be available for all back-ends when calling only
-		Measure. E.g., for the IBM Quantum Experience back-end, sending the
-		circuit for each Measure-gate would be too inefficient, which is way a
-		final
-		
-		.. code-block: python
-		
-			eng.flush()
-		
-		is required before the circuit gets sent through the API.
-	"""
-	pass
+    """
+    Base class for classical instruction gates which require a fast-forward
+    through compiler engines that cache / buffer gates. Examples include
+    Measure and Deallocate, which both should be executed asap, such
+    that Measurement results are available and resources are freed,
+    respectively.
+
+    Note:
+        The only requirement is that FlushGate commands run the entire circuit.
+        FastForwardingGate objects can be used but the user cannot expect a
+        measurement result to be available for all back-ends when calling only
+        Measure. E.g., for the IBM Quantum Experience back-end, sending the
+        circuit for each Measure-gate would be too inefficient, which is way a
+        final
+
+        .. code-block: python
+
+            eng.flush()
+
+        is required before the circuit gets sent through the API.
+    """
+    pass
 
 
 class BasicMathGate(BasicGate):
-	"""
-	Base class for all math gates.
-	
-	It allows efficient emulation by providing a mathematical representation
-	which is given by the concrete gate which derives from this base class. The
-	AddConstant gate, for example, registers a function of the form
-	
-	.. code-block:: python
-		
-		def add(x):
-			return (x+a,)
-		
-	upon initialization. More generally, the function takes integers as
-	parameters and returns a tuple / list of outputs, each entry corresponding
-	to the function input. As an example, consider out-of-place multiplication,
-	which takes two input registers and adds the result into a third, i.e.,
-	(a,b,c) -> (a,b,c+a*b). The corresponding function then is
-	
-	.. code-block:: python
-	
-		def multiply(a,b,c)
-			return (a,b,c+a*b)
-	"""
-	def __init__(self, math_fun):
-		"""
-		Initialize a BasicMathGate by providing the mathematical function that it
-		implements.
-		
-		Args:
-			math_fun (function): Function which takes as many int values as input,
-				as the gate takes registers. For each of these values, it then returns
-				the output (i.e., it returns a list/tuple of output values).
-				
-		Example:
-			.. code-block:: python
-			
-				def add(a,b):
-					return (a,a+b)
-				BasicMathGate.__init__(self, add)
-		
-		If the gate acts on, e.g., fixed point numbers, the number of bits per
-		register is also required in order to describe the action of such a
-		mathematical gate. For this reason, there is
-		
-		.. code-block:: python
-			
-			BasicMathGate.get_math_function(qubits)
-		
-		which can be overwritten by the gate deriving from BasicMathGate.
-		
-		Example:
-			.. code-block:: python
-			
-				def get_math_function(self, qubits):
-					n = len(qubits[0])
-					scal = 2.**n
-					def math_fun(a):
-						return (int(scal * (math.sin(math.pi * a / scal))),)
-					return math_fun
-				
-		"""
-		BasicGate.__init__(self)
-		math_function = lambda x: list(math_fun(*x))
-		self._math_function = math_function
-	
-	"""
-	Return the math function which corresponds to the action of this math gate,
-	given the input to the gate (a tuple of quantum registers).
-	
-	Args:
-		qubits (tuple<Qureg>): Qubits to which the math gate is being applied.
-		
-	Returns:
-		math_fun (function): Python function describing the action of this gate.
-			(See BasicMathGate.__init__ for an example).
-	"""
-	def get_math_function(self, qubits):
-		return self._math_function
+    """
+    Base class for all math gates.
+
+    It allows efficient emulation by providing a mathematical representation
+    which is given by the concrete gate which derives from this base class. The
+    AddConstant gate, for example, registers a function of the form
+
+    .. code-block:: python
+
+        def add(x):
+            return (x+a,)
+
+    upon initialization. More generally, the function takes integers as
+    parameters and returns a tuple / list of outputs, each entry corresponding
+    to the function input. As an example, consider out-of-place multiplication,
+    which takes two input registers and adds the result into a third, i.e.,
+    (a,b,c) -> (a,b,c+a*b). The corresponding function then is
+
+    .. code-block:: python
+
+        def multiply(a,b,c)
+            return (a,b,c+a*b)
+    """
+    def __init__(self, math_fun):
+        """
+        Initialize a BasicMathGate by providing the mathematical function that it
+        implements.
+
+        Args:
+            math_fun (function): Function which takes as many int values as input,
+                as the gate takes registers. For each of these values, it then returns
+                the output (i.e., it returns a list/tuple of output values).
+
+        Example:
+            .. code-block:: python
+
+                def add(a,b):
+                    return (a,a+b)
+                BasicMathGate.__init__(self, add)
+
+        If the gate acts on, e.g., fixed point numbers, the number of bits per
+        register is also required in order to describe the action of such a
+        mathematical gate. For this reason, there is
+
+        .. code-block:: python
+
+            BasicMathGate.get_math_function(qubits)
+
+        which can be overwritten by the gate deriving from BasicMathGate.
+
+        Example:
+            .. code-block:: python
+
+                def get_math_function(self, qubits):
+                    n = len(qubits[0])
+                    scal = 2.**n
+                    def math_fun(a):
+                        return (int(scal * (math.sin(math.pi * a / scal))),)
+                    return math_fun
+
+        """
+        BasicGate.__init__(self)
+        math_function = lambda x: list(math_fun(*x))
+        self._math_function = math_function
+
+    """
+    Return the math function which corresponds to the action of this math gate,
+    given the input to the gate (a tuple of quantum registers).
+
+    Args:
+        qubits (tuple<Qureg>): Qubits to which the math gate is being applied.
+
+    Returns:
+        math_fun (function): Python function describing the action of this gate.
+            (See BasicMathGate.__init__ for an example).
+    """
+    def get_math_function(self, qubits):
+        return self._math_function

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -26,171 +26,171 @@ from projectq.ops import _basics
 
 @pytest.fixture
 def main_engine():
-	return MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    return MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
 
 
 def test_basic_gate_init():
-	basic_gate = _basics.BasicGate()
-	assert basic_gate.interchangeable_qubit_indices == []
-	with pytest.raises(_basics.NotInvertible):
-		basic_gate.get_inverse()
-	with pytest.raises(_basics.NotMergeable):
-		basic_gate.get_merged("other gate")
+    basic_gate = _basics.BasicGate()
+    assert basic_gate.interchangeable_qubit_indices == []
+    with pytest.raises(_basics.NotInvertible):
+        basic_gate.get_inverse()
+    with pytest.raises(_basics.NotMergeable):
+        basic_gate.get_merged("other gate")
 
 
 def test_basic_gate_make_tuple_of_qureg(main_engine):
-	qubit0 = Qubit(main_engine, 0)
-	qubit1 = Qubit(main_engine, 1)
-	qubit2 = Qubit(main_engine, 2)
-	qubit3 = Qubit(main_engine, 3)
-	qureg = Qureg([qubit2, qubit3])
-	case1 = _basics.BasicGate.make_tuple_of_qureg(qubit0)
-	assert case1 == ([qubit0],)
-	case2 = _basics.BasicGate.make_tuple_of_qureg([qubit0, qubit1])
-	assert case2 == ([qubit0, qubit1],)
-	case3 = _basics.BasicGate.make_tuple_of_qureg(qureg)
-	assert case3 == (qureg,)
-	case4 = _basics.BasicGate.make_tuple_of_qureg((qubit0,))
-	assert case4 == ([qubit0],)
-	case5 = _basics.BasicGate.make_tuple_of_qureg((qureg, qubit0))
-	assert case5 == (qureg, [qubit0])
+    qubit0 = Qubit(main_engine, 0)
+    qubit1 = Qubit(main_engine, 1)
+    qubit2 = Qubit(main_engine, 2)
+    qubit3 = Qubit(main_engine, 3)
+    qureg = Qureg([qubit2, qubit3])
+    case1 = _basics.BasicGate.make_tuple_of_qureg(qubit0)
+    assert case1 == ([qubit0],)
+    case2 = _basics.BasicGate.make_tuple_of_qureg([qubit0, qubit1])
+    assert case2 == ([qubit0, qubit1],)
+    case3 = _basics.BasicGate.make_tuple_of_qureg(qureg)
+    assert case3 == (qureg,)
+    case4 = _basics.BasicGate.make_tuple_of_qureg((qubit0,))
+    assert case4 == ([qubit0],)
+    case5 = _basics.BasicGate.make_tuple_of_qureg((qureg, qubit0))
+    assert case5 == (qureg, [qubit0])
 
 
 def test_basic_gate_generate_command(main_engine):
-	qubit0 = Qubit(main_engine, 0)
-	qubit1 = Qubit(main_engine, 1)
-	qubit2 = Qubit(main_engine, 2)
-	qubit3 = Qubit(main_engine, 3)
-	qureg = Qureg([qubit2, qubit3])
-	basic_gate = _basics.BasicGate()
-	command1 = basic_gate.generate_command(qubit0)
-	assert command1 == Command(main_engine, basic_gate,
-		([qubit0],))
-	command2 = basic_gate.generate_command([qubit0, qubit1])
-	assert command2 == Command(main_engine, basic_gate,
-		([qubit0, qubit1],))
-	command3 = basic_gate.generate_command(qureg)
-	assert command3 == Command(main_engine, basic_gate,
-		(qureg,))
-	command4 = basic_gate.generate_command((qubit0,))
-	assert command4 == Command(main_engine, basic_gate,
-		([qubit0],))
-	command5 = basic_gate.generate_command((qureg, qubit0))
-	assert command5 == Command(main_engine, basic_gate,
-		(qureg, [qubit0]))
+    qubit0 = Qubit(main_engine, 0)
+    qubit1 = Qubit(main_engine, 1)
+    qubit2 = Qubit(main_engine, 2)
+    qubit3 = Qubit(main_engine, 3)
+    qureg = Qureg([qubit2, qubit3])
+    basic_gate = _basics.BasicGate()
+    command1 = basic_gate.generate_command(qubit0)
+    assert command1 == Command(main_engine, basic_gate,
+        ([qubit0],))
+    command2 = basic_gate.generate_command([qubit0, qubit1])
+    assert command2 == Command(main_engine, basic_gate,
+        ([qubit0, qubit1],))
+    command3 = basic_gate.generate_command(qureg)
+    assert command3 == Command(main_engine, basic_gate,
+        (qureg,))
+    command4 = basic_gate.generate_command((qubit0,))
+    assert command4 == Command(main_engine, basic_gate,
+        ([qubit0],))
+    command5 = basic_gate.generate_command((qureg, qubit0))
+    assert command5 == Command(main_engine, basic_gate,
+        (qureg, [qubit0]))
 
 
 def test_basic_gate_or():
-	saving_backend = DummyEngine(save_commands=True)
-	main_engine = MainEngine(backend=saving_backend,
-		engine_list=[DummyEngine()])
-	qubit0 = Qubit(main_engine, 0)
-	qubit1 = Qubit(main_engine, 1)
-	qubit2 = Qubit(main_engine, 2)
-	qubit3 = Qubit(main_engine, 3)
-	qureg = Qureg([qubit2, qubit3])
-	basic_gate = _basics.BasicGate()
-	command1 = basic_gate.generate_command(qubit0)
-	basic_gate | qubit0
-	command2 = basic_gate.generate_command([qubit0, qubit1])
-	basic_gate | [qubit0, qubit1]
-	command3 = basic_gate.generate_command(qureg)
-	basic_gate | qureg
-	command4 = basic_gate.generate_command((qubit0,))
-	basic_gate | (qubit0,)
-	command5 = basic_gate.generate_command((qureg, qubit0))
-	basic_gate | (qureg, qubit0)
-	received_commands = []
-	# Remove Deallocate gates
-	for cmd in saving_backend.received_commands:
-		if not isinstance(cmd.gate, _basics.FastForwardingGate):
-			received_commands.append(cmd)
-	assert received_commands == ([command1, command2, command3, command4, 
-		command5])
+    saving_backend = DummyEngine(save_commands=True)
+    main_engine = MainEngine(backend=saving_backend,
+        engine_list=[DummyEngine()])
+    qubit0 = Qubit(main_engine, 0)
+    qubit1 = Qubit(main_engine, 1)
+    qubit2 = Qubit(main_engine, 2)
+    qubit3 = Qubit(main_engine, 3)
+    qureg = Qureg([qubit2, qubit3])
+    basic_gate = _basics.BasicGate()
+    command1 = basic_gate.generate_command(qubit0)
+    basic_gate | qubit0
+    command2 = basic_gate.generate_command([qubit0, qubit1])
+    basic_gate | [qubit0, qubit1]
+    command3 = basic_gate.generate_command(qureg)
+    basic_gate | qureg
+    command4 = basic_gate.generate_command((qubit0,))
+    basic_gate | (qubit0,)
+    command5 = basic_gate.generate_command((qureg, qubit0))
+    basic_gate | (qureg, qubit0)
+    received_commands = []
+    # Remove Deallocate gates
+    for cmd in saving_backend.received_commands:
+        if not isinstance(cmd.gate, _basics.FastForwardingGate):
+            received_commands.append(cmd)
+    assert received_commands == ([command1, command2, command3, command4,
+        command5])
 
 
 def test_basic_gate_compare(main_engine):
-	gate1 = _basics.BasicGate()
-	gate2 = _basics.BasicGate()
-	assert gate1 == gate2
-	assert not (gate1 != gate2)
+    gate1 = _basics.BasicGate()
+    gate2 = _basics.BasicGate()
+    assert gate1 == gate2
+    assert not (gate1 != gate2)
 
 
 def test_comparing_different_gates(main_engine):
-	basic_gate = _basics.BasicGate()
-	basic_rotation_gate = _basics.BasicRotationGate(1.0)
-	self_inverse_gate = _basics.SelfInverseGate()
-	assert not basic_gate == basic_rotation_gate
-	assert not basic_gate == self_inverse_gate
-	assert not self_inverse_gate == basic_rotation_gate
+    basic_gate = _basics.BasicGate()
+    basic_rotation_gate = _basics.BasicRotationGate(1.0)
+    self_inverse_gate = _basics.SelfInverseGate()
+    assert not basic_gate == basic_rotation_gate
+    assert not basic_gate == self_inverse_gate
+    assert not self_inverse_gate == basic_rotation_gate
 
 
 def test_self_inverse_gate():
-	self_inverse_gate = _basics.SelfInverseGate()
-	assert self_inverse_gate.get_inverse() == self_inverse_gate
-	assert id(self_inverse_gate.get_inverse()) != id(self_inverse_gate)
+    self_inverse_gate = _basics.SelfInverseGate()
+    assert self_inverse_gate.get_inverse() == self_inverse_gate
+    assert id(self_inverse_gate.get_inverse()) != id(self_inverse_gate)
 
 
-@pytest.mark.parametrize("input_angle, modulo_angle", [(2.0, 2.0), 
-	(17., 4.4336293856408275), (-0.5 * math.pi, 3.5 * math.pi),
-	(4 * math.pi, 0)])
+@pytest.mark.parametrize("input_angle, modulo_angle", [(2.0, 2.0),
+    (17., 4.4336293856408275), (-0.5 * math.pi, 3.5 * math.pi),
+    (4 * math.pi, 0)])
 def test_basic_rotation_gate_init(input_angle, modulo_angle):
-	# Test internal representation
-	gate = _basics.BasicRotationGate(input_angle)
-	assert gate._angle == pytest.approx(modulo_angle)
+    # Test internal representation
+    gate = _basics.BasicRotationGate(input_angle)
+    assert gate._angle == pytest.approx(modulo_angle)
 
 
 def test_basic_rotation_gate_str():
-	basic_rotation_gate = _basics.BasicRotationGate(0.5)
-	assert str(basic_rotation_gate) == "BasicRotationGate(0.5)"
+    basic_rotation_gate = _basics.BasicRotationGate(0.5)
+    assert str(basic_rotation_gate) == "BasicRotationGate(0.5)"
 
 
-@pytest.mark.parametrize("input_angle, inverse_angle", 
-	[(2.0, -2.0 + 4 * math.pi), (-0.5, 0.5)])
+@pytest.mark.parametrize("input_angle, inverse_angle",
+    [(2.0, -2.0 + 4 * math.pi), (-0.5, 0.5)])
 def test_basic_rotation_gate_get_inverse(input_angle, inverse_angle):
-	basic_rotation_gate = _basics.BasicRotationGate(input_angle)
-	inverse = basic_rotation_gate.get_inverse()
-	assert isinstance(inverse, _basics.BasicRotationGate)
-	assert inverse._angle == pytest.approx(inverse_angle)
+    basic_rotation_gate = _basics.BasicRotationGate(input_angle)
+    inverse = basic_rotation_gate.get_inverse()
+    assert isinstance(inverse, _basics.BasicRotationGate)
+    assert inverse._angle == pytest.approx(inverse_angle)
 
 
 def test_basic_rotation_gate_get_merged():
-	basic_gate = _basics.BasicGate()
-	basic_rotation_gate1 = _basics.BasicRotationGate(0.5)
-	basic_rotation_gate2 = _basics.BasicRotationGate(1.0)
-	basic_rotation_gate3 = _basics.BasicRotationGate(1.5)
-	with pytest.raises(_basics.NotMergeable):
-		basic_rotation_gate1.get_merged(basic_gate)
-	merged_gate = basic_rotation_gate1.get_merged(basic_rotation_gate2)
-	assert merged_gate == basic_rotation_gate3
+    basic_gate = _basics.BasicGate()
+    basic_rotation_gate1 = _basics.BasicRotationGate(0.5)
+    basic_rotation_gate2 = _basics.BasicRotationGate(1.0)
+    basic_rotation_gate3 = _basics.BasicRotationGate(1.5)
+    with pytest.raises(_basics.NotMergeable):
+        basic_rotation_gate1.get_merged(basic_gate)
+    merged_gate = basic_rotation_gate1.get_merged(basic_rotation_gate2)
+    assert merged_gate == basic_rotation_gate3
 
 
 def test_basic_rotation_gate_comparison():
-	basic_rotation_gate1 = _basics.BasicRotationGate(0.5)
-	basic_rotation_gate2 = _basics.BasicRotationGate(0.5)
-	basic_rotation_gate3 = _basics.BasicRotationGate(0.5 + 4 * math.pi)
-	assert basic_rotation_gate1 == basic_rotation_gate2
-	assert basic_rotation_gate1 == basic_rotation_gate3
-	basic_rotation_gate4 = _basics.BasicRotationGate(0.50000001)
-	# Test __ne__:
-	assert basic_rotation_gate4 != basic_rotation_gate1 
-	# Test one gate close to 4*pi the other one close to 0
-	basic_rotation_gate5 = _basics.BasicRotationGate(1.e-13)
-	basic_rotation_gate6 = _basics.BasicRotationGate(4 * math.pi - 1.e-13)
-	assert basic_rotation_gate5 == basic_rotation_gate6
-	# Test different types of gates
-	basic_gate = _basics.BasicGate()
-	assert not basic_gate == basic_rotation_gate6
+    basic_rotation_gate1 = _basics.BasicRotationGate(0.5)
+    basic_rotation_gate2 = _basics.BasicRotationGate(0.5)
+    basic_rotation_gate3 = _basics.BasicRotationGate(0.5 + 4 * math.pi)
+    assert basic_rotation_gate1 == basic_rotation_gate2
+    assert basic_rotation_gate1 == basic_rotation_gate3
+    basic_rotation_gate4 = _basics.BasicRotationGate(0.50000001)
+    # Test __ne__:
+    assert basic_rotation_gate4 != basic_rotation_gate1
+    # Test one gate close to 4*pi the other one close to 0
+    basic_rotation_gate5 = _basics.BasicRotationGate(1.e-13)
+    basic_rotation_gate6 = _basics.BasicRotationGate(4 * math.pi - 1.e-13)
+    assert basic_rotation_gate5 == basic_rotation_gate6
+    # Test different types of gates
+    basic_gate = _basics.BasicGate()
+    assert not basic_gate == basic_rotation_gate6
 
 
 def test_basic_math_gate():
-	def my_math_function(a, b, c):
-		return (a, b, c + a * b)
-	
-	class MyMultiplyGate(_basics.BasicMathGate):
-		def __init__(self):
-			_basics.BasicMathGate.__init__(self, my_math_function)
-	
-	gate = MyMultiplyGate()
-	# Test a=2, b=3, and c=5 should give a=2, b=3, c=11
-	assert gate.get_math_function(("qreg1", "qreg2", "qreg3"))([2,3,5]) == [2,3,11]
+    def my_math_function(a, b, c):
+        return (a, b, c + a * b)
+
+    class MyMultiplyGate(_basics.BasicMathGate):
+        def __init__(self):
+            _basics.BasicMathGate.__init__(self, my_math_function)
+
+    gate = MyMultiplyGate()
+    # Test a=2, b=3, and c=5 should give a=2, b=3, c=11
+    assert gate.get_math_function(("qreg1", "qreg2", "qreg3"))([2,3,5]) == [2,3,11]

--- a/projectq/ops/_command.py
+++ b/projectq/ops/_command.py
@@ -17,7 +17,7 @@ When a gate is applied to qubits, e.g.,
 
 .. code-block:: python
 
-	CNOT | (qubit1, qubit2)
+    CNOT | (qubit1, qubit2)
 
 a Command object is generated which represents both the gate, qubits and
 control qubits. This Command object then gets sent down the compilation
@@ -29,8 +29,8 @@ using interchangeable qubit indices defined by the gate to allow the
 optimizer to cancel the following two gates
 
 .. code-block:: python
-	Swap | (qubit1, qubit2)
-	Swap | (qubit2, qubit1)
+    Swap | (qubit1, qubit2)
+    Swap | (qubit2, qubit1)
 
 The command then gets sent to the MainEngine via the
 apply wrapper (apply_command).
@@ -43,259 +43,259 @@ from projectq.types import WeakQubitRef, Qureg
 
 
 def apply_command(cmd):
-	"""
-	Apply a command.
+    """
+    Apply a command.
 
-	Extracts the qubits-owning (target) engine from the Command object
-	and sends the Command to it.
+    Extracts the qubits-owning (target) engine from the Command object
+    and sends the Command to it.
 
-	Args:
-		cmd (Command): Command to apply
-	"""
-	engine = cmd.engine
-	engine.receive([cmd])
+    Args:
+        cmd (Command): Command to apply
+    """
+    engine = cmd.engine
+    engine.receive([cmd])
 
 
 class Command(object):
-	"""
-	Class used as a container to store commands. If a gate is applied to qubits,
-	then the gate and qubits are saved in a command object. Qubits are copied
-	into WeakQubitRefs in order to allow early deallocation (would be kept alive
-	otherwise). WeakQubitRef qubits don't send deallocate gate when destructed.
+    """
+    Class used as a container to store commands. If a gate is applied to qubits,
+    then the gate and qubits are saved in a command object. Qubits are copied
+    into WeakQubitRefs in order to allow early deallocation (would be kept alive
+    otherwise). WeakQubitRef qubits don't send deallocate gate when destructed.
 
-	Attributes:
-		gate: The gate to execute
-		qubits: Tuple of qubit lists (e.g. Quregs). Interchangeable qubits
-		          are stored in a unique order
-		control_qubits: The Qureg of control qubits in a unique order
-		engine: The engine (usually: MainEngine)
-		tags: The list of tag objects associated with this command 
-		  (e.g., ComputeTag, UncomputeTag, LoopTag, ...). tag objects need to 
-		  support ==, != (__eq__ and __ne__) for comparison as used in e.g.
-		  TagRemover. New tags should always be added to the end of the list.
-		  This means that if there are e.g. two LoopTags in a command, tag[0]
-		  is from the inner scope while tag[1] is from the other scope as the
-		  other scope receives the command after the inner scope LoopEngine and
-		  hence adds its LoopTag to the end.
-		all_qubits: A tuple of control_qubits + qubits
-	"""
+    Attributes:
+        gate: The gate to execute
+        qubits: Tuple of qubit lists (e.g. Quregs). Interchangeable qubits
+                  are stored in a unique order
+        control_qubits: The Qureg of control qubits in a unique order
+        engine: The engine (usually: MainEngine)
+        tags: The list of tag objects associated with this command
+          (e.g., ComputeTag, UncomputeTag, LoopTag, ...). tag objects need to
+          support ==, != (__eq__ and __ne__) for comparison as used in e.g.
+          TagRemover. New tags should always be added to the end of the list.
+          This means that if there are e.g. two LoopTags in a command, tag[0]
+          is from the inner scope while tag[1] is from the other scope as the
+          other scope receives the command after the inner scope LoopEngine and
+          hence adds its LoopTag to the end.
+        all_qubits: A tuple of control_qubits + qubits
+    """
 
-	def __init__(self, engine, gate, qubits):
-		"""
-		Initialize a Command object.
+    def __init__(self, engine, gate, qubits):
+        """
+        Initialize a Command object.
 
-		Note:
-			control qubits (Command.control_qubits) are stored as a
-			list of qubits, and command tags (Command.tags) as a list of tag-
-			objects. All functions within this class also work if WeakQubitRefs are
-			supplied instead of normal Qubit objects (see WeakQubitRef).
+        Note:
+            control qubits (Command.control_qubits) are stored as a
+            list of qubits, and command tags (Command.tags) as a list of tag-
+            objects. All functions within this class also work if WeakQubitRefs are
+            supplied instead of normal Qubit objects (see WeakQubitRef).
 
-		Args:
-			engine: engine which created the qubit (mostly the MainEngine)
-			gate: Gate to be executed
-			qubits: Tuple of quantum registers (to which the gate is applied)
-		"""
-		qubits = tuple([[WeakQubitRef(qubit.engine, qubit.id) for qubit in qreg]
-		                for qreg in qubits])
+        Args:
+            engine: engine which created the qubit (mostly the MainEngine)
+            gate: Gate to be executed
+            qubits: Tuple of quantum registers (to which the gate is applied)
+        """
+        qubits = tuple([[WeakQubitRef(qubit.engine, qubit.id) for qubit in qreg]
+                        for qreg in qubits])
 
-		self.gate = gate
-		self.tags = []
-		self.qubits = qubits # property
-		self._control_qubits = [] # access it via self.control_qubits property
-		self.engine = engine # property
+        self.gate = gate
+        self.tags = []
+        self.qubits = qubits # property
+        self._control_qubits = [] # access it via self.control_qubits property
+        self.engine = engine # property
 
-	@property	
-	def qubits(self):
-		return self._qubits
+    @property
+    def qubits(self):
+        return self._qubits
 
-	@qubits.setter
-	def qubits(self, qubits):
-		self._qubits = self._order_qubits(qubits)
+    @qubits.setter
+    def qubits(self, qubits):
+        self._qubits = self._order_qubits(qubits)
 
-	def __deepcopy__(self, memo):
-		""" Deepcopy implementation. Engine should stay a reference."""
-		cpy = Command(self.engine, deepcopy(self.gate), self.qubits)
-		cpy.tags = deepcopy(self.tags)
-		cpy.add_control_qubits(self.control_qubits)
-		return cpy
+    def __deepcopy__(self, memo):
+        """ Deepcopy implementation. Engine should stay a reference."""
+        cpy = Command(self.engine, deepcopy(self.gate), self.qubits)
+        cpy.tags = deepcopy(self.tags)
+        cpy.add_control_qubits(self.control_qubits)
+        return cpy
 
-	def get_inverse(self):
-		"""
-		Get the command object corresponding to the inverse of this command.
+    def get_inverse(self):
+        """
+        Get the command object corresponding to the inverse of this command.
 
-		Inverts the gate (if possible) and creates a new command object from
-		the result.
+        Inverts the gate (if possible) and creates a new command object from
+        the result.
 
-		Raises:
-			NotInvertible: If the gate does not provide an inverse (see
-			BasicGate.get_inverse)
-		"""
-		cmd = Command(self._engine, projectq.ops.get_inverse(self.gate), self.qubits)
-		cmd.tags = deepcopy(self.tags)
-		cmd.add_control_qubits(self.control_qubits)
-		return cmd
+        Raises:
+            NotInvertible: If the gate does not provide an inverse (see
+            BasicGate.get_inverse)
+        """
+        cmd = Command(self._engine, projectq.ops.get_inverse(self.gate), self.qubits)
+        cmd.tags = deepcopy(self.tags)
+        cmd.add_control_qubits(self.control_qubits)
+        return cmd
 
-	def get_merged(self, other):
-		"""
-		Merge this command with another one and return the merged command object.
+    def get_merged(self, other):
+        """
+        Merge this command with another one and return the merged command object.
 
-		Args:
-			other: Other command to merge with this one (self)
+        Args:
+            other: Other command to merge with this one (self)
 
-		Raises:
-			NotMergeable: if the gates don't supply a get_merged()-function or can't
-			be merged for other reasons.
-		"""
-		if (self.tags == other.tags and self.all_qubits == other.all_qubits and
-			  self.engine == other.engine):
-			merged_command = Command(self.engine, self.gate, self.qubits)
-			merged_command.gate = merged_command.gate.get_merged(other.gate)
-			merged_command.add_control_qubits(self.control_qubits)
-			merged_command.tags = deepcopy(self.tags)
-			return merged_command
-		raise projectq.ops.NotMergeable("Commands not mergeable.")
+        Raises:
+            NotMergeable: if the gates don't supply a get_merged()-function or can't
+            be merged for other reasons.
+        """
+        if (self.tags == other.tags and self.all_qubits == other.all_qubits and
+              self.engine == other.engine):
+            merged_command = Command(self.engine, self.gate, self.qubits)
+            merged_command.gate = merged_command.gate.get_merged(other.gate)
+            merged_command.add_control_qubits(self.control_qubits)
+            merged_command.tags = deepcopy(self.tags)
+            return merged_command
+        raise projectq.ops.NotMergeable("Commands not mergeable.")
 
-	def _order_qubits(self, qubits):
-		"""
-		Order the given qubits according to their IDs (for unique comparison of
-		commands).
+    def _order_qubits(self, qubits):
+        """
+        Order the given qubits according to their IDs (for unique comparison of
+        commands).
 
-		Args:
-			qubits: Tuple of quantum registers (i.e., tuple of lists of qubits)
+        Args:
+            qubits: Tuple of quantum registers (i.e., tuple of lists of qubits)
 
-		Returns: Ordered tuple of quantum registers
-		"""
-		ordered_qubits = list(qubits)
-		# e.g. [[0,4],[1,2,3]]
-		interchangeable_qubit_indices = self.interchangeable_qubit_indices
-		for old_positions in interchangeable_qubit_indices:
-			new_positions = sorted(old_positions,
-				                      key=lambda x: ordered_qubits[x][0].id)
-			qubits_new_order = [ordered_qubits[i] for i in new_positions]
-			for i in range(len(old_positions)):
-				ordered_qubits[old_positions[i]] = qubits_new_order[i]
-		return tuple(ordered_qubits)
+        Returns: Ordered tuple of quantum registers
+        """
+        ordered_qubits = list(qubits)
+        # e.g. [[0,4],[1,2,3]]
+        interchangeable_qubit_indices = self.interchangeable_qubit_indices
+        for old_positions in interchangeable_qubit_indices:
+            new_positions = sorted(old_positions,
+                                      key=lambda x: ordered_qubits[x][0].id)
+            qubits_new_order = [ordered_qubits[i] for i in new_positions]
+            for i in range(len(old_positions)):
+                ordered_qubits[old_positions[i]] = qubits_new_order[i]
+        return tuple(ordered_qubits)
 
-	@property
-	def interchangeable_qubit_indices(self):
-		"""
-		Return nested list of qubit indices which are interchangeable.
+    @property
+    def interchangeable_qubit_indices(self):
+        """
+        Return nested list of qubit indices which are interchangeable.
 
-		Certain qubits can be interchanged (e.g., the qubit order for a Swap 
-		gate). To ensure that only those are sorted when determining the 
-		ordering (see _order_qubits), self.interchangeable_qubit_indices is 
-		used.
-		Example:
-			If we can interchange qubits 0,1 and qubits 3,4,5,
-			then this function returns [[0,1],[3,4,5]]
-		"""
-		return self.gate.interchangeable_qubit_indices
+        Certain qubits can be interchanged (e.g., the qubit order for a Swap
+        gate). To ensure that only those are sorted when determining the
+        ordering (see _order_qubits), self.interchangeable_qubit_indices is
+        used.
+        Example:
+            If we can interchange qubits 0,1 and qubits 3,4,5,
+            then this function returns [[0,1],[3,4,5]]
+        """
+        return self.gate.interchangeable_qubit_indices
 
-	@property
-	def control_qubits(self):
-		""" Returns Qureg of control qubits."""
-		return self._control_qubits
+    @property
+    def control_qubits(self):
+        """ Returns Qureg of control qubits."""
+        return self._control_qubits
 
-	@control_qubits.setter
-	def control_qubits(self, qubits):
-		""" 
-		Set control_qubits to qubits
+    @control_qubits.setter
+    def control_qubits(self, qubits):
+        """
+        Set control_qubits to qubits
 
-		Args:
-			control_qubits (Qureg): quantum register
-		"""
-		self._control_qubits = ([WeakQubitRef(qubit.engine, qubit.id)
-		                            for qubit in qubits])
-		self._control_qubits = sorted(self._control_qubits, key=lambda x: x.id)
+        Args:
+            control_qubits (Qureg): quantum register
+        """
+        self._control_qubits = ([WeakQubitRef(qubit.engine, qubit.id)
+                                    for qubit in qubits])
+        self._control_qubits = sorted(self._control_qubits, key=lambda x: x.id)
 
-	def add_control_qubits(self, qubits):
-		"""
-		Add (additional) control qubits to this command object.
+    def add_control_qubits(self, qubits):
+        """
+        Add (additional) control qubits to this command object.
 
-		They are sorted to ensure a canonical order. Also Qubit objects
-		are converted to WeakQubitRef objects to allow garbage collection and
-		thus early deallocation of qubits.
+        They are sorted to ensure a canonical order. Also Qubit objects
+        are converted to WeakQubitRef objects to allow garbage collection and
+        thus early deallocation of qubits.
 
-		Args:
-			qubits (list of Qubit objects): List of qubits which control this
-			gate, i.e., the gate is only executed if all qubits are in state 1.
-		"""
-		assert(isinstance(qubits, list))
-		self._control_qubits.extend([WeakQubitRef(qubit.engine, qubit.id)
-		                            for qubit in qubits])
-		self._control_qubits = sorted(self._control_qubits, key=lambda x: x.id)
+        Args:
+            qubits (list of Qubit objects): List of qubits which control this
+            gate, i.e., the gate is only executed if all qubits are in state 1.
+        """
+        assert(isinstance(qubits, list))
+        self._control_qubits.extend([WeakQubitRef(qubit.engine, qubit.id)
+                                    for qubit in qubits])
+        self._control_qubits = sorted(self._control_qubits, key=lambda x: x.id)
 
-	@property
-	def all_qubits(self):
-		"""
-		Get all qubits (gate and control qubits).
+    @property
+    def all_qubits(self):
+        """
+        Get all qubits (gate and control qubits).
 
-		Returns a tuple T where T[0] is a quantum register (a list of WeakQubitRef
-		objects) containing the control qubits and T[1:] contains the quantum
-		registers to which the gate is applied.
-		"""
-		return (self.control_qubits,) + self.qubits
+        Returns a tuple T where T[0] is a quantum register (a list of WeakQubitRef
+        objects) containing the control qubits and T[1:] contains the quantum
+        registers to which the gate is applied.
+        """
+        return (self.control_qubits,) + self.qubits
 
-	@property
-	def engine(self):
-		"""
-		Return engine to which the qubits belong / on which the gates are executed.
-		"""
-		return self._engine
+    @property
+    def engine(self):
+        """
+        Return engine to which the qubits belong / on which the gates are executed.
+        """
+        return self._engine
 
-	@engine.setter
-	def engine(self, engine):
-		"""
-		Set / Change engine of all qubits to engine.
+    @engine.setter
+    def engine(self, engine):
+        """
+        Set / Change engine of all qubits to engine.
 
-		Args:
-			engine: New owner of qubits and owner of this Command object
-		"""
-		self._engine = engine
-		for qureg in self.qubits:
-			for qubit in qureg:
-				qubit.engine = engine
-		for qubit in self.control_qubits:
-			qubit.engine = engine
+        Args:
+            engine: New owner of qubits and owner of this Command object
+        """
+        self._engine = engine
+        for qureg in self.qubits:
+            for qubit in qureg:
+                qubit.engine = engine
+        for qubit in self.control_qubits:
+            qubit.engine = engine
 
-	def __eq__(self, other):
-		"""
-		Compare this command to another command.
+    def __eq__(self, other):
+        """
+        Compare this command to another command.
 
-		Args:
-			other (Command): Command object to compare this to
+        Args:
+            other (Command): Command object to compare this to
 
-		Returns: True if Command objects are equal (same gate, applied to same
-		qubits; ordered modulo interchangeability; and same tags)
-		"""
-		if (isinstance(other, self.__class__) and
-			  self.gate == other.gate and
-			  self.tags == other.tags and
-			  self.engine == other.engine and
-			  self.all_qubits == other.all_qubits):
-			return True
-		return False
+        Returns: True if Command objects are equal (same gate, applied to same
+        qubits; ordered modulo interchangeability; and same tags)
+        """
+        if (isinstance(other, self.__class__) and
+              self.gate == other.gate and
+              self.tags == other.tags and
+              self.engine == other.engine and
+              self.all_qubits == other.all_qubits):
+            return True
+        return False
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
-	def __str__(self):
-		"""
-		Get string representation of this Command object.
-		"""
-		qubits = self.qubits
-		ctrlqubits = self.control_qubits
-		if len(ctrlqubits) > 0:
-			qubits = (self.control_qubits,) + qubits
-		qstring = ""
-		if len(qubits) == 1:
-			qstring = str(Qureg(qubits[0]))
-		else:
-			qstring = "( "
-			for qreg in qubits:
-				qstring += str(Qureg(qreg))
-				qstring += ", "
-			qstring = qstring[:-2] + " )"
-		#qstring = convert_qubits_to_string(qubits)
-		cstring = "C" * len(ctrlqubits)
-		return cstring + str(self.gate) + " | " + qstring
+    def __str__(self):
+        """
+        Get string representation of this Command object.
+        """
+        qubits = self.qubits
+        ctrlqubits = self.control_qubits
+        if len(ctrlqubits) > 0:
+            qubits = (self.control_qubits,) + qubits
+        qstring = ""
+        if len(qubits) == 1:
+            qstring = str(Qureg(qubits[0]))
+        else:
+            qstring = "( "
+            for qreg in qubits:
+                qstring += str(Qureg(qreg))
+                qstring += ", "
+            qstring = qstring[:-2] + " )"
+        #qstring = convert_qubits_to_string(qubits)
+        cstring = "C" * len(ctrlqubits)
+        return cstring + str(self.gate) + " | " + qstring

--- a/projectq/ops/_command_test.py
+++ b/projectq/ops/_command_test.py
@@ -27,208 +27,208 @@ from projectq.ops import _command
 
 @pytest.fixture
 def main_engine():
-	return MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
+    return MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
 
 
 def test_command_init(main_engine):
-	qureg0 = Qureg([Qubit(main_engine, 0)])
-	qureg1 = Qureg([Qubit(main_engine, 1)])
-	qureg2 = Qureg([Qubit(main_engine, 2)])
-	qureg3 = Qureg([Qubit(main_engine, 3)])
-	qureg4 = Qureg([Qubit(main_engine, 4)])
-	gate = BasicGate()
-	cmd = _command.Command(main_engine, gate, (qureg0, qureg1, qureg2))
-	assert cmd.gate == gate
-	assert cmd.tags == []
-	expected_tuple = (qureg0, qureg1, qureg2)
-	for cmd_qureg, expected_qureg in zip(cmd.qubits, expected_tuple):
-		assert cmd_qureg[0].id == expected_qureg[0].id
-		# Testing that Qubits are now WeakQubitRef objects
-		assert type(cmd_qureg[0]) == WeakQubitRef
-	assert cmd._engine == main_engine
-	# Test that quregs are ordered if gate has interchangeable qubits:
-	symmetric_gate = BasicGate()
-	symmetric_gate.interchangeable_qubit_indices=[[0,1]]
-	symmetric_cmd = _command.Command(main_engine, symmetric_gate, 
-		(qureg2, qureg1, qureg0))
-	assert cmd.gate == gate
-	assert cmd.tags == []
-	expected_ordered_tuple = (qureg1, qureg2, qureg0)
-	for cmd_qureg, expected_qureg in zip(symmetric_cmd.qubits, 
-		expected_ordered_tuple):
-		assert cmd_qureg[0].id == expected_qureg[0].id
-	assert symmetric_cmd._engine == main_engine
+    qureg0 = Qureg([Qubit(main_engine, 0)])
+    qureg1 = Qureg([Qubit(main_engine, 1)])
+    qureg2 = Qureg([Qubit(main_engine, 2)])
+    qureg3 = Qureg([Qubit(main_engine, 3)])
+    qureg4 = Qureg([Qubit(main_engine, 4)])
+    gate = BasicGate()
+    cmd = _command.Command(main_engine, gate, (qureg0, qureg1, qureg2))
+    assert cmd.gate == gate
+    assert cmd.tags == []
+    expected_tuple = (qureg0, qureg1, qureg2)
+    for cmd_qureg, expected_qureg in zip(cmd.qubits, expected_tuple):
+        assert cmd_qureg[0].id == expected_qureg[0].id
+        # Testing that Qubits are now WeakQubitRef objects
+        assert type(cmd_qureg[0]) == WeakQubitRef
+    assert cmd._engine == main_engine
+    # Test that quregs are ordered if gate has interchangeable qubits:
+    symmetric_gate = BasicGate()
+    symmetric_gate.interchangeable_qubit_indices=[[0,1]]
+    symmetric_cmd = _command.Command(main_engine, symmetric_gate,
+        (qureg2, qureg1, qureg0))
+    assert cmd.gate == gate
+    assert cmd.tags == []
+    expected_ordered_tuple = (qureg1, qureg2, qureg0)
+    for cmd_qureg, expected_qureg in zip(symmetric_cmd.qubits,
+        expected_ordered_tuple):
+        assert cmd_qureg[0].id == expected_qureg[0].id
+    assert symmetric_cmd._engine == main_engine
 
 
 def test_command_deepcopy(main_engine):
-	qureg0 = Qureg([Qubit(main_engine, 0)])
-	qureg1 = Qureg([Qubit(main_engine, 1)])
-	gate = BasicGate()
-	cmd = _command.Command(main_engine, gate, (qureg0,))
-	cmd.add_control_qubits(qureg1)
-	cmd.tags.append("MyTestTag")
-	copied_cmd = deepcopy(cmd)
-	# Test that deepcopy gives same cmd
-	assert copied_cmd.gate == gate
-	assert copied_cmd.tags == ["MyTestTag"]
-	assert len(copied_cmd.qubits) == 1
-	assert copied_cmd.qubits[0][0].id == qureg0[0].id 
-	assert len(copied_cmd.control_qubits) == 1
-	assert copied_cmd.control_qubits[0].id == qureg1[0].id
-	# Engine should not be deepcopied but a reference:
-	assert id(copied_cmd.engine) == id(main_engine) 
-	# Test that deepcopy is actually a deepcopy
-	cmd.tags = ["ChangedTag"]
-	assert copied_cmd.tags == ["MyTestTag"]
-	cmd.control_qubits[0].id == 10
-	assert copied_cmd.control_qubits[0].id == qureg1[0].id
-	cmd.gate = "ChangedGate"
-	assert copied_cmd.gate == gate
+    qureg0 = Qureg([Qubit(main_engine, 0)])
+    qureg1 = Qureg([Qubit(main_engine, 1)])
+    gate = BasicGate()
+    cmd = _command.Command(main_engine, gate, (qureg0,))
+    cmd.add_control_qubits(qureg1)
+    cmd.tags.append("MyTestTag")
+    copied_cmd = deepcopy(cmd)
+    # Test that deepcopy gives same cmd
+    assert copied_cmd.gate == gate
+    assert copied_cmd.tags == ["MyTestTag"]
+    assert len(copied_cmd.qubits) == 1
+    assert copied_cmd.qubits[0][0].id == qureg0[0].id
+    assert len(copied_cmd.control_qubits) == 1
+    assert copied_cmd.control_qubits[0].id == qureg1[0].id
+    # Engine should not be deepcopied but a reference:
+    assert id(copied_cmd.engine) == id(main_engine)
+    # Test that deepcopy is actually a deepcopy
+    cmd.tags = ["ChangedTag"]
+    assert copied_cmd.tags == ["MyTestTag"]
+    cmd.control_qubits[0].id == 10
+    assert copied_cmd.control_qubits[0].id == qureg1[0].id
+    cmd.gate = "ChangedGate"
+    assert copied_cmd.gate == gate
 
 
 def test_command_get_inverse(main_engine):
-	qubit = main_engine.allocate_qubit()
-	ctrl_qubit = main_engine.allocate_qubit()
-	cmd = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd.add_control_qubits(ctrl_qubit)
-	cmd.tags = [ComputeTag()]
-	inverse_cmd = cmd.get_inverse()
-	assert inverse_cmd.gate == Rx(-0.5 + 4 * math.pi)
-	assert len(cmd.qubits) == len(inverse_cmd.qubits)
-	assert cmd.qubits[0][0].id == inverse_cmd.qubits[0][0].id
-	assert id(cmd.qubits[0][0]) != id(inverse_cmd.qubits[0][0])
-	assert len(cmd.control_qubits) == len(inverse_cmd.control_qubits)
-	assert cmd.control_qubits[0].id == inverse_cmd.control_qubits[0].id
-	assert id(cmd.control_qubits[0]) != id(inverse_cmd.control_qubits[0])
-	assert cmd.tags == inverse_cmd.tags
-	assert id(cmd.tags[0]) != id(inverse_cmd.tags[0])
-	assert id(cmd.engine) == id(inverse_cmd.engine)
+    qubit = main_engine.allocate_qubit()
+    ctrl_qubit = main_engine.allocate_qubit()
+    cmd = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd.add_control_qubits(ctrl_qubit)
+    cmd.tags = [ComputeTag()]
+    inverse_cmd = cmd.get_inverse()
+    assert inverse_cmd.gate == Rx(-0.5 + 4 * math.pi)
+    assert len(cmd.qubits) == len(inverse_cmd.qubits)
+    assert cmd.qubits[0][0].id == inverse_cmd.qubits[0][0].id
+    assert id(cmd.qubits[0][0]) != id(inverse_cmd.qubits[0][0])
+    assert len(cmd.control_qubits) == len(inverse_cmd.control_qubits)
+    assert cmd.control_qubits[0].id == inverse_cmd.control_qubits[0].id
+    assert id(cmd.control_qubits[0]) != id(inverse_cmd.control_qubits[0])
+    assert cmd.tags == inverse_cmd.tags
+    assert id(cmd.tags[0]) != id(inverse_cmd.tags[0])
+    assert id(cmd.engine) == id(inverse_cmd.engine)
 
 
 def test_command_get_merged(main_engine):
-	qubit = main_engine.allocate_qubit()
-	ctrl_qubit = main_engine.allocate_qubit()
-	cmd = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd.tags = ["TestTag"]
-	cmd.add_control_qubits(ctrl_qubit)
-	# Merge two commands
-	cmd2 = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd2.add_control_qubits(ctrl_qubit)
-	cmd2.tags = ["TestTag"]
-	merged_cmd = cmd.get_merged(cmd2)
-	expected_cmd = _command.Command(main_engine, Rx(1.0), (qubit,))
-	expected_cmd.add_control_qubits(ctrl_qubit)
-	expected_cmd.tags = ["TestTag"]
-	# Don't merge commands as different control qubits
-	cmd3 = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd3.tags = ["TestTag"]
-	with pytest.raises(NotMergeable):
-		cmd.get_merged(cmd3)
-	# Don't merge commands as different tags
-	cmd4 = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd4.add_control_qubits(ctrl_qubit)
-	with pytest.raises(NotMergeable):
-		cmd.get_merged(cmd4)
+    qubit = main_engine.allocate_qubit()
+    ctrl_qubit = main_engine.allocate_qubit()
+    cmd = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd.tags = ["TestTag"]
+    cmd.add_control_qubits(ctrl_qubit)
+    # Merge two commands
+    cmd2 = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd2.add_control_qubits(ctrl_qubit)
+    cmd2.tags = ["TestTag"]
+    merged_cmd = cmd.get_merged(cmd2)
+    expected_cmd = _command.Command(main_engine, Rx(1.0), (qubit,))
+    expected_cmd.add_control_qubits(ctrl_qubit)
+    expected_cmd.tags = ["TestTag"]
+    # Don't merge commands as different control qubits
+    cmd3 = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd3.tags = ["TestTag"]
+    with pytest.raises(NotMergeable):
+        cmd.get_merged(cmd3)
+    # Don't merge commands as different tags
+    cmd4 = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd4.add_control_qubits(ctrl_qubit)
+    with pytest.raises(NotMergeable):
+        cmd.get_merged(cmd4)
 
 
 def test_command_order_qubits(main_engine):
-	qubit0 = Qureg([Qubit(main_engine, 0)])
-	qubit1 = Qureg([Qubit(main_engine, 1)])
-	qubit2 = Qureg([Qubit(main_engine, 2)])
-	qubit3 = Qureg([Qubit(main_engine, 3)])
-	qubit4 = Qureg([Qubit(main_engine, 4)])
-	qubit5 = Qureg([Qubit(main_engine, 5)])
-	gate = BasicGate()
-	gate.interchangeable_qubit_indices=[[0,4,5],[1,2]]
-	input_tuple = (qubit4, qubit5, qubit3, qubit2, qubit1, qubit0)
-	expected_tuple = (qubit0, qubit3, qubit5, qubit2, qubit1, qubit4)
-	cmd = _command.Command(main_engine, gate, input_tuple)
-	for ordered_qubit, expected_qubit in zip(cmd.qubits, expected_tuple):
-		assert ordered_qubit[0].id == expected_qubit[0].id
+    qubit0 = Qureg([Qubit(main_engine, 0)])
+    qubit1 = Qureg([Qubit(main_engine, 1)])
+    qubit2 = Qureg([Qubit(main_engine, 2)])
+    qubit3 = Qureg([Qubit(main_engine, 3)])
+    qubit4 = Qureg([Qubit(main_engine, 4)])
+    qubit5 = Qureg([Qubit(main_engine, 5)])
+    gate = BasicGate()
+    gate.interchangeable_qubit_indices=[[0,4,5],[1,2]]
+    input_tuple = (qubit4, qubit5, qubit3, qubit2, qubit1, qubit0)
+    expected_tuple = (qubit0, qubit3, qubit5, qubit2, qubit1, qubit4)
+    cmd = _command.Command(main_engine, gate, input_tuple)
+    for ordered_qubit, expected_qubit in zip(cmd.qubits, expected_tuple):
+        assert ordered_qubit[0].id == expected_qubit[0].id
 
 def test_command_interchangeable_qubit_indices(main_engine):
-	gate = BasicGate()
-	gate.interchangeable_qubit_indices = [[0,4,5],[1,2]]
-	qubit0 = Qureg([Qubit(main_engine, 0)])
-	qubit1 = Qureg([Qubit(main_engine, 1)])
-	qubit2 = Qureg([Qubit(main_engine, 2)])
-	qubit3 = Qureg([Qubit(main_engine, 3)])
-	qubit4 = Qureg([Qubit(main_engine, 4)])
-	qubit5 = Qureg([Qubit(main_engine, 5)])
-	input_tuple = (qubit4, qubit5, qubit3, qubit2, qubit1, qubit0)
-	cmd = _command.Command(main_engine, gate, input_tuple)
-	assert (cmd.interchangeable_qubit_indices == [[0,4,5],[1,2]] or
-		cmd.interchangeable_qubit_indices == [[1,2],[0,4,5]])
+    gate = BasicGate()
+    gate.interchangeable_qubit_indices = [[0,4,5],[1,2]]
+    qubit0 = Qureg([Qubit(main_engine, 0)])
+    qubit1 = Qureg([Qubit(main_engine, 1)])
+    qubit2 = Qureg([Qubit(main_engine, 2)])
+    qubit3 = Qureg([Qubit(main_engine, 3)])
+    qubit4 = Qureg([Qubit(main_engine, 4)])
+    qubit5 = Qureg([Qubit(main_engine, 5)])
+    input_tuple = (qubit4, qubit5, qubit3, qubit2, qubit1, qubit0)
+    cmd = _command.Command(main_engine, gate, input_tuple)
+    assert (cmd.interchangeable_qubit_indices == [[0,4,5],[1,2]] or
+        cmd.interchangeable_qubit_indices == [[1,2],[0,4,5]])
 
 
 def test_commmand_add_control_qubits(main_engine):
-	qubit0 = Qureg([Qubit(main_engine, 0)])
-	qubit1 = Qureg([Qubit(main_engine, 1)])
-	qubit2 = Qureg([Qubit(main_engine, 2)])
-	cmd = _command.Command(main_engine, Rx(0.5), (qubit0,))
-	cmd.add_control_qubits(qubit2 + qubit1)
-	assert cmd.control_qubits[0].id == 1
-	assert cmd.control_qubits[1].id == 2
+    qubit0 = Qureg([Qubit(main_engine, 0)])
+    qubit1 = Qureg([Qubit(main_engine, 1)])
+    qubit2 = Qureg([Qubit(main_engine, 2)])
+    cmd = _command.Command(main_engine, Rx(0.5), (qubit0,))
+    cmd.add_control_qubits(qubit2 + qubit1)
+    assert cmd.control_qubits[0].id == 1
+    assert cmd.control_qubits[1].id == 2
 
 
 def test_command_all_qubits(main_engine):
-	qubit0 = Qureg([Qubit(main_engine, 0)])
-	qubit1 = Qureg([Qubit(main_engine, 1)])
-	cmd = _command.Command(main_engine, Rx(0.5), (qubit0,))
-	cmd.add_control_qubits(qubit1)
-	all_qubits = cmd.all_qubits
-	assert all_qubits[0][0].id == 1
-	assert all_qubits[1][0].id == 0
+    qubit0 = Qureg([Qubit(main_engine, 0)])
+    qubit1 = Qureg([Qubit(main_engine, 1)])
+    cmd = _command.Command(main_engine, Rx(0.5), (qubit0,))
+    cmd.add_control_qubits(qubit1)
+    all_qubits = cmd.all_qubits
+    assert all_qubits[0][0].id == 1
+    assert all_qubits[1][0].id == 0
 
 def test_command_engine(main_engine):
-	qubit0 = Qureg([Qubit("fake_engine", 0)])
-	qubit1 = Qureg([Qubit("fake_engine", 1)])
-	cmd = _command.Command("fake_engine", Rx(0.5), (qubit0,))
-	cmd.add_control_qubits(qubit1)
-	assert cmd.engine == "fake_engine"
-	cmd.engine = main_engine
-	assert id(cmd.engine) == id(main_engine)
-	assert id(cmd.control_qubits[0].engine) == id(main_engine)
-	assert id(cmd.qubits[0][0].engine) == id(main_engine)
+    qubit0 = Qureg([Qubit("fake_engine", 0)])
+    qubit1 = Qureg([Qubit("fake_engine", 1)])
+    cmd = _command.Command("fake_engine", Rx(0.5), (qubit0,))
+    cmd.add_control_qubits(qubit1)
+    assert cmd.engine == "fake_engine"
+    cmd.engine = main_engine
+    assert id(cmd.engine) == id(main_engine)
+    assert id(cmd.control_qubits[0].engine) == id(main_engine)
+    assert id(cmd.qubits[0][0].engine) == id(main_engine)
 
 def test_command_comparison(main_engine):
-	qubit = Qureg([Qubit(main_engine, 0)])
-	ctrl_qubit = Qureg([Qubit(main_engine, 1)])
-	cmd1 = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd1.tags = ["TestTag"]
-	cmd1.add_control_qubits(ctrl_qubit)
-	# Test equality
-	cmd2 = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd2.tags = ["TestTag"]
-	cmd2.add_control_qubits(ctrl_qubit)
-	assert cmd2 == cmd1
-	# Test not equal because of tags
-	cmd3 = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd3.tags = ["TestTag", "AdditionalTag"]
-	cmd3.add_control_qubits(ctrl_qubit)
-	assert not cmd3 == cmd1
-	# Test not equal because of control qubit
-	cmd4 = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd4.tags = ["TestTag"]
-	assert not cmd4 == cmd1
-	# Test not equal because of qubit
-	qubit2 = Qureg([Qubit(main_engine, 2)])
-	cmd5 = _command.Command(main_engine, Rx(0.5), (qubit2,))
-	cmd5.tags = ["TestTag"]
-	cmd5.add_control_qubits(ctrl_qubit)
-	assert cmd5 != cmd1
-	# Test not equal because of engine
-	cmd6 = _command.Command("FakeEngine", Rx(0.5), (qubit,))
-	cmd6.tags = ["TestTag"]
-	cmd6.add_control_qubits(ctrl_qubit)
-	assert cmd6 != cmd1
+    qubit = Qureg([Qubit(main_engine, 0)])
+    ctrl_qubit = Qureg([Qubit(main_engine, 1)])
+    cmd1 = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd1.tags = ["TestTag"]
+    cmd1.add_control_qubits(ctrl_qubit)
+    # Test equality
+    cmd2 = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd2.tags = ["TestTag"]
+    cmd2.add_control_qubits(ctrl_qubit)
+    assert cmd2 == cmd1
+    # Test not equal because of tags
+    cmd3 = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd3.tags = ["TestTag", "AdditionalTag"]
+    cmd3.add_control_qubits(ctrl_qubit)
+    assert not cmd3 == cmd1
+    # Test not equal because of control qubit
+    cmd4 = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd4.tags = ["TestTag"]
+    assert not cmd4 == cmd1
+    # Test not equal because of qubit
+    qubit2 = Qureg([Qubit(main_engine, 2)])
+    cmd5 = _command.Command(main_engine, Rx(0.5), (qubit2,))
+    cmd5.tags = ["TestTag"]
+    cmd5.add_control_qubits(ctrl_qubit)
+    assert cmd5 != cmd1
+    # Test not equal because of engine
+    cmd6 = _command.Command("FakeEngine", Rx(0.5), (qubit,))
+    cmd6.tags = ["TestTag"]
+    cmd6.add_control_qubits(ctrl_qubit)
+    assert cmd6 != cmd1
 
 def test_command_str():
-	qubit = Qureg([Qubit(main_engine, 0)])
-	ctrl_qubit = Qureg([Qubit(main_engine, 1)])
-	cmd = _command.Command(main_engine, Rx(0.5), (qubit,))
-	cmd.tags = ["TestTag"]
-	cmd.add_control_qubits(ctrl_qubit)
-	assert str(cmd) == "CRx(0.5) | ( Qubit[1], Qubit[0] )"
-	cmd2 = _command.Command(main_engine, Rx(0.5), (qubit,))
-	assert str(cmd2) == "Rx(0.5) | Qubit[0]"
+    qubit = Qureg([Qubit(main_engine, 0)])
+    ctrl_qubit = Qureg([Qubit(main_engine, 1)])
+    cmd = _command.Command(main_engine, Rx(0.5), (qubit,))
+    cmd.tags = ["TestTag"]
+    cmd.add_control_qubits(ctrl_qubit)
+    assert str(cmd) == "CRx(0.5) | ( Qubit[1], Qubit[0] )"
+    cmd2 = _command.Command(main_engine, Rx(0.5), (qubit,))
+    assert str(cmd2) == "Rx(0.5) | Qubit[0]"

--- a/projectq/ops/_gates.py
+++ b/projectq/ops/_gates.py
@@ -40,208 +40,208 @@ from ._basics import (BasicGate,
 
 
 class HGate(SelfInverseGate):
-	""" Hadamard gate class """
-	def __str__(self):
-		return "H"
+    """ Hadamard gate class """
+    def __str__(self):
+        return "H"
 
-	@property
-	def matrix(self):
-		return 1. / cmath.sqrt(2.) * np.matrix([[1, 1], [1, -1]])
+    @property
+    def matrix(self):
+        return 1. / cmath.sqrt(2.) * np.matrix([[1, 1], [1, -1]])
 
 H = HGate()
 
 
 class XGate(SelfInverseGate):
-	""" Pauli-X gate class """
-	def __str__(self):
-		return "X"
+    """ Pauli-X gate class """
+    def __str__(self):
+        return "X"
 
-	@property
-	def matrix(self):
-		return np.matrix([[0, 1], [1, 0]])
+    @property
+    def matrix(self):
+        return np.matrix([[0, 1], [1, 0]])
 
 X = NOT = XGate()
 
 
 class YGate(SelfInverseGate):
-	""" Pauli-Y gate class """
-	def __str__(self):
-		return "Y"
+    """ Pauli-Y gate class """
+    def __str__(self):
+        return "Y"
 
-	@property
-	def matrix(self):
-		return np.matrix([[0, -1j], [1j, 0]])
+    @property
+    def matrix(self):
+        return np.matrix([[0, -1j], [1j, 0]])
 
 Y = YGate()
 
 
 class ZGate(SelfInverseGate):
-	""" Pauli-Z gate class """
-	def __str__(self):
-		return "Z"
+    """ Pauli-Z gate class """
+    def __str__(self):
+        return "Z"
 
-	@property
-	def matrix(self):
-		return np.matrix([[1, 0], [0, -1]])
+    @property
+    def matrix(self):
+        return np.matrix([[1, 0], [0, -1]])
 
 Z = ZGate()
 
 
 class SGate(BasicGate):
-	""" S gate class """
-	@property
-	def matrix(self):
-		return np.matrix([[1, 0], [0, 1j]])
+    """ S gate class """
+    @property
+    def matrix(self):
+        return np.matrix([[1, 0], [0, 1j]])
 
-	def __str__(self):
-		return "S"
+    def __str__(self):
+        return "S"
 
 S = SGate()
 Sdag = Sdagger = get_inverse(S)
 
 
 class TGate(BasicGate):
-	""" T gate class """
-	@property
-	def matrix(self):
-		return np.matrix([[1, 0], [0, cmath.exp(1j * cmath.pi / 4)]])
+    """ T gate class """
+    @property
+    def matrix(self):
+        return np.matrix([[1, 0], [0, cmath.exp(1j * cmath.pi / 4)]])
 
-	def __str__(self):
-		return "T"
+    def __str__(self):
+        return "T"
 
 T = TGate()
 Tdag = Tdagger = get_inverse(T)
 
 
 class SwapGate(SelfInverseGate):
-	""" Swap gate class (swaps 2 qubits) """
-	def __init__(self):
-		SelfInverseGate.__init__(self)
-		self.interchangeable_qubit_indices = [[0, 1]]
+    """ Swap gate class (swaps 2 qubits) """
+    def __init__(self):
+        SelfInverseGate.__init__(self)
+        self.interchangeable_qubit_indices = [[0, 1]]
 
-	def __str__(self):
-		return "Swap"
+    def __str__(self):
+        return "Swap"
 
-	@property
-	def matrix(self):
-		return np.matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
+    @property
+    def matrix(self):
+        return np.matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]])
 
 Swap = SwapGate()
 
 
 class EntangleGate(BasicGate):
-	"""
-	Entangle gate (Hadamard on first qubit, followed by CNOTs applied to all
-	other qubits).
-	"""
-	def __str__(self):
-		return "Entangle"
+    """
+    Entangle gate (Hadamard on first qubit, followed by CNOTs applied to all
+    other qubits).
+    """
+    def __str__(self):
+        return "Entangle"
 
 Entangle = EntangleGate()
 
 
 class Ph(BasicRotationGate):
-	""" Phase gate (global phase) """
-	@property
-	def matrix(self):
-		return np.matrix([[cmath.exp(1j * self._angle), 0],
-		                  [0, cmath.exp(1j * self._angle)]])
+    """ Phase gate (global phase) """
+    @property
+    def matrix(self):
+        return np.matrix([[cmath.exp(1j * self._angle), 0],
+                          [0, cmath.exp(1j * self._angle)]])
 
 
 class Rx(BasicRotationGate):
-	""" RotationX gate class """
-	@property
-	def matrix(self):
-		return np.matrix([[math.cos(0.5 * self._angle),
-		                   -1j * math.sin(0.5 * self._angle)],
-			                [-1j * math.sin(0.5 * self._angle),
-			                 math.cos(0.5 * self._angle)]])
+    """ RotationX gate class """
+    @property
+    def matrix(self):
+        return np.matrix([[math.cos(0.5 * self._angle),
+                           -1j * math.sin(0.5 * self._angle)],
+                            [-1j * math.sin(0.5 * self._angle),
+                             math.cos(0.5 * self._angle)]])
 
 
 class Ry(BasicRotationGate):
-	""" RotationX gate class """
-	@property
-	def matrix(self):
-		return np.matrix([[math.cos(0.5 * self._angle),
-		                   -math.sin(0.5 * self._angle)],
-			                [math.sin(0.5 * self._angle),
-			                 math.cos(0.5 * self._angle)]])
+    """ RotationX gate class """
+    @property
+    def matrix(self):
+        return np.matrix([[math.cos(0.5 * self._angle),
+                           -math.sin(0.5 * self._angle)],
+                            [math.sin(0.5 * self._angle),
+                             math.cos(0.5 * self._angle)]])
 
 
 class Rz(BasicRotationGate):
-	""" RotationZ gate class """
-	@property
-	def matrix(self):
-		return np.matrix([[cmath.exp(-.5 * 1j * self._angle), 0],
-		                  [0, cmath.exp(.5 * 1j * self._angle)]])
+    """ RotationZ gate class """
+    @property
+    def matrix(self):
+        return np.matrix([[cmath.exp(-.5 * 1j * self._angle), 0],
+                          [0, cmath.exp(.5 * 1j * self._angle)]])
 
 
 class R(BasicRotationGate):
-	""" Phase-shift gate (equivalent to Rz up to a global phase) """
-	@property
-	def matrix(self):
-		return np.matrix([[1, 0], [0, cmath.exp(1j * self._angle)]])
+    """ Phase-shift gate (equivalent to Rz up to a global phase) """
+    @property
+    def matrix(self):
+        return np.matrix([[1, 0], [0, cmath.exp(1j * self._angle)]])
 
 
 class FlushGate(FastForwardingGate):
-	"""
-	Flush gate (denotes the end of the circuit).
+    """
+    Flush gate (denotes the end of the circuit).
 
-	Note:
-		All compiler engines (cengines) which cache/buffer gates are obligated to
-		flush and send all gates to the next compiler engine (followed by the
-		flush command).
-	
-	Note:
-		This gate is sent when calling
-		
-		.. code-block:: python
-		
-			eng.flush()
-		
-		on the MainEngine `eng`.
-	"""
+    Note:
+        All compiler engines (cengines) which cache/buffer gates are obligated to
+        flush and send all gates to the next compiler engine (followed by the
+        flush command).
 
-	def __str__(self):
-		return ""
+    Note:
+        This gate is sent when calling
+
+        .. code-block:: python
+
+            eng.flush()
+
+        on the MainEngine `eng`.
+    """
+
+    def __str__(self):
+        return ""
 
 
 class MeasureGate(FastForwardingGate):
-	""" Measurement gate class """
-	def __str__(self):
-		return "Measure"
+    """ Measurement gate class """
+    def __str__(self):
+        return "Measure"
 
 Measure = MeasureGate()
 
 
 class AllocateQubitGate(ClassicalInstructionGate):
-	""" Qubit allocation gate class """
-	def __str__(self):
-		return "Allocate"
+    """ Qubit allocation gate class """
+    def __str__(self):
+        return "Allocate"
 
-	def get_inverse(self):
-		return DeallocateQubitGate()
+    def get_inverse(self):
+        return DeallocateQubitGate()
 
 Allocate = AllocateQubitGate()
 
 
 class DeallocateQubitGate(FastForwardingGate):
-	""" Qubit deallocation gate class """
-	def __str__(self):
-		return "Deallocate"
+    """ Qubit deallocation gate class """
+    def __str__(self):
+        return "Deallocate"
 
-	def get_inverse(self):
-		return Allocate
+    def get_inverse(self):
+        return Allocate
 
 Deallocate = DeallocateQubitGate()
 
 
 class AllocateDirtyQubitGate(ClassicalInstructionGate):
-	""" Dirty qubit allocation gate class """
-	def __str__(self):
-		return "AllocateDirty"
+    """ Dirty qubit allocation gate class """
+    def __str__(self):
+        return "AllocateDirty"
 
-	def get_inverse(self):
-		return Deallocate
+    def get_inverse(self):
+        return Deallocate
 
 AllocateDirty = AllocateDirtyQubitGate()

--- a/projectq/ops/_gates_test.py
+++ b/projectq/ops/_gates_test.py
@@ -17,143 +17,143 @@ import cmath
 import numpy as np
 import pytest
 
-from projectq.ops import (get_inverse, SelfInverseGate, BasicRotationGate, 
-                          ClassicalInstructionGate, FastForwardingGate, 
+from projectq.ops import (get_inverse, SelfInverseGate, BasicRotationGate,
+                          ClassicalInstructionGate, FastForwardingGate,
                           BasicGate)
 
 from projectq.ops import _gates
 
 
 def test_h_gate():
-	gate = _gates.HGate()
-	assert gate == gate.get_inverse()
-	assert str(gate) == "H"
-	assert np.array_equal(gate.matrix, 
-		1. / math.sqrt(2) * np.matrix([[1, 1], [1, -1]]))
-	assert isinstance(_gates.H, _gates.HGate)
+    gate = _gates.HGate()
+    assert gate == gate.get_inverse()
+    assert str(gate) == "H"
+    assert np.array_equal(gate.matrix,
+        1. / math.sqrt(2) * np.matrix([[1, 1], [1, -1]]))
+    assert isinstance(_gates.H, _gates.HGate)
 
 
 def test_x_gate():
-	gate = _gates.XGate()
-	assert gate == gate.get_inverse()
-	assert str(gate) == "X"
-	assert np.array_equal(gate.matrix, np.matrix([[0, 1], [1, 0]]))
-	assert isinstance(_gates.X, _gates.XGate)
-	assert isinstance(_gates.NOT, _gates.XGate)
+    gate = _gates.XGate()
+    assert gate == gate.get_inverse()
+    assert str(gate) == "X"
+    assert np.array_equal(gate.matrix, np.matrix([[0, 1], [1, 0]]))
+    assert isinstance(_gates.X, _gates.XGate)
+    assert isinstance(_gates.NOT, _gates.XGate)
 
 
 def test_y_gate():
-	gate = _gates.YGate()
-	assert gate == gate.get_inverse()
-	assert str(gate) == "Y"
-	assert np.array_equal(gate.matrix, np.matrix([[0, -1j], [1j, 0]]))
-	assert isinstance(_gates.Y, _gates.YGate)
+    gate = _gates.YGate()
+    assert gate == gate.get_inverse()
+    assert str(gate) == "Y"
+    assert np.array_equal(gate.matrix, np.matrix([[0, -1j], [1j, 0]]))
+    assert isinstance(_gates.Y, _gates.YGate)
 
 
 def test_z_gate():
-	gate = _gates.ZGate()
-	assert gate == gate.get_inverse()
-	assert str(gate) == "Z"
-	assert np.array_equal(gate.matrix, np.matrix([[1, 0], [0, -1]]))
-	assert isinstance(_gates.Z, _gates.ZGate)
+    gate = _gates.ZGate()
+    assert gate == gate.get_inverse()
+    assert str(gate) == "Z"
+    assert np.array_equal(gate.matrix, np.matrix([[1, 0], [0, -1]]))
+    assert isinstance(_gates.Z, _gates.ZGate)
 
 
 def test_s_gate():
-	gate = _gates.SGate()
-	assert str(gate) == "S"
-	assert np.array_equal(gate.matrix, np.matrix([[1, 0], [0, 1j]]))
-	assert isinstance(_gates.S, _gates.SGate)
-	assert type(_gates.Sdag) == type(get_inverse(gate))
-	assert type(_gates.Sdagger) == type(get_inverse(gate))
+    gate = _gates.SGate()
+    assert str(gate) == "S"
+    assert np.array_equal(gate.matrix, np.matrix([[1, 0], [0, 1j]]))
+    assert isinstance(_gates.S, _gates.SGate)
+    assert type(_gates.Sdag) == type(get_inverse(gate))
+    assert type(_gates.Sdagger) == type(get_inverse(gate))
 
 
 def test_t_gate():
-	gate = _gates.TGate()
-	assert str(gate) == "T"
-	assert np.array_equal(gate.matrix, 
-	                np.matrix([[1, 0], [0, cmath.exp(1j * cmath.pi / 4)]]))
-	assert isinstance(_gates.T, _gates.TGate)
-	assert type(_gates.Tdag) == type(get_inverse(gate))
-	assert type(_gates.Tdagger) == type(get_inverse(gate))
+    gate = _gates.TGate()
+    assert str(gate) == "T"
+    assert np.array_equal(gate.matrix,
+                    np.matrix([[1, 0], [0, cmath.exp(1j * cmath.pi / 4)]]))
+    assert isinstance(_gates.T, _gates.TGate)
+    assert type(_gates.Tdag) == type(get_inverse(gate))
+    assert type(_gates.Tdagger) == type(get_inverse(gate))
 
 
 def test_swap_gate():
-	gate = _gates.SwapGate()
-	assert gate == gate.get_inverse()
-	assert str(gate) == "Swap"
-	assert gate.interchangeable_qubit_indices == [[0, 1]]
-	assert np.array_equal(gate.matrix, 
-	       np.matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]))
-	assert isinstance(_gates.Swap, _gates.SwapGate)
+    gate = _gates.SwapGate()
+    assert gate == gate.get_inverse()
+    assert str(gate) == "Swap"
+    assert gate.interchangeable_qubit_indices == [[0, 1]]
+    assert np.array_equal(gate.matrix,
+           np.matrix([[1, 0, 0, 0], [0, 0, 1, 0], [0, 1, 0, 0], [0, 0, 0, 1]]))
+    assert isinstance(_gates.Swap, _gates.SwapGate)
 
 
 def test_engangle_gate():
-	gate = _gates.EntangleGate()
-	assert str(gate) == "Entangle"
-	assert isinstance(_gates.Entangle, _gates.EntangleGate)
+    gate = _gates.EntangleGate()
+    assert str(gate) == "Entangle"
+    assert isinstance(_gates.Entangle, _gates.EntangleGate)
 
 
 @pytest.mark.parametrize("angle", [0, 0.2, 2.1, 4.1, 2* math.pi,
-	4 * math.pi])
+    4 * math.pi])
 def test_rx(angle):
-	gate = _gates.Rx(angle)
-	expected_matrix = np.matrix([[math.cos(0.5 * angle),
-		               -1j * math.sin(0.5 * angle)],
-			          [-1j * math.sin(0.5 * angle),
-			           math.cos(0.5 * angle)]])
-	assert gate.matrix.shape == expected_matrix.shape
-	assert np.allclose(gate.matrix, expected_matrix)
+    gate = _gates.Rx(angle)
+    expected_matrix = np.matrix([[math.cos(0.5 * angle),
+                       -1j * math.sin(0.5 * angle)],
+                      [-1j * math.sin(0.5 * angle),
+                       math.cos(0.5 * angle)]])
+    assert gate.matrix.shape == expected_matrix.shape
+    assert np.allclose(gate.matrix, expected_matrix)
 
 
 @pytest.mark.parametrize("angle", [0, 0.2, 2.1, 4.1, 2* math.pi,
-	4 * math.pi])
+    4 * math.pi])
 def test_ry(angle):
-	gate = _gates.Ry(angle)
-	expected_matrix = np.matrix([[math.cos(0.5 * angle),
-		               -math.sin(0.5 * angle)],
-			          [math.sin(0.5 * angle),
-			           math.cos(0.5 * angle)]])
-	assert gate.matrix.shape == expected_matrix.shape
-	assert np.allclose(gate.matrix, expected_matrix)
+    gate = _gates.Ry(angle)
+    expected_matrix = np.matrix([[math.cos(0.5 * angle),
+                       -math.sin(0.5 * angle)],
+                      [math.sin(0.5 * angle),
+                       math.cos(0.5 * angle)]])
+    assert gate.matrix.shape == expected_matrix.shape
+    assert np.allclose(gate.matrix, expected_matrix)
 
 
 @pytest.mark.parametrize("angle", [0, 0.2, 2.1, 4.1, 2* math.pi,
-	4 * math.pi])
+    4 * math.pi])
 def test_rz(angle):
-	gate = _gates.Rz(angle)
-	expected_matrix = np.matrix([[cmath.exp(-.5 * 1j * angle), 0],
-	                  [0, cmath.exp(.5 * 1j * angle)]])
-	assert gate.matrix.shape == expected_matrix.shape
-	assert np.allclose(gate.matrix, expected_matrix)
+    gate = _gates.Rz(angle)
+    expected_matrix = np.matrix([[cmath.exp(-.5 * 1j * angle), 0],
+                      [0, cmath.exp(.5 * 1j * angle)]])
+    assert gate.matrix.shape == expected_matrix.shape
+    assert np.allclose(gate.matrix, expected_matrix)
 
 
 def test_flush_gate():
-	gate = _gates.FlushGate()
-	assert str(gate) == ""
+    gate = _gates.FlushGate()
+    assert str(gate) == ""
 
 
 def test_measure_gate():
-	gate = _gates.MeasureGate()
-	assert str(gate) == "Measure"
-	assert isinstance(_gates.Measure, _gates.MeasureGate)
+    gate = _gates.MeasureGate()
+    assert str(gate) == "Measure"
+    assert isinstance(_gates.Measure, _gates.MeasureGate)
 
 
 def test_allocate_qubit_gate():
-	gate = _gates.AllocateQubitGate()
-	assert str(gate) == "Allocate"
-	assert gate.get_inverse() == _gates.DeallocateQubitGate()
-	assert isinstance(_gates.Allocate, _gates.AllocateQubitGate)
+    gate = _gates.AllocateQubitGate()
+    assert str(gate) == "Allocate"
+    assert gate.get_inverse() == _gates.DeallocateQubitGate()
+    assert isinstance(_gates.Allocate, _gates.AllocateQubitGate)
 
 
 def test_deallocate_qubit_gate():
-	gate = _gates.DeallocateQubitGate()
-	assert str(gate) == "Deallocate"
-	assert gate.get_inverse() == _gates.AllocateQubitGate()
-	assert isinstance(_gates.Deallocate, _gates.DeallocateQubitGate)
+    gate = _gates.DeallocateQubitGate()
+    assert str(gate) == "Deallocate"
+    assert gate.get_inverse() == _gates.AllocateQubitGate()
+    assert isinstance(_gates.Deallocate, _gates.DeallocateQubitGate)
 
 
 def test_allocate_dirty_qubit_gate():
-	gate = _gates.AllocateDirtyQubitGate()
-	assert str(gate) == "AllocateDirty"
-	assert gate.get_inverse() == _gates.DeallocateQubitGate()
-	assert isinstance(_gates.AllocateDirty, _gates.AllocateDirtyQubitGate)
+    gate = _gates.AllocateDirtyQubitGate()
+    assert str(gate) == "AllocateDirty"
+    assert gate.get_inverse() == _gates.DeallocateQubitGate()
+    assert isinstance(_gates.AllocateDirty, _gates.AllocateDirtyQubitGate)

--- a/projectq/ops/_metagates.py
+++ b/projectq/ops/_metagates.py
@@ -15,10 +15,10 @@ Contains meta gates, i.e.,
 * DaggeredGate (Represents the inverse of an arbitrary gate)
 * ControlledGate (Represents a controlled version of an arbitrary gate)
 * Tensor/All (Applies a single qubit gate to all supplied qubits), e.g.,
-	Example:
-		.. code-block:: python
-		
-	  	Tensor(H) | (qubit1, qubit2) # apply H to qubit #1 and #2
+    Example:
+        .. code-block:: python
+
+          Tensor(H) | (qubit1, qubit2) # apply H to qubit #1 and #2
 
 As well as the meta functions
 * get_inverse (Tries to access the get_inverse member function of a gate
@@ -31,248 +31,248 @@ from ._command import Command, apply_command
 
 
 class ControlQubitError(Exception):
-	"""
-	Exception thrown when wrong number of control qubits are supplied.
-	"""
-	pass
+    """
+    Exception thrown when wrong number of control qubits are supplied.
+    """
+    pass
 
 
 class DaggeredGate(BasicGate):
-	"""
-	Wrapper class allowing to execute the inverse of a gate, even when it does
-	not define one.
+    """
+    Wrapper class allowing to execute the inverse of a gate, even when it does
+    not define one.
 
-	If there is a replacement available, then there is also one for the inverse,
-	namely the replacement function run in reverse, while inverting all gates.
-	This class enables using this emulation automatically.
+    If there is a replacement available, then there is also one for the inverse,
+    namely the replacement function run in reverse, while inverting all gates.
+    This class enables using this emulation automatically.
 
-	A DaggeredGate is returned automatically when employing the get_inverse-
-	function on a gate which does not provide a get_inverse() member function.
+    A DaggeredGate is returned automatically when employing the get_inverse-
+    function on a gate which does not provide a get_inverse() member function.
 
-	Example:
-		.. code-block:: python
-		
-			with Dagger(eng):
-				MySpecialGate | qubits
-	
-	will create a DaggeredGate if MySpecialGate does not implement get_inverse.
-	If there is a decomposition function available, an auto-replacer engine can
-	automatically replace the inverted gate by a call to the decomposition
-	function inside a "with Dagger"-statement.
-	"""
+    Example:
+        .. code-block:: python
 
-	def __init__(self, gate):
-		"""
-		Initialize a DaggeredGate representing the inverse of the gate 'gate'.
+            with Dagger(eng):
+                MySpecialGate | qubits
 
-		Args:
-			gate: Any gate object of which to represent the inverse.
-		"""
-		BasicGate.__init__(self)
-		self._gate = gate
+    will create a DaggeredGate if MySpecialGate does not implement get_inverse.
+    If there is a decomposition function available, an auto-replacer engine can
+    automatically replace the inverted gate by a call to the decomposition
+    function inside a "with Dagger"-statement.
+    """
 
-		try:
-			# Hermitian conjugate is inverse matrix
-			self.matrix = gate.matrix.getH()
-		except AttributeError:
-			pass
+    def __init__(self, gate):
+        """
+        Initialize a DaggeredGate representing the inverse of the gate 'gate'.
 
-	def __str__(self):
-		"""
-		Return string representation (str(gate) + \"^\dagger\").
-		"""
-		return str(self._gate) + "^\dagger"
+        Args:
+            gate: Any gate object of which to represent the inverse.
+        """
+        BasicGate.__init__(self)
+        self._gate = gate
 
-	def get_inverse(self):
-		"""
-		Return the inverse gate (the inverse of the inverse of a gate is the
-		gate itself).
-		"""
-		return self._gate
+        try:
+            # Hermitian conjugate is inverse matrix
+            self.matrix = gate.matrix.getH()
+        except AttributeError:
+            pass
 
-	def __eq__(self, other):
-		"""
-		Return True if self is equal to other, i.e., same type and
-		representing the inverse of the same gate.
-		"""
-		return isinstance(other, self.__class__) and self._gate == other._gate
+    def __str__(self):
+        """
+        Return string representation (str(gate) + \"^\dagger\").
+        """
+        return str(self._gate) + "^\dagger"
+
+    def get_inverse(self):
+        """
+        Return the inverse gate (the inverse of the inverse of a gate is the
+        gate itself).
+        """
+        return self._gate
+
+    def __eq__(self, other):
+        """
+        Return True if self is equal to other, i.e., same type and
+        representing the inverse of the same gate.
+        """
+        return isinstance(other, self.__class__) and self._gate == other._gate
 
 
 def get_inverse(gate):
-	"""
-	Return the inverse of a gate.
+    """
+    Return the inverse of a gate.
 
-	Tries to call gate.get_inverse and, upon failure, creates a DaggeredGate
-	instead.
+    Tries to call gate.get_inverse and, upon failure, creates a DaggeredGate
+    instead.
 
-	Args:
-		gate: Gate of which to get the inverse
+    Args:
+        gate: Gate of which to get the inverse
 
-	Example:
-		.. code-block:: python
-		
-			get_inverse(H) # returns a Hadamard gate (HGate object)
-	"""
-	try:
-		return gate.get_inverse()
-	except NotInvertible:
-		return DaggeredGate(gate)
+    Example:
+        .. code-block:: python
+
+            get_inverse(H) # returns a Hadamard gate (HGate object)
+    """
+    try:
+        return gate.get_inverse()
+    except NotInvertible:
+        return DaggeredGate(gate)
 
 
 class ControlledGate(BasicGate):
-	"""
-	Controlled version of a gate.
+    """
+    Controlled version of a gate.
 
-	Note:
-		Use the meta function :func:`C()` to create a controlled gate
+    Note:
+        Use the meta function :func:`C()` to create a controlled gate
 
-	A wrapper class which enables (multi-) controlled gates. It overloads
-	the __or__-operator, using the first qubits provided as control qubits.
-	The n control-qubits need to be the first n qubits. They can be in
-	separate quregs.
+    A wrapper class which enables (multi-) controlled gates. It overloads
+    the __or__-operator, using the first qubits provided as control qubits.
+    The n control-qubits need to be the first n qubits. They can be in
+    separate quregs.
 
-	Example:
-		.. code-block:: python
-		
-			ControlledGate(gate, 2) | (qb0, qb2, qb3) # qb0 and qb2 are controls
-			C(gate, 2) | (qb0, qb2, qb3) # This is much nicer.
-			C(gate, 2) | ([qb0,qb2], qb3) # Is equivalent
+    Example:
+        .. code-block:: python
 
-	Note:
-		Use :func:`C` rather than ControlledGate, i.e.,
-		
-		.. code-block:: python
-		
-			C(X, 2) == Toffoli
-	"""
+            ControlledGate(gate, 2) | (qb0, qb2, qb3) # qb0 and qb2 are controls
+            C(gate, 2) | (qb0, qb2, qb3) # This is much nicer.
+            C(gate, 2) | ([qb0,qb2], qb3) # Is equivalent
 
-	def __init__(self, gate, n=1):
-		"""
-		Initialize a ControlledGate object.
+    Note:
+        Use :func:`C` rather than ControlledGate, i.e.,
 
-		Args:
-			gate: Gate to wrap.
-			n (int): Number of control qubits.
-		"""
-		BasicGate.__init__(self)
-		if isinstance(gate, ControlledGate):
-			self._gate = gate._gate
-			self._n = gate._n + n
-		else:
-			self._gate = gate
-			self._n = n
+        .. code-block:: python
 
-	def __str__(self):
-		""" Return string representation, i.e., CC...C(gate). """
-		return "C" * self._n + str(self._gate)
+            C(X, 2) == Toffoli
+    """
 
-	def get_inverse(self):
-		"""
-		Return inverse of a controlled gate, which is the controlled inverse gate.
-		"""
-		return ControlledGate(get_inverse(self._gate), self._n)
+    def __init__(self, gate, n=1):
+        """
+        Initialize a ControlledGate object.
 
-	def __or__(self, qubits):
-		"""
-		Apply the controlled gate to qubits, using the first n qubits as controls.
+        Args:
+            gate: Gate to wrap.
+            n (int): Number of control qubits.
+        """
+        BasicGate.__init__(self)
+        if isinstance(gate, ControlledGate):
+            self._gate = gate._gate
+            self._n = gate._n + n
+        else:
+            self._gate = gate
+            self._n = n
 
-		Note: The control qubits can be split across the first quregs. However,
-		      the n-th control qubit needs to be the last qubit in a qureg. 
-		      The following quregs belong to the gate.
+    def __str__(self):
+        """ Return string representation, i.e., CC...C(gate). """
+        return "C" * self._n + str(self._gate)
 
-		Args:
-			qubits (tuple of lists of Qubit objects): qubits to which to apply the
-			                                          gate.
-		"""
-		qubits = BasicGate.make_tuple_of_qureg(qubits)
-		n = self._n
-		ctrl = []
-		gate_quregs = []
-		added_ctrl_qubits = 0
-		for qureg in qubits:
-			if added_ctrl_qubits < n:
-				ctrl = ctrl + qureg
-				added_ctrl_qubits += len(qureg)
-			else:
-				gate_quregs.append(qureg)
-		# Test that there were enough control qubits and that that
-		# the last control qubit was the last qubit in a qureg.
-		if added_ctrl_qubits != n:
-			raise ControlQubitError("Wrong number of control qubits. " + 
-				"First qureg(s) need to contain exactly the required " +
-				"number of control qubits.")
-		cmd = BasicGate.generate_command(self._gate, tuple(gate_quregs))
-		cmd.add_control_qubits(ctrl)
-		apply_command(cmd)
+    def get_inverse(self):
+        """
+        Return inverse of a controlled gate, which is the controlled inverse gate.
+        """
+        return ControlledGate(get_inverse(self._gate), self._n)
+
+    def __or__(self, qubits):
+        """
+        Apply the controlled gate to qubits, using the first n qubits as controls.
+
+        Note: The control qubits can be split across the first quregs. However,
+              the n-th control qubit needs to be the last qubit in a qureg.
+              The following quregs belong to the gate.
+
+        Args:
+            qubits (tuple of lists of Qubit objects): qubits to which to apply the
+                                                      gate.
+        """
+        qubits = BasicGate.make_tuple_of_qureg(qubits)
+        n = self._n
+        ctrl = []
+        gate_quregs = []
+        added_ctrl_qubits = 0
+        for qureg in qubits:
+            if added_ctrl_qubits < n:
+                ctrl = ctrl + qureg
+                added_ctrl_qubits += len(qureg)
+            else:
+                gate_quregs.append(qureg)
+        # Test that there were enough control qubits and that that
+        # the last control qubit was the last qubit in a qureg.
+        if added_ctrl_qubits != n:
+            raise ControlQubitError("Wrong number of control qubits. " +
+                "First qureg(s) need to contain exactly the required " +
+                "number of control qubits.")
+        cmd = BasicGate.generate_command(self._gate, tuple(gate_quregs))
+        cmd.add_control_qubits(ctrl)
+        apply_command(cmd)
 
 
-	def __eq__(self, other):
-		""" Compare two ControlledGate objects (return True if equal). """
-		return (isinstance(other, self.__class__) and
-		        self._gate == other._gate and self._n == other._n)
+    def __eq__(self, other):
+        """ Compare two ControlledGate objects (return True if equal). """
+        return (isinstance(other, self.__class__) and
+                self._gate == other._gate and self._n == other._n)
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 
 def C(gate, n=1):
-	"""
-	Return n-controlled version of the provided gate.
+    """
+    Return n-controlled version of the provided gate.
 
-	Args:
-		gate: Gate to turn into its controlled version
-		n: Number of controls (default: 1)
+    Args:
+        gate: Gate to turn into its controlled version
+        n: Number of controls (default: 1)
 
-	Example:
-		.. code-block:: python
-		
-			C(NOT) | (c, q) # equivalent to CNOT | (c, q)
-	"""
-	return ControlledGate(gate, n)
+    Example:
+        .. code-block:: python
+
+            C(NOT) | (c, q) # equivalent to CNOT | (c, q)
+    """
+    return ControlledGate(gate, n)
 
 
 class Tensor(BasicGate):
-	"""
-	Wrapper class allowing to apply a (single-qubit) gate to every qubit in a
-	quantum register. Allowed syntax is to supply either a qureg or a tuple
-	which contains only one qureg.
+    """
+    Wrapper class allowing to apply a (single-qubit) gate to every qubit in a
+    quantum register. Allowed syntax is to supply either a qureg or a tuple
+    which contains only one qureg.
 
-	Example:
-		.. code-block:: python
-		
-			Tensor(H) | x # applies H to every qubit in the list of qubits x
-			Tensor(H) | (x,) # alternative to be consistent with other syntax
-	"""
+    Example:
+        .. code-block:: python
 
-	def __init__(self, gate):
-		""" Initialize a Tensor object for the gate. """
-		BasicGate.__init__(self)
-		self._gate = gate
+            Tensor(H) | x # applies H to every qubit in the list of qubits x
+            Tensor(H) | (x,) # alternative to be consistent with other syntax
+    """
 
-	def __str__(self):
-		""" Return string representation. """
-		return "Tensor(" + str(self._gate) + ")"
+    def __init__(self, gate):
+        """ Initialize a Tensor object for the gate. """
+        BasicGate.__init__(self)
+        self._gate = gate
 
-	def get_inverse(self):
-		"""
-		Return the inverse of this tensored gate (which is the tensored inverse of
-		the gate).
-		"""
-		return Tensor(get_inverse(self._gate))
+    def __str__(self):
+        """ Return string representation. """
+        return "Tensor(" + str(self._gate) + ")"
 
-	def __eq__(self, other):
-		return isinstance(other, Tensor) and self._gate == other._gate
+    def get_inverse(self):
+        """
+        Return the inverse of this tensored gate (which is the tensored inverse of
+        the gate).
+        """
+        return Tensor(get_inverse(self._gate))
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __eq__(self, other):
+        return isinstance(other, Tensor) and self._gate == other._gate
 
-	def __or__(self, qubits):
-		""" Applies the gate to every qubit in the quantum register qubits. """
-		if isinstance(qubits, tuple):
-			assert len(qubits) == 1
-			qubits = qubits[0]
-		assert isinstance(qubits, list)
-		for qubit in qubits:
-			self._gate | qubit
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __or__(self, qubits):
+        """ Applies the gate to every qubit in the quantum register qubits. """
+        if isinstance(qubits, tuple):
+            assert len(qubits) == 1
+            qubits = qubits[0]
+        assert isinstance(qubits, list)
+        for qubit in qubits:
+            self._gate | qubit
 
 All = Tensor

--- a/projectq/ops/_metagates_test.py
+++ b/projectq/ops/_metagates_test.py
@@ -20,7 +20,7 @@ import pytest
 from projectq.types import Qubit, Qureg
 from projectq import MainEngine
 from projectq.cengines import DummyEngine
-from projectq.ops import (T, Y, NotInvertible, Entangle, Rx, 
+from projectq.ops import (T, Y, NotInvertible, Entangle, Rx,
                           FastForwardingGate, Command,
                           ClassicalInstructionGate)
 
@@ -28,180 +28,180 @@ from projectq.ops import _metagates
 
 
 def test_daggered_gate_init():
-	# Choose gate which does not have an inverse gate:
-	not_invertible_gate = T
-	with pytest.raises(NotInvertible):
-		not_invertible_gate.get_inverse()
-	# Choose gate which does have an inverse defined:
-	invertible_gate = Y
-	assert invertible_gate.get_inverse() == Y
-	# Test init and matrix
-	dagger_inv = _metagates.DaggeredGate(not_invertible_gate)
-	assert dagger_inv._gate == not_invertible_gate
-	assert np.array_equal(dagger_inv.matrix, 
-		np.matrix([[1, 0], [0, cmath.exp(-1j * cmath.pi / 4)]]))
-	inv = _metagates.DaggeredGate(invertible_gate)
-	assert inv._gate == invertible_gate
-	assert np.array_equal(inv.matrix, np.matrix([[0, -1j], [1j, 0]]))
-	# Test matrix 
-	no_matrix_gate = Entangle
-	with pytest.raises(AttributeError):
-		no_matrix_gate.matrix
-	inv_no_matrix_gate = _metagates.DaggeredGate(no_matrix_gate)
-	with pytest.raises(AttributeError):
-		inv_no_matrix_gate.matrix
+    # Choose gate which does not have an inverse gate:
+    not_invertible_gate = T
+    with pytest.raises(NotInvertible):
+        not_invertible_gate.get_inverse()
+    # Choose gate which does have an inverse defined:
+    invertible_gate = Y
+    assert invertible_gate.get_inverse() == Y
+    # Test init and matrix
+    dagger_inv = _metagates.DaggeredGate(not_invertible_gate)
+    assert dagger_inv._gate == not_invertible_gate
+    assert np.array_equal(dagger_inv.matrix,
+        np.matrix([[1, 0], [0, cmath.exp(-1j * cmath.pi / 4)]]))
+    inv = _metagates.DaggeredGate(invertible_gate)
+    assert inv._gate == invertible_gate
+    assert np.array_equal(inv.matrix, np.matrix([[0, -1j], [1j, 0]]))
+    # Test matrix
+    no_matrix_gate = Entangle
+    with pytest.raises(AttributeError):
+        no_matrix_gate.matrix
+    inv_no_matrix_gate = _metagates.DaggeredGate(no_matrix_gate)
+    with pytest.raises(AttributeError):
+        inv_no_matrix_gate.matrix
 
 
 def test_daggered_gate_str():
-	daggered_gate = _metagates.DaggeredGate(Y)
-	assert str(daggered_gate) == str(Y) + "^\dagger"
+    daggered_gate = _metagates.DaggeredGate(Y)
+    assert str(daggered_gate) == str(Y) + "^\dagger"
 
 
 def test_daggered_gate_get_inverse():
-	daggered_gate = _metagates.DaggeredGate(Y)
-	assert daggered_gate.get_inverse() == Y
+    daggered_gate = _metagates.DaggeredGate(Y)
+    assert daggered_gate.get_inverse() == Y
 
 
 def test_daggered_gate_comparison():
-	daggered_gate = _metagates.DaggeredGate(Y)
-	daggered_gate2 = _metagates.DaggeredGate(Y)
-	assert daggered_gate == daggered_gate2
+    daggered_gate = _metagates.DaggeredGate(Y)
+    daggered_gate2 = _metagates.DaggeredGate(Y)
+    assert daggered_gate == daggered_gate2
 
 
 def test_get_inverse():
-	# Choose gate which does not have an inverse gate:
-	not_invertible_gate = T
-	with pytest.raises(NotInvertible):
-		not_invertible_gate.get_inverse()
-	# Choose gate which does have an inverse defined:
-	invertible_gate = Y
-	assert invertible_gate.get_inverse() == Y
-	# Check get_inverse(gate)
-	inv = _metagates.get_inverse(not_invertible_gate)
-	assert (isinstance(inv, _metagates.DaggeredGate) and 
-	        inv._gate == not_invertible_gate)
-	inv2 = _metagates.get_inverse(invertible_gate)
-	assert inv2 == Y
+    # Choose gate which does not have an inverse gate:
+    not_invertible_gate = T
+    with pytest.raises(NotInvertible):
+        not_invertible_gate.get_inverse()
+    # Choose gate which does have an inverse defined:
+    invertible_gate = Y
+    assert invertible_gate.get_inverse() == Y
+    # Check get_inverse(gate)
+    inv = _metagates.get_inverse(not_invertible_gate)
+    assert (isinstance(inv, _metagates.DaggeredGate) and
+            inv._gate == not_invertible_gate)
+    inv2 = _metagates.get_inverse(invertible_gate)
+    assert inv2 == Y
 
 
 def test_controlled_gate_init():
-	one_control = _metagates.ControlledGate(Y,1)
-	two_control = _metagates.ControlledGate(Y,2)
-	three_control = _metagates.ControlledGate(one_control, 2)
-	assert one_control._gate == Y
-	assert one_control._n == 1
-	assert two_control._gate == Y
-	assert two_control._n == 2
-	assert three_control._gate == Y
-	assert three_control._n == 3
+    one_control = _metagates.ControlledGate(Y,1)
+    two_control = _metagates.ControlledGate(Y,2)
+    three_control = _metagates.ControlledGate(one_control, 2)
+    assert one_control._gate == Y
+    assert one_control._n == 1
+    assert two_control._gate == Y
+    assert two_control._n == 2
+    assert three_control._gate == Y
+    assert three_control._n == 3
 
 
 def test_controlled_gate_str():
-	one_control = _metagates.ControlledGate(Y,2)
-	assert str(one_control) == "CC" + str(Y)
+    one_control = _metagates.ControlledGate(Y,2)
+    assert str(one_control) == "CC" + str(Y)
 
 
 def test_controlled_gate_get_inverse():
-	one_control = _metagates.ControlledGate(Rx(0.5),1)
-	expected = _metagates.ControlledGate(Rx(-0.5 + 4 * math.pi),1)
-	assert one_control.get_inverse() == expected
+    one_control = _metagates.ControlledGate(Rx(0.5),1)
+    expected = _metagates.ControlledGate(Rx(-0.5 + 4 * math.pi),1)
+    assert one_control.get_inverse() == expected
 
 
 def test_controlled_gate_or():
-	saving_backend = DummyEngine(save_commands = True)
-	main_engine = MainEngine(backend = saving_backend,
-	                         engine_list = [DummyEngine()])
-	gate = Rx(0.6)
-	qubit0 = Qubit(main_engine, 0)
-	qubit1 = Qubit(main_engine, 1)
-	qubit2 = Qubit(main_engine, 2)
-	qubit3 = Qubit(main_engine, 3)
-	expected_cmd = Command(main_engine, gate, ([qubit3],))
-	expected_cmd.add_control_qubits([qubit0, qubit1, qubit2])
-	received_commands = []
-	# Option 1:
-	_metagates.ControlledGate(gate, 3) | ([qubit1], [qubit0], [qubit2], [qubit3])
-	# Option 2:
-	_metagates.ControlledGate(gate, 3) | (qubit1, qubit0, qubit2, qubit3)
-	# Option 3:
-	_metagates.ControlledGate(gate, 3) | ([qubit1, qubit0], qubit2, qubit3)
-	# Option 4:
-	_metagates.ControlledGate(gate, 3) | (qubit1, [qubit0, qubit2], qubit3)
-	# Wrong option 5:
-	with pytest.raises(_metagates.ControlQubitError):
-		_metagates.ControlledGate(gate, 3) | (qubit1, [qubit0, qubit2, qubit3])
-	# Remove Allocate and Deallocate gates
-	for cmd in saving_backend.received_commands:
-		if not (isinstance(cmd.gate, FastForwardingGate) or 
-	            isinstance(cmd.gate, ClassicalInstructionGate)):
-			received_commands.append(cmd)
-	assert len(received_commands) == 4
-	for cmd in received_commands:
-		assert cmd == expected_cmd
+    saving_backend = DummyEngine(save_commands = True)
+    main_engine = MainEngine(backend = saving_backend,
+                             engine_list = [DummyEngine()])
+    gate = Rx(0.6)
+    qubit0 = Qubit(main_engine, 0)
+    qubit1 = Qubit(main_engine, 1)
+    qubit2 = Qubit(main_engine, 2)
+    qubit3 = Qubit(main_engine, 3)
+    expected_cmd = Command(main_engine, gate, ([qubit3],))
+    expected_cmd.add_control_qubits([qubit0, qubit1, qubit2])
+    received_commands = []
+    # Option 1:
+    _metagates.ControlledGate(gate, 3) | ([qubit1], [qubit0], [qubit2], [qubit3])
+    # Option 2:
+    _metagates.ControlledGate(gate, 3) | (qubit1, qubit0, qubit2, qubit3)
+    # Option 3:
+    _metagates.ControlledGate(gate, 3) | ([qubit1, qubit0], qubit2, qubit3)
+    # Option 4:
+    _metagates.ControlledGate(gate, 3) | (qubit1, [qubit0, qubit2], qubit3)
+    # Wrong option 5:
+    with pytest.raises(_metagates.ControlQubitError):
+        _metagates.ControlledGate(gate, 3) | (qubit1, [qubit0, qubit2, qubit3])
+    # Remove Allocate and Deallocate gates
+    for cmd in saving_backend.received_commands:
+        if not (isinstance(cmd.gate, FastForwardingGate) or
+                isinstance(cmd.gate, ClassicalInstructionGate)):
+            received_commands.append(cmd)
+    assert len(received_commands) == 4
+    for cmd in received_commands:
+        assert cmd == expected_cmd
 
 
 def test_controlled_gate_comparison():
-	gate1 = _metagates.ControlledGate(Y,1)
-	gate2 = _metagates.ControlledGate(Y,1)
-	gate3 = _metagates.ControlledGate(T,1)
-	gate4 = _metagates.ControlledGate(Y,2)
-	assert gate1 == gate2
-	assert not gate1 == gate3
-	assert gate1 != gate4
+    gate1 = _metagates.ControlledGate(Y,1)
+    gate2 = _metagates.ControlledGate(Y,1)
+    gate3 = _metagates.ControlledGate(T,1)
+    gate4 = _metagates.ControlledGate(Y,2)
+    assert gate1 == gate2
+    assert not gate1 == gate3
+    assert gate1 != gate4
 
 
 def test_c():
-	expected = _metagates.ControlledGate(Y,2)
-	assert _metagates.C(Y, 2) == expected
+    expected = _metagates.ControlledGate(Y,2)
+    assert _metagates.C(Y, 2) == expected
 
 
 def test_tensor_init():
-	gate = _metagates.Tensor(Y)
-	assert gate._gate == Y
+    gate = _metagates.Tensor(Y)
+    assert gate._gate == Y
 
 
 def test_tensor_str():
-	gate = _metagates.Tensor(Y)
-	assert str(gate) == "Tensor(" + str(Y) + ")"
+    gate = _metagates.Tensor(Y)
+    assert str(gate) == "Tensor(" + str(Y) + ")"
 
 
 def test_tensor_get_inverse():
-	gate = _metagates.Tensor(Rx(0.6))
-	inverse = gate.get_inverse()
-	assert isinstance(inverse, _metagates.Tensor)
-	assert inverse._gate == Rx(-0.6 + 4 * math.pi)
+    gate = _metagates.Tensor(Rx(0.6))
+    inverse = gate.get_inverse()
+    assert isinstance(inverse, _metagates.Tensor)
+    assert inverse._gate == Rx(-0.6 + 4 * math.pi)
 
 
 def test_tensor_comparison():
-	gate1 = _metagates.Tensor(Rx(0.6))
-	gate2 = _metagates.Tensor(Rx(0.6 + 4 * math.pi))
-	assert gate1 == gate2
-	assert gate1 != Rx(0.6)
+    gate1 = _metagates.Tensor(Rx(0.6))
+    gate2 = _metagates.Tensor(Rx(0.6 + 4 * math.pi))
+    assert gate1 == gate2
+    assert gate1 != Rx(0.6)
 
 
 def test_tensor_or():
-	saving_backend = DummyEngine(save_commands = True)
-	main_engine = MainEngine(backend = saving_backend,
-	                         engine_list = [DummyEngine()])
-	gate = Rx(0.6)
-	qubit0 = Qubit(main_engine, 0)
-	qubit1 = Qubit(main_engine, 1)
-	qubit2 = Qubit(main_engine, 2)
-	# Option 1:
-	_metagates.Tensor(gate) | ([qubit0, qubit1, qubit2],)
-	# Option 2:
-	_metagates.Tensor(gate) | [qubit0, qubit1, qubit2]
-	received_commands = []
-	# Remove Allocate and Deallocate gates
-	for cmd in saving_backend.received_commands:
-		if not (isinstance(cmd.gate, FastForwardingGate) or 
-	            isinstance(cmd.gate, ClassicalInstructionGate)):
-			received_commands.append(cmd)
-	# Check results
-	assert len(received_commands) == 6
-	qubit_ids = []
-	for cmd in received_commands:
-		assert len(cmd.qubits) == 1
-		assert cmd.gate == gate
-		qubit_ids.append(cmd.qubits[0][0].id)
-	assert sorted(qubit_ids) == [0,0,1,1,2,2]
+    saving_backend = DummyEngine(save_commands = True)
+    main_engine = MainEngine(backend = saving_backend,
+                             engine_list = [DummyEngine()])
+    gate = Rx(0.6)
+    qubit0 = Qubit(main_engine, 0)
+    qubit1 = Qubit(main_engine, 1)
+    qubit2 = Qubit(main_engine, 2)
+    # Option 1:
+    _metagates.Tensor(gate) | ([qubit0, qubit1, qubit2],)
+    # Option 2:
+    _metagates.Tensor(gate) | [qubit0, qubit1, qubit2]
+    received_commands = []
+    # Remove Allocate and Deallocate gates
+    for cmd in saving_backend.received_commands:
+        if not (isinstance(cmd.gate, FastForwardingGate) or
+                isinstance(cmd.gate, ClassicalInstructionGate)):
+            received_commands.append(cmd)
+    # Check results
+    assert len(received_commands) == 6
+    qubit_ids = []
+    for cmd in received_commands:
+        assert len(cmd.qubits) == 1
+        assert cmd.gate == gate
+        qubit_ids.append(cmd.qubits[0][0].id)
+    assert sorted(qubit_ids) == [0,0,1,1,2,2]

--- a/projectq/ops/_qftgate.py
+++ b/projectq/ops/_qftgate.py
@@ -14,10 +14,10 @@ from ._basics import BasicGate
 
 
 class QFTGate(BasicGate):
-	"""
-	Quantum Fourier Transform gate.
-	"""
-	def __str__(self):
-		return "QFT"
+    """
+    Quantum Fourier Transform gate.
+    """
+    def __str__(self):
+        return "QFT"
 
 QFT = QFTGate()

--- a/projectq/ops/_qftgate_test.py
+++ b/projectq/ops/_qftgate_test.py
@@ -15,5 +15,5 @@
 from projectq.ops import _qftgate
 
 def test_qft_gate_str():
-	gate = _qftgate.QFT
-	assert str(gate) == "QFT"
+    gate = _qftgate.QFT
+    assert str(gate) == "QFT"

--- a/projectq/ops/_shortcuts.py
+++ b/projectq/ops/_shortcuts.py
@@ -22,7 +22,7 @@ from ._gates import Rz, NOT
 
 
 def CRz(angle):
-	return C(Rz(angle), n=1)
+    return C(Rz(angle), n=1)
 
 CNOT = CX = C(NOT)
 Toffoli = C(CNOT)

--- a/projectq/ops/_shortcuts_test.py
+++ b/projectq/ops/_shortcuts_test.py
@@ -17,7 +17,7 @@ from projectq.ops import ControlledGate, Rz
 from projectq.ops import _shortcuts
 
 def test_crz():
-	gate = _shortcuts.CRz(0.5)
-	assert isinstance(gate, ControlledGate)
-	assert gate._gate == Rz(0.5)
-	assert gate._n == 1
+    gate = _shortcuts.CRz(0.5)
+    assert isinstance(gate, ControlledGate)
+    assert gate._gate == Rz(0.5)
+    assert gate._n == 1

--- a/projectq/setups/decompositions/_gates_test.py
+++ b/projectq/setups/decompositions/_gates_test.py
@@ -38,78 +38,78 @@ from projectq.meta import Control
 
 
 def low_level_gates(eng, cmd):
-	g = cmd.gate
-	if isinstance(g, ClassicalInstructionGate):
-		return True
-	if len(cmd.control_qubits) == 0:
-		if (g == T or g == Tdag or g == H or isinstance(g, Rz)
-		    or isinstance(g, Ph)):
-			return True
-	else:
-		if len(cmd.control_qubits) == 1 and cmd.gate == X:
-			return True
-	return False
+    g = cmd.gate
+    if isinstance(g, ClassicalInstructionGate):
+        return True
+    if len(cmd.control_qubits) == 0:
+        if (g == T or g == Tdag or g == H or isinstance(g, Rz)
+            or isinstance(g, Ph)):
+            return True
+    else:
+        if len(cmd.control_qubits) == 1 and cmd.gate == X:
+            return True
+    return False
 
 
 def test_entangle():
-	sim = Simulator()
-	eng = MainEngine(sim, [AutoReplacer(), InstructionFilter(low_level_gates)])
-	qureg = eng.allocate_qureg(4)
-	Entangle | qureg
-	
-	assert .5 == pytest.approx(abs(sim.cheat()[1][0])**2)
-	assert .5 == pytest.approx(abs(sim.cheat()[1][-1])**2)
-	
-	Measure | qureg
+    sim = Simulator()
+    eng = MainEngine(sim, [AutoReplacer(), InstructionFilter(low_level_gates)])
+    qureg = eng.allocate_qureg(4)
+    Entangle | qureg
+
+    assert .5 == pytest.approx(abs(sim.cheat()[1][0])**2)
+    assert .5 == pytest.approx(abs(sim.cheat()[1][-1])**2)
+
+    Measure | qureg
 
 
 def low_level_gates_noglobalphase(eng, cmd):
-	return (low_level_gates(eng, cmd) and not isinstance(cmd.gate, Ph)
-	        and not isinstance(cmd.gate, R))
+    return (low_level_gates(eng, cmd) and not isinstance(cmd.gate, Ph)
+            and not isinstance(cmd.gate, R))
 
 
 def test_globalphase():
-	dummy = DummyEngine(save_commands=True)
-	eng = MainEngine(dummy, [AutoReplacer(),
-	                       InstructionFilter(low_level_gates_noglobalphase)])
-	
-	qubit = eng.allocate_qubit()
-	R(1.2) | qubit
-	
-	rz_count = 0
-	for cmd in dummy.received_commands:
-		assert not isinstance(cmd.gate, R)
-		if isinstance(cmd.gate, Rz):
-			rz_count += 1
-			assert cmd.gate == Rz(1.2)
-	
-	assert rz_count == 1
+    dummy = DummyEngine(save_commands=True)
+    eng = MainEngine(dummy, [AutoReplacer(),
+                           InstructionFilter(low_level_gates_noglobalphase)])
+
+    qubit = eng.allocate_qubit()
+    R(1.2) | qubit
+
+    rz_count = 0
+    for cmd in dummy.received_commands:
+        assert not isinstance(cmd.gate, R)
+        if isinstance(cmd.gate, Rz):
+            rz_count += 1
+            assert cmd.gate == Rz(1.2)
+
+    assert rz_count == 1
 
 
 def run_circuit(eng):
-	qureg = eng.allocate_qureg(4)
-	All(H) | qureg
-	CRz(3.0) | (qureg[0], qureg[1])
-	Toffoli | (qureg[1], qureg[2], qureg[3])
-	
-	with Control(eng, qureg[0:2]):
-		Ph(1.43) | qureg[2]
-	return qureg
+    qureg = eng.allocate_qureg(4)
+    All(H) | qureg
+    CRz(3.0) | (qureg[0], qureg[1])
+    Toffoli | (qureg[1], qureg[2], qureg[3])
+
+    with Control(eng, qureg[0:2]):
+        Ph(1.43) | qureg[2]
+    return qureg
 
 
 def test_gate_decompositions():
-	sim = Simulator()
-	eng = MainEngine(sim, [])
-	
-	qureg = run_circuit(eng)
-	
-	sim2 = Simulator()
-	eng_lowlevel = MainEngine(sim2, [AutoReplacer(),
-	                                InstructionFilter(low_level_gates)])
-	qureg2 = run_circuit(eng_lowlevel)
-	
-	for i in range(len(sim.cheat()[1])):
-		assert sim.cheat()[1][i] == pytest.approx(sim2.cheat()[1][i])
-	
-	Measure | qureg
-	Measure | qureg2
+    sim = Simulator()
+    eng = MainEngine(sim, [])
+
+    qureg = run_circuit(eng)
+
+    sim2 = Simulator()
+    eng_lowlevel = MainEngine(sim2, [AutoReplacer(),
+                                    InstructionFilter(low_level_gates)])
+    qureg2 = run_circuit(eng_lowlevel)
+
+    for i in range(len(sim.cheat()[1])):
+        assert sim.cheat()[1][i] == pytest.approx(sim2.cheat()[1][i])
+
+    Measure | qureg
+    Measure | qureg2

--- a/projectq/setups/decompositions/crz2cxandrz.py
+++ b/projectq/setups/decompositions/crz2cxandrz.py
@@ -22,21 +22,21 @@ from projectq.ops import NOT, Rz, C
 
 
 def _decompose_CRz(cmd):
-	""" Decompose the controlled Rz gate (into CNOT and Rz). """
-	qubit = cmd.qubits[0]
-	ctrl = cmd.control_qubits
-	gate = cmd.gate
-	n = get_control_count(cmd)
-	
-	Rz(0.5 * gate._angle) | qubit
-	C(NOT, n) | (ctrl, qubit)
-	Rz(-0.5 * gate._angle) | qubit
-	C(NOT, n) | (ctrl, qubit)
+    """ Decompose the controlled Rz gate (into CNOT and Rz). """
+    qubit = cmd.qubits[0]
+    ctrl = cmd.control_qubits
+    gate = cmd.gate
+    n = get_control_count(cmd)
+
+    Rz(0.5 * gate._angle) | qubit
+    C(NOT, n) | (ctrl, qubit)
+    Rz(-0.5 * gate._angle) | qubit
+    C(NOT, n) | (ctrl, qubit)
 
 
 def _recognize_CRz(cmd):
-	""" Recognize the controlled Rz gate. """
-	return get_control_count(cmd) >= 1
+    """ Recognize the controlled Rz gate. """
+    return get_control_count(cmd) >= 1
 
 
 register_decomposition(Rz, _decompose_CRz, _recognize_CRz)

--- a/projectq/setups/decompositions/entangle.py
+++ b/projectq/setups/decompositions/entangle.py
@@ -23,14 +23,14 @@ from projectq.ops import X, H, Entangle, All
 
 
 def _decompose_entangle(cmd):
-	""" Decompose the entangle gate. """
-	qr = cmd.qubits[0]
-	eng = cmd.engine
-	
-	with Control(eng, cmd.control_qubits):
-		H | qr[0]
-		with Control(eng, qr[0]):
-			All(X) | qr[1:]
+    """ Decompose the entangle gate. """
+    qr = cmd.qubits[0]
+    eng = cmd.engine
+
+    with Control(eng, cmd.control_qubits):
+        H | qr[0]
+        with Control(eng, qr[0]):
+            All(X) | qr[1:]
 
 
 register_decomposition(Entangle.__class__, _decompose_entangle)

--- a/projectq/setups/decompositions/globalphase.py
+++ b/projectq/setups/decompositions/globalphase.py
@@ -22,13 +22,13 @@ from projectq.ops import Ph
 
 
 def _decompose_PhNoCtrl(cmd):
-	""" Throw out global phases (no controls). """
-	pass
+    """ Throw out global phases (no controls). """
+    pass
 
 
 def _recognize_PhNoCtrl(cmd):
-	""" Recognize global phases (no controls). """
-	return get_control_count(cmd) == 0
+    """ Recognize global phases (no controls). """
+    return get_control_count(cmd) == 0
 
 
 register_decomposition(Ph, _decompose_PhNoCtrl, _recognize_PhNoCtrl)

--- a/projectq/setups/decompositions/ph2r.py
+++ b/projectq/setups/decompositions/ph2r.py
@@ -23,18 +23,18 @@ from projectq.ops import Ph, R
 
 
 def _decompose_Ph(cmd):
-	""" Decompose the controlled phase gate (C^nPh(phase)). """
-	ctrl = cmd.control_qubits
-	gate = cmd.gate
-	eng = cmd.engine
-	
-	with Control(eng, ctrl[1:]):
-		R(gate._angle) | ctrl[0]
+    """ Decompose the controlled phase gate (C^nPh(phase)). """
+    ctrl = cmd.control_qubits
+    gate = cmd.gate
+    eng = cmd.engine
+
+    with Control(eng, ctrl[1:]):
+        R(gate._angle) | ctrl[0]
 
 
 def _recognize_Ph(cmd):
-	""" Recognize the controlled phase gate. """
-	return get_control_count(cmd) >= 1
+    """ Recognize the controlled phase gate. """
+    return get_control_count(cmd) >= 1
 
 
 register_decomposition(Ph, _decompose_Ph, _recognize_Ph)

--- a/projectq/setups/decompositions/qft2crandhadamard.py
+++ b/projectq/setups/decompositions/qft2crandhadamard.py
@@ -16,8 +16,8 @@ Registers a decomposition rule for the quantum Fourier transform.
 Decomposes the QFT gate into Hadamard and controlled phase-shift gates (R).
 
 Warning:
-	The final Swaps are not included, as those are simply a re-indexing of
-	quantum registers.
+    The final Swaps are not included, as those are simply a re-indexing of
+    quantum registers.
 """
 
 import math
@@ -28,14 +28,14 @@ from projectq.meta import Control
 
 
 def _decompose_QFT(cmd):
-	qb = cmd.qubits[0]
-	eng = cmd.engine
-	with Control(eng, cmd.control_qubits):
-		for i in range(len(qb)):
-			H | qb[-1 - i]
-			for j in range(len(qb) - 1 - i):
-				with Control(eng, qb[-1 - (j + i + 1)]):
-					R(math.pi / (1 << (1 + j))) | qb[-1 - i]
+    qb = cmd.qubits[0]
+    eng = cmd.engine
+    with Control(eng, cmd.control_qubits):
+        for i in range(len(qb)):
+            H | qb[-1 - i]
+            for j in range(len(qb) - 1 - i):
+                with Control(eng, qb[-1 - (j + i + 1)]):
+                    R(math.pi / (1 << (1 + j))) | qb[-1 - i]
 
 
 register_decomposition(QFT.__class__, _decompose_QFT)

--- a/projectq/setups/decompositions/r2rzandph.py
+++ b/projectq/setups/decompositions/r2rzandph.py
@@ -23,14 +23,14 @@ from projectq.ops import Ph, Rz, R
 
 
 def _decompose_R(cmd):
-	""" Decompose the (controlled) phase-shift gate, denoted by R(phase). """
-	ctrl = cmd.control_qubits
-	eng = cmd.engine
-	gate = cmd.gate
-	
-	with Control(eng, ctrl):
-		Ph(.5 * gate._angle) | cmd.qubits
-		Rz(gate._angle) | cmd.qubits
+    """ Decompose the (controlled) phase-shift gate, denoted by R(phase). """
+    ctrl = cmd.control_qubits
+    eng = cmd.engine
+    gate = cmd.gate
+
+    with Control(eng, ctrl):
+        Ph(.5 * gate._angle) | cmd.qubits
+        Rz(gate._angle) | cmd.qubits
 
 
 register_decomposition(R, _decompose_R)

--- a/projectq/setups/decompositions/swap2cnot.py
+++ b/projectq/setups/decompositions/swap2cnot.py
@@ -23,14 +23,14 @@ from projectq.ops import Swap, CNOT
 
 
 def _decompose_swap(cmd):
-	""" Decompose (controlled) swap gates. """
-	ctrl = cmd.control_qubits
-	eng = cmd.engine
-	with Compute(eng):
-		CNOT | (cmd.qubits[0], cmd.qubits[1])
-	with Control(eng, ctrl):
-		CNOT | (cmd.qubits[1], cmd.qubits[0])
-	Uncompute(eng)
+    """ Decompose (controlled) swap gates. """
+    ctrl = cmd.control_qubits
+    eng = cmd.engine
+    with Compute(eng):
+        CNOT | (cmd.qubits[0], cmd.qubits[1])
+    with Control(eng, ctrl):
+        CNOT | (cmd.qubits[1], cmd.qubits[0])
+    Uncompute(eng)
 
 
 register_decomposition(Swap.__class__, _decompose_swap)

--- a/projectq/setups/decompositions/toffoli2cnotandtgate.py
+++ b/projectq/setups/decompositions/toffoli2cnotandtgate.py
@@ -22,34 +22,34 @@ from projectq.ops import NOT, CNOT, T, Tdag, H
 
 
 def _decompose_toffoli(cmd):
-	""" Decompose the Toffoli gate into CNOT, H, T, and Tdagger gates. """
-	ctrl = cmd.control_qubits
-	eng = cmd.engine
-	
-	target = cmd.qubits[0]
-	c1 = ctrl[0]
-	c2 = ctrl[1]
-	
-	H | target
-	CNOT | (c1, target)
-	T | c1
-	Tdag | target
-	CNOT | (c2, target)
-	CNOT | (c2, c1)
-	Tdag | c1
-	T | target
-	CNOT | (c2, c1)
-	CNOT | (c1, target)
-	Tdag | target
-	CNOT | (c2, target)
-	T | target
-	T | c2
-	H | target
+    """ Decompose the Toffoli gate into CNOT, H, T, and Tdagger gates. """
+    ctrl = cmd.control_qubits
+    eng = cmd.engine
+
+    target = cmd.qubits[0]
+    c1 = ctrl[0]
+    c2 = ctrl[1]
+
+    H | target
+    CNOT | (c1, target)
+    T | c1
+    Tdag | target
+    CNOT | (c2, target)
+    CNOT | (c2, c1)
+    Tdag | c1
+    T | target
+    CNOT | (c2, c1)
+    CNOT | (c1, target)
+    Tdag | target
+    CNOT | (c2, target)
+    T | target
+    T | c2
+    H | target
 
 
 def _recognize_toffoli(cmd):
-	""" Recognize the Toffoli gate. """
-	return get_control_count(cmd) == 2
+    """ Recognize the Toffoli gate. """
+    return get_control_count(cmd) == 2
 
 
 register_decomposition(NOT.__class__, _decompose_toffoli, _recognize_toffoli)

--- a/projectq/setups/default.py
+++ b/projectq/setups/default.py
@@ -13,11 +13,11 @@
 """
 Registers a variety of useful gate decompositions. Among others it includes
 
-	* Controlled z-rotations --> Controlled NOTs and single-qubit rotations
-	* Toffoli gate --> CNOT and single-qubit gates
-	* m-Controlled global phases --> (m-1)-controlled phase-shifts
-	* Global phases --> ignore
-	* (controlled) Swap gates --> CNOTs and Toffolis
+    * Controlled z-rotations --> Controlled NOTs and single-qubit rotations
+    * Toffoli gate --> CNOT and single-qubit gates
+    * m-Controlled global phases --> (m-1)-controlled phase-shifts
+    * Global phases --> ignore
+    * (controlled) Swap gates --> CNOTs and Toffolis
 """
 
 import projectq
@@ -34,8 +34,8 @@ from projectq.setups.decompositions import (crz2cxandrz,
 
 
 def default_engines():
-	return [TagRemover(), LocalOptimizer(10), AutoReplacer(), TagRemover(),
-	        LocalOptimizer(10)]
+    return [TagRemover(), LocalOptimizer(10), AutoReplacer(), TagRemover(),
+            LocalOptimizer(10)]
 
 
 projectq.default_engines = default_engines

--- a/projectq/setups/ibm.py
+++ b/projectq/setups/ibm.py
@@ -14,11 +14,11 @@
 Registers a variety of useful gate decompositions, specifically for the IBM
 quantum experience backend. Among others it includes:
 
-	* Controlled z-rotations --> Controlled NOTs and single-qubit rotations
-	* Toffoli gate --> CNOT and single-qubit gates
-	* m-Controlled global phases --> (m-1)-controlled phase-shifts
-	* Global phases --> ignore
-	* (controlled) Swap gates --> CNOTs and Toffolis
+    * Controlled z-rotations --> Controlled NOTs and single-qubit rotations
+    * Toffoli gate --> CNOT and single-qubit gates
+    * m-Controlled global phases --> (m-1)-controlled phase-shifts
+    * Global phases --> ignore
+    * (controlled) Swap gates --> CNOTs and Toffolis
 """
 
 
@@ -39,8 +39,8 @@ from projectq.setups.decompositions import (crz2cxandrz,
 
 
 def ibm_default_engines():
-	return [TagRemover(), LocalOptimizer(10), AutoReplacer(), TagRemover(),
-	        IBMCNOTMapper(), LocalOptimizer(10)]
+    return [TagRemover(), LocalOptimizer(10), AutoReplacer(), TagRemover(),
+            IBMCNOTMapper(), LocalOptimizer(10)]
 
 
 projectq.default_engines = ibm_default_engines

--- a/projectq/tests/_factoring_test.py
+++ b/projectq/tests/_factoring_test.py
@@ -24,67 +24,67 @@ from projectq.backends._sim._simulator_test import sim
 
 
 def high_level_gates(eng, cmd):
-	g = cmd.gate
-	if g == QFT or get_inverse(g) == QFT or g == Swap:
-		return True
-	if isinstance(g, BasicMathGate):
-		return False
-	return eng.next_engine.is_available(cmd)
+    g = cmd.gate
+    if g == QFT or get_inverse(g) == QFT or g == Swap:
+        return True
+    if isinstance(g, BasicMathGate):
+        return False
+    return eng.next_engine.is_available(cmd)
 
 
 def get_main_engine(sim):
-	engine_list=[AutoReplacer(), InstructionFilter(high_level_gates),
-	             TagRemover(), LocalOptimizer(3), AutoReplacer(),
-	             TagRemover(), LocalOptimizer(3)]
-	return MainEngine(sim, engine_list)
+    engine_list=[AutoReplacer(), InstructionFilter(high_level_gates),
+                 TagRemover(), LocalOptimizer(3), AutoReplacer(),
+                 TagRemover(), LocalOptimizer(3)]
+    return MainEngine(sim, engine_list)
 
 
 def test_factoring(sim):
-	eng = get_main_engine(sim)
-	
-	ctrl_qubit = eng.allocate_qubit()
-	
-	N = 15
-	a = 2
-	
-	x = eng.allocate_qureg(4)
-	X | x[0]
-	
-	H | ctrl_qubit
-	with Control(eng, ctrl_qubit):
-		MultiplyByConstantModN(pow(a, 2**7, N), N) | x
-	
-	H | ctrl_qubit
-	eng.flush()
-	cheat_tpl = sim.cheat()
-	idx = cheat_tpl[0][ctrl_qubit[0].id]
-	vec = cheat_tpl[1]
-	
-	for i in range(len(vec)):
-		if abs(vec[i]) > 1.e-8:
-			assert ((i >> idx)&1) == 0
-	
-	Measure | ctrl_qubit
-	assert int(ctrl_qubit) == 0
-	del vec, cheat_tpl
-	
-	H | ctrl_qubit
-	with Control(eng, ctrl_qubit):
-		MultiplyByConstantModN(pow(a, 2, N), N) | x
-	
-	H | ctrl_qubit
-	eng.flush()
-	cheat_tpl = sim.cheat()
-	idx = cheat_tpl[0][ctrl_qubit[0].id]
-	vec = cheat_tpl[1]
-	
-	probability = 0.
-	for i in range(len(vec)):
-		if abs(vec[i]) > 1.e-8:
-			if ((i >> idx)&1) == 0:
-				probability += abs(vec[i])**2
-	
-	assert probability == pytest.approx(.5)
-	
-	Measure | ctrl_qubit
-	Measure | x
+    eng = get_main_engine(sim)
+
+    ctrl_qubit = eng.allocate_qubit()
+
+    N = 15
+    a = 2
+
+    x = eng.allocate_qureg(4)
+    X | x[0]
+
+    H | ctrl_qubit
+    with Control(eng, ctrl_qubit):
+        MultiplyByConstantModN(pow(a, 2**7, N), N) | x
+
+    H | ctrl_qubit
+    eng.flush()
+    cheat_tpl = sim.cheat()
+    idx = cheat_tpl[0][ctrl_qubit[0].id]
+    vec = cheat_tpl[1]
+
+    for i in range(len(vec)):
+        if abs(vec[i]) > 1.e-8:
+            assert ((i >> idx)&1) == 0
+
+    Measure | ctrl_qubit
+    assert int(ctrl_qubit) == 0
+    del vec, cheat_tpl
+
+    H | ctrl_qubit
+    with Control(eng, ctrl_qubit):
+        MultiplyByConstantModN(pow(a, 2, N), N) | x
+
+    H | ctrl_qubit
+    eng.flush()
+    cheat_tpl = sim.cheat()
+    idx = cheat_tpl[0][ctrl_qubit[0].id]
+    vec = cheat_tpl[1]
+
+    probability = 0.
+    for i in range(len(vec)):
+        if abs(vec[i]) > 1.e-8:
+            if ((i >> idx)&1) == 0:
+                probability += abs(vec[i])**2
+
+    assert probability == pytest.approx(.5)
+
+    Measure | ctrl_qubit
+    Measure | x

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -19,11 +19,11 @@ MainEngine. Qubit objects are automatically deallocated if they go out of
 scope and intented to be used within Qureg objects in user code.
 
 Example:
-	.. code-block:: python
+    .. code-block:: python
 
-		from projectq import MainEngine
-		eng = MainEngine()
-		qubit = eng.allocate_qubit()
+        from projectq import MainEngine
+        eng = MainEngine()
+        qubit = eng.allocate_qubit()
 
 qubit is a Qureg of size 1 with one Qubit object which is deallocated once
 qubit goes out of scope.
@@ -34,188 +34,188 @@ deallocated.
 
 
 class BasicQubit(object):
-	"""
-	BasicQubit objects represent qubits.
-	
-	They have an id and a reference to the owning engine.
-	"""
-	def __init__(self, engine, idx):
-		"""
-		Initialize a BasicQubit object.
-		
-		Args:
-			engine: Owning engine / engine that created the qubit
-			idx: Unique index of the qubit referenced by this qubit
-		"""
-		self.id = idx
-		self.engine = engine
+    """
+    BasicQubit objects represent qubits.
 
-	def __str__(self):
-		"""
-		Return string representation of this qubit.
-		"""
-		return str(self.id)
+    They have an id and a reference to the owning engine.
+    """
+    def __init__(self, engine, idx):
+        """
+        Initialize a BasicQubit object.
 
-	def __bool__(self):
-		"""
-		Access the result of a previous measurement and return False / True (0/1)
-		"""
-		return self.engine.main_engine.get_measurement_result(self)
+        Args:
+            engine: Owning engine / engine that created the qubit
+            idx: Unique index of the qubit referenced by this qubit
+        """
+        self.id = idx
+        self.engine = engine
 
-	def __nonzero__(self):
-		"""
-		Access the result of a previous measurement for Python 2.7.
-		"""
-		return self.__bool__()
+    def __str__(self):
+        """
+        Return string representation of this qubit.
+        """
+        return str(self.id)
 
-	def __int__(self):
-		"""
-		Access the result of a previous measurement and return as integer (0 / 1).
-		"""
-		return int(bool(self))
+    def __bool__(self):
+        """
+        Access the result of a previous measurement and return False / True (0/1)
+        """
+        return self.engine.main_engine.get_measurement_result(self)
 
-	def __eq__(self, other):
-		"""
-		Compare with other qubit (Returns True if equal id and engine).
-		
-		Args:
-			other (BasicQubit): BasicQubit to which to compare this one
-		"""
-		return (isinstance(other, self.__class__) and self.id == other.id and
-		        self.engine == other.engine)
+    def __nonzero__(self):
+        """
+        Access the result of a previous measurement for Python 2.7.
+        """
+        return self.__bool__()
 
-	def __ne__(self, other):
-		return not self.__eq__(other)
+    def __int__(self):
+        """
+        Access the result of a previous measurement and return as integer (0 / 1).
+        """
+        return int(bool(self))
 
-	def __hash__(self):
-		"""
-		Return the hash of this qubit.
-		
-		Hash definition because of custom __eq__.
-		Enables storing a qubit in, e.g., a set.
-		"""
-		return hash((self.id, self.engine, object.__hash__(self)))
+    def __eq__(self, other):
+        """
+        Compare with other qubit (Returns True if equal id and engine).
+
+        Args:
+            other (BasicQubit): BasicQubit to which to compare this one
+        """
+        return (isinstance(other, self.__class__) and self.id == other.id and
+                self.engine == other.engine)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        """
+        Return the hash of this qubit.
+
+        Hash definition because of custom __eq__.
+        Enables storing a qubit in, e.g., a set.
+        """
+        return hash((self.id, self.engine, object.__hash__(self)))
 
 
 class Qubit(BasicQubit):
-	"""
-	Qubit class.
-	
-	Represents a (logical-level) qubit with a unique index provided by the
-	MainEngine. Once the qubit goes out of scope (and is garbage-collected), it
-	deallocates itself automatically, allowing automatic resource management.
-	
-	Thus the qubit is not copyable; only returns a reference to the same object.
-	"""
-	def __del__(self):
-		"""
-		Destroy the qubit and deallocate it (automatically).
-		"""
-		self.engine.deallocate_qubit(self)
-		self.id = -1
+    """
+    Qubit class.
 
-	def __copy__(self):
-		"""
-		Non-copyable (returns reference to self).
-		
-		Note:
-			To prevent problems with automatic deallocation, qubits are not copyable!
-		"""
-		return self
+    Represents a (logical-level) qubit with a unique index provided by the
+    MainEngine. Once the qubit goes out of scope (and is garbage-collected), it
+    deallocates itself automatically, allowing automatic resource management.
 
-	def __deepcopy__(self, memo):
-		"""
-		Non-deepcopyable (returns reference to self).
-		
-		Note:
-			To prevent problems with automatic deallocation, qubits are not deepcopyable!
-		"""
-		return self
+    Thus the qubit is not copyable; only returns a reference to the same object.
+    """
+    def __del__(self):
+        """
+        Destroy the qubit and deallocate it (automatically).
+        """
+        self.engine.deallocate_qubit(self)
+        self.id = -1
+
+    def __copy__(self):
+        """
+        Non-copyable (returns reference to self).
+
+        Note:
+            To prevent problems with automatic deallocation, qubits are not copyable!
+        """
+        return self
+
+    def __deepcopy__(self, memo):
+        """
+        Non-deepcopyable (returns reference to self).
+
+        Note:
+            To prevent problems with automatic deallocation, qubits are not deepcopyable!
+        """
+        return self
 
 
 class WeakQubitRef(BasicQubit):
-	"""
-	WeakQubitRef objects are used inside the Command object.
-	
-	Qubits feature automatic deallocation when destroyed. WeakQubitRefs, on the
-	other hand, do not share this feature, allowing to copy them and pass them
-	along the compiler pipeline, while the actual qubit objects may be garbage-
-	collected (and, thus, cleaned up early). Otherwise there is no difference
-	between a WeakQubitRef and a Qubit object.
-	"""
-	pass
+    """
+    WeakQubitRef objects are used inside the Command object.
+
+    Qubits feature automatic deallocation when destroyed. WeakQubitRefs, on the
+    other hand, do not share this feature, allowing to copy them and pass them
+    along the compiler pipeline, while the actual qubit objects may be garbage-
+    collected (and, thus, cleaned up early). Otherwise there is no difference
+    between a WeakQubitRef and a Qubit object.
+    """
+    pass
 
 
 class Qureg(list):
-	"""
-	Quantum register class.
-	
-	Simplifies accessing measured values for single-qubit registers (no []-
-	access necessary) and enables pretty-printing of general quantum registers
-	(call Qureg.__str__(qureg)).
-	"""
-	def __bool__(self):
-		"""
-		Return measured value if Qureg consists of 1 qubit only.
-		
-		Raises:
-			Exception if more than 1 qubit resides in this register (then you
-			need to specify which value to get using qureg[???])
-		"""
-		if len(self) == 1:
-			return bool(self[0])
-		else:
-			raise Exception("__bool__(qureg): Quantum register contains more than 1"
-			                "qubit. Use __bool__(qureg[idx]) instead.")
+    """
+    Quantum register class.
 
-	def __int__(self):
-		"""
-		Return measured value if Qureg consists of 1 qubit only.
-		
-		Raises:
-			Exception if more than 1 qubit resides in this register (then you
-			need to specify which value to get using qureg[???])
-		"""
-		if len(self) == 1:
-			return int(self[0])
-		else:
-			raise Exception("__int__(qureg): Quantum register contains more than 1"
-			                "qubit. Use __int__(qureg[idx]) instead.")
+    Simplifies accessing measured values for single-qubit registers (no []-
+    access necessary) and enables pretty-printing of general quantum registers
+    (call Qureg.__str__(qureg)).
+    """
+    def __bool__(self):
+        """
+        Return measured value if Qureg consists of 1 qubit only.
 
-	def __nonzero__(self):
-		"""
-		Return measured value if Qureg consists of 1 qubit only for Python 2.7.
-		
-		Raises:
-			Exception if more than 1 qubit resides in this register (then you
-			need to specify which value to get using qureg[???])
-		"""
-		if len(self) == 1:
-			return int(self[0])
-		else:
-			raise Exception("__int__(qureg): Quantum register contains more than 1"
-			                "qubit. Use __int__(qureg[idx]) instead.")
+        Raises:
+            Exception if more than 1 qubit resides in this register (then you
+            need to specify which value to get using qureg[???])
+        """
+        if len(self) == 1:
+            return bool(self[0])
+        else:
+            raise Exception("__bool__(qureg): Quantum register contains more than 1"
+                            "qubit. Use __bool__(qureg[idx]) instead.")
 
-	def __str__(self):
-		"""
-		Get string representation of a quantum register.
-		"""
-		if len(self) == 1:
-			return "Qubit[" + str(self[0]) + "]"
-		else:
-			return "Qureg" + str([q.id for q in self])
+    def __int__(self):
+        """
+        Return measured value if Qureg consists of 1 qubit only.
 
-	@property
-	def engine(self):
-		"""
-		Return owning engine.
-		"""
-		return self[0].engine
-	
-	@engine.setter
-	def engine(self, eng):
-		"""
-		Set owning engine.
-		"""
-		for qb in self:
-			qb.engine = eng
+        Raises:
+            Exception if more than 1 qubit resides in this register (then you
+            need to specify which value to get using qureg[???])
+        """
+        if len(self) == 1:
+            return int(self[0])
+        else:
+            raise Exception("__int__(qureg): Quantum register contains more than 1"
+                            "qubit. Use __int__(qureg[idx]) instead.")
+
+    def __nonzero__(self):
+        """
+        Return measured value if Qureg consists of 1 qubit only for Python 2.7.
+
+        Raises:
+            Exception if more than 1 qubit resides in this register (then you
+            need to specify which value to get using qureg[???])
+        """
+        if len(self) == 1:
+            return int(self[0])
+        else:
+            raise Exception("__int__(qureg): Quantum register contains more than 1"
+                            "qubit. Use __int__(qureg[idx]) instead.")
+
+    def __str__(self):
+        """
+        Get string representation of a quantum register.
+        """
+        if len(self) == 1:
+            return "Qubit[" + str(self[0]) + "]"
+        else:
+            return "Qureg" + str([q.id for q in self])
+
+    @property
+    def engine(self):
+        """
+        Return owning engine.
+        """
+        return self[0].engine
+
+    @engine.setter
+    def engine(self, eng):
+        """
+        Set owning engine.
+        """
+        for qb in self:
+            qb.engine = eng

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -23,149 +23,149 @@ from projectq.types import _qubit
 
 @pytest.mark.parametrize("qubit_id", [0, 1])
 def test_basic_qubit_str(qubit_id):
-	fake_engine = "Fake"
-	qubit = _qubit.BasicQubit(fake_engine, qubit_id)
-	assert str(qubit) == str(qubit_id)
+    fake_engine = "Fake"
+    qubit = _qubit.BasicQubit(fake_engine, qubit_id)
+    assert str(qubit) == str(qubit_id)
 
 
 def test_basic_qubit_measurement():
-	eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
-	qubit0 = eng.allocate_qubit()[0]
-	qubit1 = eng.allocate_qubit()[0]
-	eng.set_measurement_result(qubit0, False)
-	eng.set_measurement_result(qubit1, True)
-	assert not bool(qubit0)
-	assert not qubit0
-	assert bool(qubit1)
-	assert qubit1
-	assert int(qubit0) == 0
-	assert int(qubit1) == 1
-	# Testing functions for python 2 and python 3
-	assert not qubit0.__bool__()
-	assert not qubit0.__nonzero__()
-	assert qubit1.__bool__()
-	assert qubit1.__nonzero__()
+    eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
+    qubit0 = eng.allocate_qubit()[0]
+    qubit1 = eng.allocate_qubit()[0]
+    eng.set_measurement_result(qubit0, False)
+    eng.set_measurement_result(qubit1, True)
+    assert not bool(qubit0)
+    assert not qubit0
+    assert bool(qubit1)
+    assert qubit1
+    assert int(qubit0) == 0
+    assert int(qubit1) == 1
+    # Testing functions for python 2 and python 3
+    assert not qubit0.__bool__()
+    assert not qubit0.__nonzero__()
+    assert qubit1.__bool__()
+    assert qubit1.__nonzero__()
 
 
 @pytest.mark.parametrize("id0, id1, expected", [(0, 0, True), (0, 1, False)])
 def test_basic_qubit_comparison(id0, id1, expected):
-	fake_engine = "Fake"
-	fake_engine2 = "Fake2"
-	qubit0 = _qubit.BasicQubit(fake_engine, id0)
-	qubit1 = _qubit.BasicQubit(fake_engine, id1)
-	qubit2 = _qubit.BasicQubit(fake_engine2, id0)
-	# Different engines
-	assert not (qubit2 == qubit0)
-	assert not (qubit2 == qubit1)
-	assert qubit2 != qubit0
-	assert qubit2 != qubit1
-	# Same engines
-	if expected:
-		assert qubit0 == qubit1
-	else:
-		assert not (qubit0 == qubit1)
+    fake_engine = "Fake"
+    fake_engine2 = "Fake2"
+    qubit0 = _qubit.BasicQubit(fake_engine, id0)
+    qubit1 = _qubit.BasicQubit(fake_engine, id1)
+    qubit2 = _qubit.BasicQubit(fake_engine2, id0)
+    # Different engines
+    assert not (qubit2 == qubit0)
+    assert not (qubit2 == qubit1)
+    assert qubit2 != qubit0
+    assert qubit2 != qubit1
+    # Same engines
+    if expected:
+        assert qubit0 == qubit1
+    else:
+        assert not (qubit0 == qubit1)
 
 
 def test_basic_qubit_hash():
-	fake_engine = "Fake"
-	qubit0 = _qubit.BasicQubit(fake_engine, 0)
-	qubit1 = _qubit.BasicQubit(fake_engine, 1)
-	assert hash(qubit0) != hash(qubit1)
-	qubit0.id = -1
-	qubit1.id = -1
-	# Important that weakref.WeakSet in projectq.cengines._main.py works.
-	assert hash(qubit0) != hash(qubit1)
+    fake_engine = "Fake"
+    qubit0 = _qubit.BasicQubit(fake_engine, 0)
+    qubit1 = _qubit.BasicQubit(fake_engine, 1)
+    assert hash(qubit0) != hash(qubit1)
+    qubit0.id = -1
+    qubit1.id = -1
+    # Important that weakref.WeakSet in projectq.cengines._main.py works.
+    assert hash(qubit0) != hash(qubit1)
 
 
 @pytest.fixture
 def mock_main_engine():
-	class MockMainEngine(object):
-		def __init__(self):
-			self.num_calls = 0
-		
-		def deallocate_qubit(self, qubit):
-			self.num_calls += 1
-			self.qubit_id = qubit.id
-	
-	return MockMainEngine()
+    class MockMainEngine(object):
+        def __init__(self):
+            self.num_calls = 0
+
+        def deallocate_qubit(self, qubit):
+            self.num_calls += 1
+            self.qubit_id = qubit.id
+
+    return MockMainEngine()
 
 
 def test_qubit_del(mock_main_engine):
-	qubit = _qubit.Qubit(mock_main_engine, 10)
-	assert qubit.id == 10
-	qubit.__del__()
-	assert qubit.id == -1
-	assert mock_main_engine.num_calls == 1
-	# We need hand coded mock here as mock.Mock cannot check qubit_id
-	# (it would save the call argument which is a qubit but id would be 
-	#  reset to -1 as qubits only have references)
-	assert mock_main_engine.qubit_id == 10
+    qubit = _qubit.Qubit(mock_main_engine, 10)
+    assert qubit.id == 10
+    qubit.__del__()
+    assert qubit.id == -1
+    assert mock_main_engine.num_calls == 1
+    # We need hand coded mock here as mock.Mock cannot check qubit_id
+    # (it would save the call argument which is a qubit but id would be
+    #  reset to -1 as qubits only have references)
+    assert mock_main_engine.qubit_id == 10
 
 
 def test_qubit_not_copyable():
-	eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
-	qubit = _qubit.Qubit(eng, 10)
-	qubit_copy = copy(qubit)
-	assert id(qubit) == id(qubit_copy)
-	qubit_deepcopy = deepcopy(qubit)
-	assert id(qubit) == id(qubit_deepcopy)
+    eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
+    qubit = _qubit.Qubit(eng, 10)
+    qubit_copy = copy(qubit)
+    assert id(qubit) == id(qubit_copy)
+    qubit_deepcopy = deepcopy(qubit)
+    assert id(qubit) == id(qubit_deepcopy)
 
 
 def test_weak_qubit_ref():
-	# Test that there is no deallocate gate
-	qubit = _qubit.WeakQubitRef("Engine without deallocate_qubit()", 0)
-	with pytest.raises(AttributeError):
-		qubit.__del__()
+    # Test that there is no deallocate gate
+    qubit = _qubit.WeakQubitRef("Engine without deallocate_qubit()", 0)
+    with pytest.raises(AttributeError):
+        qubit.__del__()
 
 
 @pytest.mark.parametrize("qubit_ids, expected", [
-	([10], "Qubit[10]"), ([1, 2, 3],"Qureg[1, 2, 3]")])
+    ([10], "Qubit[10]"), ([1, 2, 3],"Qureg[1, 2, 3]")])
 def test_qureg(qubit_ids, expected):
-	eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
-	qureg = _qubit.Qureg()
-	for qubit_id in qubit_ids:
-		qubit = _qubit.Qubit(eng, qubit_id)
-		qureg.append(qubit)
-	assert str(qureg) == expected
+    eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
+    qureg = _qubit.Qureg()
+    for qubit_id in qubit_ids:
+        qubit = _qubit.Qubit(eng, qubit_id)
+        qureg.append(qubit)
+    assert str(qureg) == expected
 
 
 def test_qureg_measure_if_qubit():
-	eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
-	qureg0 = _qubit.Qureg(eng.allocate_qubit())
-	qureg1 = _qubit.Qureg(eng.allocate_qubit())
-	eng.set_measurement_result(qureg0[0], False)
-	eng.set_measurement_result(qureg1[0], True)
-	assert not bool(qureg0)
-	assert not qureg0
-	assert bool(qureg1)
-	assert qureg1
-	assert int(qureg0) == 0
-	assert int(qureg1) == 1
-	# Testing functions for python 2 and python 3
-	assert not qureg0.__bool__()
-	assert not qureg0.__nonzero__()
-	assert qureg1.__bool__()
-	assert qureg1.__nonzero__()
+    eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
+    qureg0 = _qubit.Qureg(eng.allocate_qubit())
+    qureg1 = _qubit.Qureg(eng.allocate_qubit())
+    eng.set_measurement_result(qureg0[0], False)
+    eng.set_measurement_result(qureg1[0], True)
+    assert not bool(qureg0)
+    assert not qureg0
+    assert bool(qureg1)
+    assert qureg1
+    assert int(qureg0) == 0
+    assert int(qureg1) == 1
+    # Testing functions for python 2 and python 3
+    assert not qureg0.__bool__()
+    assert not qureg0.__nonzero__()
+    assert qureg1.__bool__()
+    assert qureg1.__nonzero__()
 
 
 def test_qureg_measure_exception():
-	eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
-	qureg = _qubit.Qureg()
-	for qubit_id in [0,1]:
-		qubit = _qubit.Qubit(eng, qubit_id)
-		qureg.append(qubit)
-	with pytest.raises(Exception):
-		qureg.__bool__()
-	with pytest.raises(Exception):
-		qureg.__nonzero__()
-	with pytest.raises(Exception):
-		qureg.__int__()
+    eng = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
+    qureg = _qubit.Qureg()
+    for qubit_id in [0,1]:
+        qubit = _qubit.Qubit(eng, qubit_id)
+        qureg.append(qubit)
+    with pytest.raises(Exception):
+        qureg.__bool__()
+    with pytest.raises(Exception):
+        qureg.__nonzero__()
+    with pytest.raises(Exception):
+        qureg.__int__()
 
 
 def test_qureg_engine():
-	eng1 = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
-	eng2 = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
-	qureg = _qubit.Qureg([_qubit.Qubit(eng1, 0), _qubit.Qubit(eng1, 1)])
-	assert eng1 == qureg.engine
-	qureg.engine = eng2
-	assert qureg[0].engine == eng2 and qureg[1].engine == eng2
+    eng1 = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
+    eng2 = MainEngine(backend = DummyEngine(), engine_list = [DummyEngine()])
+    qureg = _qubit.Qureg([_qubit.Qubit(eng1, 0), _qubit.Qubit(eng1, 1)])
+    assert eng1 == qureg.engine
+    qureg.engine = eng2
+    assert qureg[0].engine == eng2 and qureg[1].engine == eng2

--- a/setup.py
+++ b/setup.py
@@ -12,154 +12,154 @@ exec(open('projectq/_version.py').read())
 long_description = open('README.rst').read()
 
 class get_pybind_include(object):
-	"""Helper class to determine the pybind11 include path
+    """Helper class to determine the pybind11 include path
 
-	The purpose of this class is to postpone importing pybind11
-	until it is actually installed, so that the ``get_include()``
-	method can be invoked. """
+    The purpose of this class is to postpone importing pybind11
+    until it is actually installed, so that the ``get_include()``
+    method can be invoked. """
 
-	def __init__(self, user=False):
-		self.user = user
+    def __init__(self, user=False):
+        self.user = user
 
-	def __str__(self):
-		import pybind11
-		return pybind11.get_include(self.user)
+    def __str__(self):
+        import pybind11
+        return pybind11.get_include(self.user)
 
 
 cppsim = Feature(
-	'C++ Simulator',
-	standard=True,
-	ext_modules=[
-		Extension(
-			'projectq.backends._sim._cppsim',
-			['projectq/backends/_sim/_cppsim.cpp'],
-				include_dirs=[
-				# Path to pybind11 headers
-				get_pybind_include(),
-				get_pybind_include(user=True)
-			],
-			language='c++'
-		),
-	],
+    'C++ Simulator',
+    standard=True,
+    ext_modules=[
+        Extension(
+            'projectq.backends._sim._cppsim',
+            ['projectq/backends/_sim/_cppsim.cpp'],
+                include_dirs=[
+                # Path to pybind11 headers
+                get_pybind_include(),
+                get_pybind_include(user=True)
+            ],
+            language='c++'
+        ),
+    ],
 )
 
 
 def has_flag(compiler, flagname=None):
-	"""
-	Return a boolean indicating whether a flag name is supported on the
-	specified compiler.
-	"""
-	import tempfile
-	f = tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False)
-	f.write('int main (int argc, char **argv) { return 0; }')
-	f.close()
-	ret = True
-	try:
-		if flagname is None:
-			compiler.compile([f.name])
-		else:
-			compiler.compile([f.name], extra_postargs=[flagname])
-	except:
-		ret = False
-	os.unlink(f.name)
-	return ret
+    """
+    Return a boolean indicating whether a flag name is supported on the
+    specified compiler.
+    """
+    import tempfile
+    f = tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False)
+    f.write('int main (int argc, char **argv) { return 0; }')
+    f.close()
+    ret = True
+    try:
+        if flagname is None:
+            compiler.compile([f.name])
+        else:
+            compiler.compile([f.name], extra_postargs=[flagname])
+    except:
+        ret = False
+    os.unlink(f.name)
+    return ret
 
 
 def knows_intrinsics(compiler):
-	"""
-	Return a boolean indicating whether the compiler can handle intrinsics.
-	"""
-	import tempfile
-	f = tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False)
-	f.write('#include <immintrin.h>\nint main (int argc, char **argv) '
-	        '{ __m256d neg = _mm256_set1_pd(1.0); }')
-	f.close()
-	ret = True
-	try:
-		compiler.compile([f.name], extra_postargs=['-march=native'])
-	except setuptools.distutils.errors.CompileError:
-		ret = False
-	os.unlink(f.name)
-	return ret
+    """
+    Return a boolean indicating whether the compiler can handle intrinsics.
+    """
+    import tempfile
+    f = tempfile.NamedTemporaryFile('w', suffix='.cpp', delete=False)
+    f.write('#include <immintrin.h>\nint main (int argc, char **argv) '
+            '{ __m256d neg = _mm256_set1_pd(1.0); }')
+    f.close()
+    ret = True
+    try:
+        compiler.compile([f.name], extra_postargs=['-march=native'])
+    except setuptools.distutils.errors.CompileError:
+        ret = False
+    os.unlink(f.name)
+    return ret
 
 
 class BuildExt(build_ext):
-	"""A custom build extension for adding compiler-specific options."""
-	c_opts = {
-		'msvc': ['/EHsc'],
-		'unix': [],
-	}
+    """A custom build extension for adding compiler-specific options."""
+    c_opts = {
+        'msvc': ['/EHsc'],
+        'unix': [],
+    }
 
-	def build_extensions(self):
-		if sys.platform == 'darwin':
-			self.c_opts['unix'] += ['-mmacosx-version-min=10.7']
-			if has_flag(self.compiler, '-stdlib=libc++'):
-				self.c_opts['unix'] += ['-stdlib=libc++']
-		
-		ct = self.compiler.compiler_type
-		opts = self.c_opts.get(ct, [])
-		
-		if not has_flag(self.compiler):
-			self.warning("Something is wrong with your C++ compiler.\n"
-			             "Failed to compile a simple test program!\n")
-			return
+    def build_extensions(self):
+        if sys.platform == 'darwin':
+            self.c_opts['unix'] += ['-mmacosx-version-min=10.7']
+            if has_flag(self.compiler, '-stdlib=libc++'):
+                self.c_opts['unix'] += ['-stdlib=libc++']
 
-		openmp = ''
-		if has_flag(self.compiler, '-fopenmp'):
-			openmp = '-fopenmp'
-		elif has_flag(self.compiler, '-openmp'):
-			openmp = '-openmp'
-		if ct == 'msvc':
-			openmp = '' # supports only OpenMP 2.0
-		
-		if knows_intrinsics(self.compiler):
-			opts.append('-DINTRIN')
-			if ct == 'msvc':
-				opts.append('/arch:AVX')
-			else:
-				opts.append('-march=native')
+        ct = self.compiler.compiler_type
+        opts = self.c_opts.get(ct, [])
 
-		opts.append(openmp)
-		if ct == 'unix':
-			if not has_flag(self.compiler, '-std=c++11'):
-				self.warning("Compiler needs to have C++11 support!")
-				return
-			
-			opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
-			opts.append('-std=c++11')
-			if has_flag(self.compiler, '-fvisibility=hidden'):
-				opts.append('-fvisibility=hidden')
-		elif ct == 'msvc':
-			opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
-		for ext in self.extensions:
-			ext.extra_compile_args = opts
-			ext.extra_link_args = [openmp]
-		try:
-			build_ext.build_extensions(self)
-		except setuptools.distutils.errors.CompileError:
-			self.warning("")
-			
-	def warning(self, warning_text):
-		Exception(warning_text + "\nCould not install the C++-Simulator.\n"
-		          "ProjectQ will default to the (slow) Python simulator.\n"
-		          "Use --without-cppsimulator to skip building the (faster) C++"
-		          " version of the simulator.")
-			
+        if not has_flag(self.compiler):
+            self.warning("Something is wrong with your C++ compiler.\n"
+                         "Failed to compile a simple test program!\n")
+            return
+
+        openmp = ''
+        if has_flag(self.compiler, '-fopenmp'):
+            openmp = '-fopenmp'
+        elif has_flag(self.compiler, '-openmp'):
+            openmp = '-openmp'
+        if ct == 'msvc':
+            openmp = '' # supports only OpenMP 2.0
+
+        if knows_intrinsics(self.compiler):
+            opts.append('-DINTRIN')
+            if ct == 'msvc':
+                opts.append('/arch:AVX')
+            else:
+                opts.append('-march=native')
+
+        opts.append(openmp)
+        if ct == 'unix':
+            if not has_flag(self.compiler, '-std=c++11'):
+                self.warning("Compiler needs to have C++11 support!")
+                return
+
+            opts.append('-DVERSION_INFO="%s"' % self.distribution.get_version())
+            opts.append('-std=c++11')
+            if has_flag(self.compiler, '-fvisibility=hidden'):
+                opts.append('-fvisibility=hidden')
+        elif ct == 'msvc':
+            opts.append('/DVERSION_INFO=\\"%s\\"' % self.distribution.get_version())
+        for ext in self.extensions:
+            ext.extra_compile_args = opts
+            ext.extra_link_args = [openmp]
+        try:
+            build_ext.build_extensions(self)
+        except setuptools.distutils.errors.CompileError:
+            self.warning("")
+
+    def warning(self, warning_text):
+        Exception(warning_text + "\nCould not install the C++-Simulator.\n"
+                  "ProjectQ will default to the (slow) Python simulator.\n"
+                  "Use --without-cppsimulator to skip building the (faster) C++"
+                  " version of the simulator.")
+
 
 setup(
-	name='projectq',
-	version=__version__,
-	author='Thomas Haener, Damian Steiger',
-	author_email='info@projectq.ch',
-	url='http://www.projectq.ch',
-	description=('ProjectQ - '
-	            'An open source software framework for quantum computing'),
-	long_description=long_description,
-	features={'cppsimulator': cppsim},
-	install_requires=['numpy', 'future', 'pytest>=3.0',
-	                  'pybind11>=1.7','requests'],
-	cmdclass={'build_ext': BuildExt},
-	zip_safe=False,
-	license='Apache 2',
-	packages=find_packages()
+    name='projectq',
+    version=__version__,
+    author='Thomas Haener, Damian Steiger',
+    author_email='info@projectq.ch',
+    url='http://www.projectq.ch',
+    description=('ProjectQ - '
+                'An open source software framework for quantum computing'),
+    long_description=long_description,
+    features={'cppsimulator': cppsim},
+    install_requires=['numpy', 'future', 'pytest>=3.0',
+                      'pybind11>=1.7','requests'],
+    cmdclass={'build_ext': BuildExt},
+    zip_safe=False,
+    license='Apache 2',
+    packages=find_packages()
 )


### PR DESCRIPTION
To produce the changes in this PR I ran exactly these three bash commands:

    files=$(find | grep \.py$)

    for file in $files; do sed -i 's/\t/    /g' ${file}; done

    for file in $files; do sed -i 's/ *$//g' ${file}; done

