### PR TITLE
Fix ResourceCounter returning None from __str__ when empty

### DIFF
--- a/projectq/backends/_resource.py
+++ b/projectq/backends/_resource.py
@@ -98,6 +98,7 @@ class ResourceCounter(BasicEngine):
             return ("\n".join(list(sorted(gate_list))) +
                     "\n\nMax. width (number of qubits) : " +
                     str(self.max_width) + ".")
+        return "(No quantum resources used)"
 
     def receive(self, command_list):
         """

--- a/projectq/backends/_resource_test.py
+++ b/projectq/backends/_resource_test.py
@@ -69,3 +69,7 @@ def test_resource_counter():
     assert sent_gates.count(H) == 1
     assert sent_gates.count(X) == 2
     assert sent_gates.count(Measure) == 1
+
+
+def test_resource_counter_str_when_empty():
+    assert isinstance(str(ResourceCounter()), str)


### PR DESCRIPTION
This was causing the Shor example to fail in the "lucky guess" case (after I did some refactors to it locally).