### PR TITLE
Fix BasicQubit.__hash__ not satisfying a==b implies hash(a)==hash(b)

### DIFF
--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -83,7 +83,10 @@ class BasicQubit(object):
         Args:
             other (BasicQubit): BasicQubit to which to compare this one
         """
-        return (isinstance(other, self.__class__) and self.id == other.id and
+        if self.id == -1:
+            return self is other
+        return (isinstance(other, BasicQubit) and
+                self.id == other.id and
                 self.engine == other.engine)
 
     def __ne__(self, other):
@@ -96,7 +99,9 @@ class BasicQubit(object):
         Hash definition because of custom __eq__.
         Enables storing a qubit in, e.g., a set.
         """
-        return hash((self.id, self.engine, object.__hash__(self)))
+        if self.id == -1:
+            return object.__hash__(self)
+        return hash((self.engine, self.id))
 
 
 class Qubit(BasicQubit):

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -75,6 +75,7 @@ def test_basic_qubit_hash():
     assert len(set(hash(_qubit.BasicQubit(fake_engine, e))
                    for e in range(100))) == 100
 
+    # Important that weakref.WeakSet in projectq.cengines._main.py works.
     # When id is -1, expect reference equality.
     x = _qubit.BasicQubit(fake_engine, -1)
     y = _qubit.BasicQubit(fake_engine, -1)

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -60,21 +60,26 @@ def test_basic_qubit_comparison(id0, id1, expected):
     assert qubit2 != qubit0
     assert qubit2 != qubit1
     # Same engines
-    if expected:
-        assert qubit0 == qubit1
-    else:
-        assert not (qubit0 == qubit1)
+    assert (qubit0 == qubit1) == expected
 
 
 def test_basic_qubit_hash():
     fake_engine = "Fake"
-    qubit0 = _qubit.BasicQubit(fake_engine, 0)
-    qubit1 = _qubit.BasicQubit(fake_engine, 1)
-    assert hash(qubit0) != hash(qubit1)
-    qubit0.id = -1
-    qubit1.id = -1
-    # Important that weakref.WeakSet in projectq.cengines._main.py works.
-    assert hash(qubit0) != hash(qubit1)
+    a = _qubit.BasicQubit(fake_engine, 1)
+    b = _qubit.BasicQubit(fake_engine, 1)
+    c = _qubit.WeakQubitRef(fake_engine, 1)
+    assert a == b and hash(a) == hash(b)
+    assert a == c and hash(a) == hash(c)
+
+    # For performance reasons, low ids should not collide.
+    assert len(set(hash(_qubit.BasicQubit(fake_engine, e))
+                   for e in range(100))) == 100
+
+    # When id is -1, expect reference equality.
+    x = _qubit.BasicQubit(fake_engine, -1)
+    y = _qubit.BasicQubit(fake_engine, -1)
+    # Note hash(x) == hash(y) isn't technically a failure, but it's surprising.
+    assert x != y and hash(x) != hash(y)
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes https://github.com/ProjectQ-Framework/ProjectQ/issues/43