### PR TITLE
[Reworking] Fix inconsistency between __or__ and generate_command

### DIFF
--- a/projectq/backends/_ibm/_ibm_test.py
+++ b/projectq/backends/_ibm/_ibm_test.py
@@ -56,8 +56,7 @@ def test_ibm_backend_is_available_control_not(num_ctrl_qubits, is_available):
     qubit1 = eng.allocate_qubit()
     qureg = eng.allocate_qureg(num_ctrl_qubits)
     ibm_backend = _ibm.IBMBackend()
-    cmd = Command(eng, NOT, (qubit1,))
-    cmd.add_control_qubits(qureg)
+    cmd = Command(eng, NOT, (qubit1,), controls=qureg)
     assert ibm_backend.is_available(cmd) == is_available
 
 

--- a/projectq/cengines/_basics.py
+++ b/projectq/cengines/_basics.py
@@ -137,7 +137,8 @@ class BasicEngine(object):
         Args:
             n (int): Number of qubits to allocate
         Returns:
-            Qureg of length n, a list of n newly allocated qubits.
+            Qureg:
+                Qureg of length n, a list of n newly allocated qubits.
         """
         return Qureg([self.allocate_qubit()[0] for _ in range(n)])
 

--- a/projectq/cengines/_testengine.py
+++ b/projectq/cengines/_testengine.py
@@ -111,6 +111,9 @@ class DummyEngine(BasicEngine):
     def is_available(self, cmd):
         return True
 
+    def restart_recording(self):
+        self.received_commands = []
+
     def receive(self, command_list):
         if self.save_commands:
             self.received_commands.extend(command_list)

--- a/projectq/meta/_control.py
+++ b/projectq/meta/_control.py
@@ -57,7 +57,7 @@ class ControlEngine(BasicEngine):
 
     def _handle_command(self, cmd):
         if (not self._has_compute_uncompute_tag(cmd) and not
-           isinstance(cmd.gate, ClassicalInstructionGate)):
+                isinstance(cmd.gate, ClassicalInstructionGate)):
             cmd.add_control_qubits(self._qubits)
         self.send([cmd])
 

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -32,7 +32,7 @@ needs to be made explicitely, while for one argument it is optional.
 import math
 from copy import deepcopy
 
-from projectq.types import BasicQubit
+from projectq.types import BasicQubit, Qubit, Qureg
 from ._command import Command, apply_command
 
 
@@ -157,15 +157,17 @@ class BasicGate(object):
 
         return tuple(qubits)
 
-    def generate_command(self, qubits):
+    def generate_commands(self, qubits):
         """
         Return a Command object which represents the gate acting on qubits.
 
         Args:
-            qubits: see BasicGate.make_tuple_of_qureg(qubits)
+            qubits (Qubit|Qureg|list[Qubit|Qureg]|tuple[Qubit|Qureg]):
+                see BasicGate.make_tuple_of_qureg(qubits)
 
         Returns:
-            A Command object which represents the gate acting on qubits.
+            tuple[Command]|list[Command]:
+                A Command object which represents the gate acting on qubits.
         """
         qubits = self.make_tuple_of_qureg(qubits)
 
@@ -174,7 +176,8 @@ class BasicGate(object):
                 assert(qubits[i][j].engine == qubits[i][j + 1].engine)
             if i < len(qubits) - 1:
                 assert(qubits[i][-1].engine == qubits[i + 1][0].engine)
-        return Command(qubits[0][0].engine, self, qubits)
+
+        return Command(qubits[0][0].engine, self, qubits),
 
     def __or__(self, qubits):
         """ Operator| overload which enables the syntax Gate | qubits.
@@ -190,8 +193,8 @@ class BasicGate(object):
             qubits: a Qubit object, a list of Qubit objects, a Qureg object, or
                     a tuple of Qubit or Qureg objects (can be mixed).
         """
-        cmd = self.generate_command(qubits)
-        apply_command(cmd)
+        for cmd in self.generate_commands(qubits):
+            apply_command(cmd)
 
     def __eq__(self, other):
         """ Return True if equal (i.e., instance of same class). """

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -56,28 +56,28 @@ def test_basic_gate_make_tuple_of_qureg(main_engine):
     assert case5 == (qureg, [qubit0])
 
 
-def test_basic_gate_generate_command(main_engine):
+def test_basic_gate_generate_commands(main_engine):
     qubit0 = Qubit(main_engine, 0)
     qubit1 = Qubit(main_engine, 1)
     qubit2 = Qubit(main_engine, 2)
     qubit3 = Qubit(main_engine, 3)
     qureg = Qureg([qubit2, qubit3])
     basic_gate = _basics.BasicGate()
-    command1 = basic_gate.generate_command(qubit0)
-    assert command1 == Command(main_engine, basic_gate,
-                               ([qubit0],))
-    command2 = basic_gate.generate_command([qubit0, qubit1])
-    assert command2 == Command(main_engine, basic_gate,
-                               ([qubit0, qubit1],))
-    command3 = basic_gate.generate_command(qureg)
-    assert command3 == Command(main_engine, basic_gate,
-                               (qureg,))
-    command4 = basic_gate.generate_command((qubit0,))
-    assert command4 == Command(main_engine, basic_gate,
-                               ([qubit0],))
-    command5 = basic_gate.generate_command((qureg, qubit0))
-    assert command5 == Command(main_engine, basic_gate,
-                               (qureg, [qubit0]))
+    commands1 = basic_gate.generate_commands(qubit0)
+    assert commands1 == (Command(main_engine, basic_gate,
+                                 ([qubit0],)),)
+    commands2 = basic_gate.generate_commands([qubit0, qubit1])
+    assert commands2 == (Command(main_engine, basic_gate,
+                                 ([qubit0, qubit1],)),)
+    commands3 = basic_gate.generate_commands(qureg)
+    assert commands3 == (Command(main_engine, basic_gate,
+                                 (qureg,)),)
+    commands4 = basic_gate.generate_commands((qubit0,))
+    assert commands4 == (Command(main_engine, basic_gate,
+                                 ([qubit0],)),)
+    commands5 = basic_gate.generate_commands((qureg, qubit0))
+    assert commands5 == (Command(main_engine, basic_gate,
+                                 (qureg, [qubit0])),)
 
 
 def test_basic_gate_or():
@@ -90,23 +90,23 @@ def test_basic_gate_or():
     qubit3 = Qubit(main_engine, 3)
     qureg = Qureg([qubit2, qubit3])
     basic_gate = _basics.BasicGate()
-    command1 = basic_gate.generate_command(qubit0)
+    commands1 = basic_gate.generate_commands(qubit0)
     basic_gate | qubit0
-    command2 = basic_gate.generate_command([qubit0, qubit1])
+    commands2 = basic_gate.generate_commands([qubit0, qubit1])
     basic_gate | [qubit0, qubit1]
-    command3 = basic_gate.generate_command(qureg)
+    commands3 = basic_gate.generate_commands(qureg)
     basic_gate | qureg
-    command4 = basic_gate.generate_command((qubit0,))
+    commands4 = basic_gate.generate_commands((qubit0,))
     basic_gate | (qubit0,)
-    command5 = basic_gate.generate_command((qureg, qubit0))
+    commands5 = basic_gate.generate_commands((qureg, qubit0))
     basic_gate | (qureg, qubit0)
     received_commands = []
     # Remove Deallocate gates
     for cmd in saving_backend.received_commands:
         if not isinstance(cmd.gate, _basics.FastForwardingGate):
             received_commands.append(cmd)
-    assert received_commands == ([command1, command2, command3, command4,
-                                  command5])
+    assert received_commands == ([commands1, commands2, commands3, commands4,
+                                  commands5])
 
 
 def test_basic_gate_compare(main_engine):

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -105,8 +105,11 @@ def test_basic_gate_or():
     for cmd in saving_backend.received_commands:
         if not isinstance(cmd.gate, _basics.FastForwardingGate):
             received_commands.append(cmd)
-    assert received_commands == ([commands1, commands2, commands3, commands4,
-                                  commands5])
+    assert received_commands == ([commands1[0],
+                                  commands2[0],
+                                  commands3[0],
+                                  commands4[0],
+                                  commands5[0]])
 
 
 def test_basic_gate_compare(main_engine):

--- a/projectq/ops/_command.py
+++ b/projectq/ops/_command.py
@@ -115,7 +115,8 @@ class Command(object):
         self.qubits = qubits  # property
 
         # access via self.control_qubits property
-        self._control_qubits = list(controls)
+        self._control_qubits = [WeakQubitRef(qubit.engine, qubit.id)
+                                for qubit in controls]
         self.engine = engine  # property
 
     @property

--- a/projectq/ops/_command.py
+++ b/projectq/ops/_command.py
@@ -64,6 +64,12 @@ class Command(object):
     be kept alive otherwise). WeakQubitRef qubits don't send deallocate gate
     when destructed.
 
+    Args:
+        engine (projectq.cengines.BasicEngine):
+        gate (projectq.ops.Gate):
+        qubits (tuple[Qureg]):
+        controls (Qureg):
+
     Attributes:
         gate: The gate to execute
         qubits: Tuple of qubit lists (e.g. Quregs). Interchangeable qubits
@@ -81,7 +87,7 @@ class Command(object):
         all_qubits: A tuple of control_qubits + qubits
     """
 
-    def __init__(self, engine, gate, qubits):
+    def __init__(self, engine, gate, qubits, controls=()):
         """
         Initialize a Command object.
 
@@ -93,18 +99,23 @@ class Command(object):
             (see WeakQubitRef).
 
         Args:
-            engine: engine which created the qubit (mostly the MainEngine)
-            gate: Gate to be executed
-            qubits: Tuple of quantum registers (to which the gate is applied)
+            engine (projectq.cengines.BasicEngine):
+                engine which created the qubit (mostly the MainEngine)
+            gate (projectq.ops.Gate):
+                Gate to be executed
+            qubits (tuple[Qureg]):
+                Tuple of quantum registers (to which the gate is applied)
         """
-        qubits = tuple([[WeakQubitRef(qubit.engine, qubit.id)
-                         for qubit in qreg]
-                        for qreg in qubits])
+        qubits = tuple([WeakQubitRef(qubit.engine, qubit.id)
+                        for qubit in qreg]
+                       for qreg in qubits)
 
         self.gate = gate
         self.tags = []
         self.qubits = qubits  # property
-        self._control_qubits = []  # access via self.control_qubits property
+
+        # access via self.control_qubits property
+        self._control_qubits = list(controls)
         self.engine = engine  # property
 
     @property
@@ -117,9 +128,11 @@ class Command(object):
 
     def __deepcopy__(self, memo):
         """ Deepcopy implementation. Engine should stay a reference."""
-        cpy = Command(self.engine, deepcopy(self.gate), self.qubits)
+        cpy = Command(self.engine,
+                      deepcopy(self.gate),
+                      self.qubits,
+                      list(self.control_qubits))
         cpy.tags = deepcopy(self.tags)
-        cpy.add_control_qubits(self.control_qubits)
         return cpy
 
     def get_inverse(self):
@@ -133,10 +146,11 @@ class Command(object):
             NotInvertible: If the gate does not provide an inverse (see
                 BasicGate.get_inverse)
         """
-        cmd = Command(self._engine, projectq.ops.get_inverse(self.gate),
-                      self.qubits)
+        cmd = Command(self._engine,
+                      projectq.ops.get_inverse(self.gate),
+                      self.qubits,
+                      list(self.control_qubits))
         cmd.tags = deepcopy(self.tags)
-        cmd.add_control_qubits(self.control_qubits)
         return cmd
 
     def get_merged(self, other):
@@ -151,11 +165,14 @@ class Command(object):
             NotMergeable: if the gates don't supply a get_merged()-function
                 or can't be merged for other reasons.
         """
+        # TODO: (github #38) check if control qubits are compatible
         if (self.tags == other.tags and self.all_qubits == other.all_qubits and
-           self.engine == other.engine):
-            merged_command = Command(self.engine, self.gate, self.qubits)
+                self.engine == other.engine):
+            merged_command = Command(self.engine,
+                                     self.gate,
+                                     self.qubits,
+                                     self.control_qubits)
             merged_command.gate = merged_command.gate.get_merged(other.gate)
-            merged_command.add_control_qubits(self.control_qubits)
             merged_command.tags = deepcopy(self.tags)
             return merged_command
         raise projectq.ops.NotMergeable("Commands not mergeable.")
@@ -275,13 +292,11 @@ class Command(object):
         Returns: True if Command objects are equal (same gate, applied to same
         qubits; ordered modulo interchangeability; and same tags)
         """
-        if (isinstance(other, self.__class__) and
-           self.gate == other.gate and
-           self.tags == other.tags and
-           self.engine == other.engine and
-           self.all_qubits == other.all_qubits):
-            return True
-        return False
+        return (isinstance(other, self.__class__) and
+                self.gate == other.gate and
+                self.tags == other.tags and
+                self.engine == other.engine and
+                self.all_qubits == other.all_qubits)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -294,7 +309,6 @@ class Command(object):
         ctrlqubits = self.control_qubits
         if len(ctrlqubits) > 0:
             qubits = (self.control_qubits,) + qubits
-        qstring = ""
         if len(qubits) == 1:
             qstring = str(Qureg(qubits[0]))
         else:
@@ -303,6 +317,11 @@ class Command(object):
                 qstring += str(Qureg(qreg))
                 qstring += ", "
             qstring = qstring[:-2] + " )"
-        #qstring = convert_qubits_to_string(qubits)
         cstring = "C" * len(ctrlqubits)
         return cstring + str(self.gate) + " | " + qstring
+
+    def __repr__(self):
+        return "Command(gate={}, qubits={}, controls={})".format(
+            repr(self.gate),
+            repr(self.qubits),
+            repr(self.control_qubits))

--- a/projectq/ops/_gates.py
+++ b/projectq/ops/_gates.py
@@ -56,6 +56,9 @@ class XGate(SelfInverseGate):
     def __str__(self):
         return "X"
 
+    def __repr__(self):
+        return "X"
+
     @property
     def matrix(self):
         return np.matrix([[0, 1], [1, 0]])
@@ -222,6 +225,9 @@ class AllocateQubitGate(ClassicalInstructionGate):
     def __str__(self):
         return "Allocate"
 
+    def __repr__(self):
+        return "Allocate"
+
     def get_inverse(self):
         return DeallocateQubitGate()
 
@@ -231,6 +237,9 @@ Allocate = AllocateQubitGate()
 class DeallocateQubitGate(FastForwardingGate):
     """ Qubit deallocation gate class """
     def __str__(self):
+        return "Deallocate"
+
+    def __repr__(self):
         return "Deallocate"
 
     def get_inverse(self):

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -50,6 +50,9 @@ class BasicQubit(object):
         self.id = idx
         self.engine = engine
 
+    def __repr__(self):
+        return "BasicQubit(idx={})".format(self.id)
+
     def __str__(self):
         """
         Return string representation of this qubit.
@@ -83,7 +86,8 @@ class BasicQubit(object):
         Args:
             other (BasicQubit): BasicQubit to which to compare this one
         """
-        return (isinstance(other, self.__class__) and self.id == other.id and
+        return (isinstance(other, BasicQubit) and
+                self.id == other.id and
                 self.engine == other.engine)
 
     def __ne__(self, other):
@@ -149,7 +153,8 @@ class WeakQubitRef(BasicQubit):
     garbage-collected (and, thus, cleaned up early). Otherwise there is no
     difference between a WeakQubitRef and a Qubit object.
     """
-    pass
+    def __repr__(self):
+        return "WeakQubitRef(idx={})".format(self.id)
 
 
 class Qureg(list):


### PR DESCRIPTION
- Stacking modifiers was bypassing lower modifiers in some cases
- Added controlled-tensor test to check that one of the cases is fixed
- Added 'restart_recording' to DummyBackend
- Fixed Qubit.__eq__ not being symmetric
- Refactored generate_command into generate_commands
- Replaced custom __or__'s with custom generate_commands
- Added type annotations in several places
- Added __repr__ methods to several classes
- Added 'controls' parameter to Command.__init__, and used it in several places