### PR TITLE
[Blocked] Implement proposed LimitedCapabilityEngine

### DIFF
--- a/projectq/cengines/__init__.py
+++ b/projectq/cengines/__init__.py
@@ -24,4 +24,4 @@ from ._replacer import (AutoReplacer,
                         DecompositionRuleSet,
                         DecompositionRule)
 from ._tagremover import TagRemover
-from ._testengine import CompareEngine, DummyEngine
+from ._testengine import CompareEngine, DummyEngine, LimitedCapabilityEngine

--- a/projectq/cengines/_testengine.py
+++ b/projectq/cengines/_testengine.py
@@ -12,10 +12,15 @@
 
 """TestEngine and DummyEngine."""
 
-
 from copy import deepcopy
+
 from projectq.cengines import BasicEngine
-from projectq.ops import FlushGate, Allocate, Deallocate
+from projectq.ops import (
+    FlushGate,
+    BasicMathGate,
+    ClassicalInstructionGate,
+    XGate
+)
 
 
 class CompareEngine(BasicEngine):
@@ -118,3 +123,119 @@ class DummyEngine(BasicEngine):
             self.send(command_list)
         else:
             pass
+
+
+class LimitedCapabilityEngine(BasicEngine):
+    """
+    An engine that restricts the available operations, on top of any
+    restrictions for later engines.
+
+    Only commands that meet as least one of the 'allow' criteria and NONE of
+    the 'ban' criteria given to the constructor are considered available. Also
+    gates are not considered available if the underlying engine can't receive
+    them.
+    """
+    def __init__(self,
+                 allow_classical_instructions=True,
+                 allow_all=False,
+                 allow_arithmetic=False,
+                 allow_toffoli=False,
+                 allow_nots_with_many_controls=False,
+                 allow_single_qubit_gates=False,
+                 allow_classes=(),
+                 allow_custom_predicate=lambda cmd: False,
+                 ban_classes=(),
+                 ban_custom_predicate=lambda cmd: False):
+        """
+        Constructs a LimitedCapabilityEngine that accepts commands based on
+        the given criteria arguments.
+
+        Note that a command is accepted if it meets *none* of the ban criteria
+        and *any* of the allow criteria.
+
+        Args:
+            allow_classical_instructions (bool):
+                Enabled by default. Marks classical instruction commands like
+                'Allocate', 'Flush', etc as available.
+
+            allow_all (bool):
+                Defaults to allowing all commands.
+                Any ban criteria will override this default.
+
+            allow_arithmetic (bool):
+                Allows gates with the BasicMathGate type.
+
+            allow_toffoli (bool):
+                Allows NOT gates with at most 2 controls.
+
+            allow_nots_with_many_controls (bool):
+                Allows NOT gates with arbitrarily many controls.
+
+            allow_single_qubit_gates (bool):
+                Allows gates that affect only a single qubit
+                (counting controls).
+
+            allow_classes (list[type]):
+                Allows any gates matching the given class.
+
+            allow_custom_predicate (function(Command) : bool):
+                Allows any gates that cause the given function to return True.
+
+            ban_classes (list[type]):
+                Bans any gates matching the given class.
+
+            ban_custom_predicate (function(Command) : bool):
+                Bans gates that cause the given function to return True.
+        """
+        BasicEngine.__init__(self)
+        self.allow_arithmetic = allow_arithmetic
+        self.allow_all = allow_all
+        self.allow_nots_with_many_controls = allow_nots_with_many_controls
+        self.allow_single_qubit_gates = allow_single_qubit_gates
+        self.allow_toffoli = allow_toffoli
+        self.allow_classical_instructions = allow_classical_instructions
+        self.allowed_classes = tuple(allow_classes)
+        self.allow_custom_predicate = allow_custom_predicate
+        self.ban_classes = tuple(ban_classes)
+        self.ban_custom_predicate = ban_custom_predicate
+
+    def is_available(self, cmd):
+        return (self._allow_command(cmd) and
+                not self._ban_command(cmd) and
+                (self.is_last_engine or self.next_engine.is_available(cmd)))
+
+    def receive(self, command_list):
+        if not self.is_last_engine:
+            self.send(command_list)
+
+    def _ban_command(self, cmd):
+        if any(isinstance(cmd.gate, c) for c in self.ban_classes):
+            return True
+
+        return self.ban_custom_predicate(cmd)
+
+    def _allow_command(self, cmd):
+        if self.allow_arithmetic and isinstance(cmd.gate, BasicMathGate):
+            return True
+
+        if (self.allow_classical_instructions and
+                isinstance(cmd.gate, ClassicalInstructionGate)):
+            return True
+
+        if (self.allow_toffoli and isinstance(cmd.gate, XGate) and
+                len(cmd.control_qubits) <= 2):
+            return True
+
+        if self.allow_single_qubit_gates and len(cmd.all_qubits) == 1:
+            return True
+
+        if self.allow_nots_with_many_controls and isinstance(cmd.gate, XGate):
+            return True
+
+        if any(isinstance(cmd.gate, c) for c in self.allowed_classes):
+            return True
+
+        if self.allow_custom_predicate(cmd):
+            return True
+
+        return self.allow_all

--- a/projectq/cengines/_testengine.py
+++ b/projectq/cengines/_testengine.py
@@ -202,7 +202,8 @@ class LimitedCapabilityEngine(BasicEngine):
     def is_available(self, cmd):
         return (self._allow_command(cmd) and
                 not self._ban_command(cmd) and
-                (self.is_last_engine or self.next_engine.is_available(cmd)))
+                (self.next_engine is None or
+                 self.next_engine.is_available(cmd)))
 
     def receive(self, command_list):
         for cmd in command_list:
@@ -220,11 +221,11 @@ class LimitedCapabilityEngine(BasicEngine):
         return self.ban_custom_predicate(cmd)
 
     def _allow_command(self, cmd):
-        if self.allow_arithmetic and isinstance(cmd.gate, BasicMathGate):
-            return True
-
         if (self.allow_classical_instructions and
                 isinstance(cmd.gate, ClassicalInstructionGate)):
+            return True
+
+        if self.allow_arithmetic and isinstance(cmd.gate, BasicMathGate):
             return True
 
         if (self.allow_toffoli and isinstance(cmd.gate, XGate) and

--- a/projectq/cengines/_testengine.py
+++ b/projectq/cengines/_testengine.py
@@ -205,6 +205,11 @@ class LimitedCapabilityEngine(BasicEngine):
                 (self.is_last_engine or self.next_engine.is_available(cmd)))
 
     def receive(self, command_list):
+        for cmd in command_list:
+            if not self._allow_command(cmd):
+                raise ValueError("Command not allowed: " + str(cmd))
+            if self._ban_command(cmd):
+                raise ValueError("Command banned: " + str(cmd))
         if not self.is_last_engine:
             self.send(command_list)
 

--- a/projectq/cengines/_testengine_test.py
+++ b/projectq/cengines/_testengine_test.py
@@ -11,12 +11,19 @@
 #   limitations under the License.
 
 """Tests for projectq.cengines._testengine.py."""
+import pytest
+from projectq.types import Qubit
 
 from projectq import MainEngine
 from projectq.cengines import DummyEngine
-from projectq.ops import CNOT, H, Rx, Allocate, FlushGate
+from projectq.ops import (
+    CNOT, H, Rx,
+    C, X, Y, Z,
+    Allocate, FlushGate, Measure, BasicMathGate, Toffoli
+)
 
 from projectq.cengines import _testengine
+from ._testengine import LimitedCapabilityEngine
 
 
 def test_compare_engine_str():
@@ -116,3 +123,71 @@ def test_dummy_engine():
     assert dummy_eng.received_commands[0].gate == Allocate
     assert dummy_eng.received_commands[1].gate == H
     assert dummy_eng.received_commands[2].gate == FlushGate()
+
+
+def test_limited_capability_engine_default():
+    eng = LimitedCapabilityEngine()
+    m = MainEngine(backend=DummyEngine(), engine_list=[eng])
+    q = m.allocate_qureg(2)
+
+    assert eng.is_available(Measure.generate_command(q))
+    assert not eng.is_available(H.generate_command(q))
+    assert not eng.is_available(Z.generate_command(q))
+    assert not eng.is_available(CNOT.generate_command(tuple(q)))
+
+
+def test_limited_capability_engine_classes():
+    eng = LimitedCapabilityEngine(allow_classes=[H.__class__, X.__class__],
+                                  ban_classes=[X.__class__, Y.__class__])
+    m = MainEngine(backend=DummyEngine(), engine_list=[eng])
+    q = m.allocate_qureg(5)
+
+    assert eng.is_available(Measure.generate_command(q))  # Default.
+    assert eng.is_available(H.generate_command(q))  # Allowed.
+    assert not eng.is_available(X.generate_command(q))  # Ban overrides allow.
+    assert not eng.is_available(Y.generate_command(q))  # Banned.
+    assert not eng.is_available(Z.generate_command(q))  # Not mentioned.
+
+
+def test_limited_capability_engine_arithmetic():
+    default_eng = LimitedCapabilityEngine()
+    eng = LimitedCapabilityEngine(allow_arithmetic=True)
+    m = MainEngine(backend=DummyEngine(), engine_list=[eng])
+    q = m.allocate_qureg(5)
+
+    inc = BasicMathGate(lambda x: x + 1)
+    assert not default_eng.is_available(inc.generate_command(q))
+    assert eng.is_available(inc.generate_command(q))
+
+
+def test_limited_capability_engine_classical_instructions():
+    default_eng = LimitedCapabilityEngine()
+    eng = LimitedCapabilityEngine(allow_classical_instructions=False,
+                                  allow_classes=[FlushGate])
+    m = MainEngine(backend=DummyEngine(), engine_list=[eng])
+    with pytest.raises(ValueError):
+        _ = m.allocate_qubit()
+    q = Qubit(m, 0)
+
+    assert default_eng.is_available(Measure.generate_command(q))
+    assert not eng.is_available(Measure.generate_command(q))
+
+
+def test_limited_capability_engine_allow_toffoli():
+    default_eng = LimitedCapabilityEngine()
+    eng = LimitedCapabilityEngine(allow_toffoli=True)
+    m = MainEngine(backend=DummyEngine(), engine_list=[eng])
+    q = m.allocate_qureg(4)
+    CCCNOT = C(Toffoli)
+
+    assert not default_eng.is_available(Z.generate_command(q))
+    assert not default_eng.is_available(X.generate_command(q))
+    assert not default_eng.is_available(CNOT.generate_command(tuple(q)))
+    assert not default_eng.is_available(Toffoli.generate_command(tuple(q)))
+    assert not default_eng.is_available(CCCNOT.generate_command(tuple(q)))
+
+    assert not eng.is_available(Z.generate_command(q))
+    assert eng.is_available(X.generate_command(q))
+    assert eng.is_available(CNOT.generate_command(tuple(q)))
+    assert eng.is_available(Toffoli.generate_command(tuple(q)))
+    assert not eng.is_available(CCCNOT.generate_command(tuple(q)))

--- a/projectq/ops/_metagates.py
+++ b/projectq/ops/_metagates.py
@@ -173,7 +173,7 @@ class ControlledGate(BasicGate):
         """
         return ControlledGate(get_inverse(self._gate), self._n)
 
-    def __or__(self, qubits):
+    def generate_command(self, qubits):
         """
         Apply the controlled gate to qubits, using the first n qubits as
         controls.
@@ -205,7 +205,7 @@ class ControlledGate(BasicGate):
                                     "the required number of control qubits.")
         cmd = BasicGate.generate_command(self._gate, tuple(gate_quregs))
         cmd.add_control_qubits(ctrl)
-        apply_command(cmd)
+        return cmd
 
     def __eq__(self, other):
         """ Compare two ControlledGate objects (return True if equal). """


### PR DESCRIPTION
For testing decompositions, it's often useful to prevent AutoReplacer from passing along complicated gates. This functionality could go into DummyEngine, but separating it out keeps DummyEngine simple.

[Not finalized. Suggestions on tests and constructor parameters please.]