### PR TITLE
Fix ControlledGate failing when a register is empty

### DIFF
--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -169,12 +169,10 @@ class BasicGate(object):
         """
         qubits = self.make_tuple_of_qureg(qubits)
 
-        for i in range(len(qubits)):
-            for j in range(len(qubits[i]) - 1):
-                assert(qubits[i][j].engine == qubits[i][j + 1].engine)
-            if i < len(qubits) - 1:
-                assert(qubits[i][-1].engine == qubits[i + 1][0].engine)
-        return Command(qubits[0][0].engine, self, qubits)
+        engines = [q.engine for reg in qubits for q in reg]
+        eng = engines[0]
+        assert all(e is eng for e in engines)
+        return Command(eng, self, qubits)
 
     def __or__(self, qubits):
         """ Operator| overload which enables the syntax Gate | qubits.

--- a/projectq/ops/_metagates.py
+++ b/projectq/ops/_metagates.py
@@ -173,7 +173,7 @@ class ControlledGate(BasicGate):
         """
         return ControlledGate(get_inverse(self._gate), self._n)
 
-    def __or__(self, qubits):
+    def generate_command(self, qubits):
         """
         Apply the controlled gate to qubits, using the first n qubits as
         controls.
@@ -187,25 +187,26 @@ class ControlledGate(BasicGate):
                 the gate.
         """
         qubits = BasicGate.make_tuple_of_qureg(qubits)
-        n = self._n
+
         ctrl = []
         gate_quregs = []
-        added_ctrl_qubits = 0
-        for qureg in qubits:
-            if added_ctrl_qubits < n:
-                ctrl = ctrl + qureg
-                added_ctrl_qubits += len(qureg)
+        adding_to_controls = True
+        for reg in qubits:
+            if adding_to_controls:
+                ctrl += reg
+                adding_to_controls = len(ctrl) < self._n
             else:
-                gate_quregs.append(qureg)
-        # Test that there were enough control qubits and that that
+                gate_quregs.append(reg)
+        # Test that there were enough control quregs and that that
         # the last control qubit was the last qubit in a qureg.
-        if added_ctrl_qubits != n:
-            raise ControlQubitError("Wrong number of control qubits. "
+        if len(ctrl) != self._n:
+            raise ControlQubitError("Wrong number of control quregs. "
                                     "First qureg(s) need to contain exactly "
-                                    "the required number of control qubits.")
+                                    "the required number of control quregs.")
+
         cmd = BasicGate.generate_command(self._gate, tuple(gate_quregs))
         cmd.add_control_qubits(ctrl)
-        apply_command(cmd)
+        return cmd
 
     def __eq__(self, other):
         """ Compare two ControlledGate objects (return True if equal). """

--- a/projectq/ops/_metagates.py
+++ b/projectq/ops/_metagates.py
@@ -173,7 +173,7 @@ class ControlledGate(BasicGate):
         """
         return ControlledGate(get_inverse(self._gate), self._n)
 
-    def generate_command(self, qubits):
+    def __or__(self, qubits):
         """
         Apply the controlled gate to qubits, using the first n qubits as
         controls.
@@ -206,7 +206,7 @@ class ControlledGate(BasicGate):
 
         cmd = BasicGate.generate_command(self._gate, tuple(gate_quregs))
         cmd.add_control_qubits(ctrl)
-        return cmd
+        apply_command(cmd)
 
     def __eq__(self, other):
         """ Compare two ControlledGate objects (return True if equal). """

--- a/projectq/ops/_metagates.py
+++ b/projectq/ops/_metagates.py
@@ -200,7 +200,7 @@ class ControlledGate(BasicGate):
         # Test that there were enough control quregs and that that
         # the last control qubit was the last qubit in a qureg.
         if len(ctrl) != self._n:
-            raise ControlQubitError("Wrong number of control quregs. "
+            raise ControlQubitError("Wrong number of control qubits. "
                                     "First qureg(s) need to contain exactly "
                                     "the required number of control quregs.")
 

--- a/projectq/ops/_metagates_test.py
+++ b/projectq/ops/_metagates_test.py
@@ -109,11 +109,12 @@ def test_controlled_gate_get_inverse():
 
 
 def test_controlled_gate_empty_controls():
-    eng = MainEngine(backend=DummyEngine())
+    rec = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=rec, engine_list=[])
 
     a = eng.allocate_qureg(1)
-    cmd = _metagates.ControlledGate(Y, 0).generate_command(((), a))
-    assert cmd == Command(eng, Y, [a])
+    _metagates.ControlledGate(Y, 0) | ((), a)
+    assert rec.received_commands[-1] == Command(eng, Y, [a])
 
 
 def test_controlled_gate_or():

--- a/projectq/ops/_metagates_test.py
+++ b/projectq/ops/_metagates_test.py
@@ -108,6 +108,14 @@ def test_controlled_gate_get_inverse():
     assert one_control.get_inverse() == expected
 
 
+def test_controlled_gate_empty_controls():
+    eng = MainEngine(backend=DummyEngine())
+
+    a = eng.allocate_qureg(1)
+    cmd = _metagates.ControlledGate(Y, 0).generate_command(((), a))
+    assert cmd == Command(eng, Y, [a])
+
+
 def test_controlled_gate_or():
     saving_backend = DummyEngine(save_commands=True)
     main_engine = MainEngine(backend=saving_backend,


### PR DESCRIPTION
- Fixed make_tuple_of_qureg assuming first register will contain items
- Fixed ControlledGate overriding __or__ instead of generate_command
- Added test of n=0 case