### PR TITLE
Support Qureg.__int__ for multiple bits (little-endian)

### DIFF
--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -187,11 +187,7 @@ class Qureg(list):
             Exception if more than 1 qubit resides in this register (then you
             need to specify which value to get using qureg[???])
         """
-        if len(self) == 1:
-            return int(self[0])
-        else:
-            raise Exception("__int__(qureg): Quantum register contains more "
-                            "than 1 qubit. Use __bool__(qureg[idx]) instead.")
+        return sum(1 << i if bool(self[i]) else 0 for i in range(len(self)))
 
     def __nonzero__(self):
         """

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -181,11 +181,10 @@ class Qureg(list):
 
     def __int__(self):
         """
-        Return measured value if Qureg consists of 1 qubit only.
+        Return the measured little-endian integer in the quregister.
 
         Raises:
-            Exception if more than 1 qubit resides in this register (then you
-            need to specify which value to get using qureg[???])
+            NotYetMeasuredError if any of the qubits isn't measured.
         """
         return sum(1 << i if bool(self[i]) else 0 for i in range(len(self)))
 

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -158,6 +158,8 @@ def test_qureg_measure_multi_qubit_int():
     eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
     a = eng.allocate_qureg(4)
 
+    assert int(_qubit.Qureg([])) == 0
+
     eng.set_measurement_result(a[3], False)
     eng.set_measurement_result(a[2], True)
     eng.set_measurement_result(a[1], False)

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -154,6 +154,32 @@ def test_qureg_measure_if_qubit():
     assert qureg1.__nonzero__()
 
 
+def test_qureg_measure_multi_qubit_int():
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    a = eng.allocate_qureg(4)
+
+    eng.set_measurement_result(a[3], False)
+    eng.set_measurement_result(a[2], True)
+    eng.set_measurement_result(a[1], False)
+    eng.set_measurement_result(a[0], True)
+    assert int(a) == 0b0101
+    assert int(_qubit.Qureg(reversed(a))) == 0b1010
+    assert int(_qubit.Qureg([a[0], a[2], a[1], a[3]])) == 0b0011
+    assert int(_qubit.Qureg([a[0], a[1]])) == 0b01
+
+    eng.set_measurement_result(a[3], True)
+    eng.set_measurement_result(a[2], True)
+    eng.set_measurement_result(a[1], True)
+    eng.set_measurement_result(a[0], True)
+    assert int(a) == 15
+
+    eng.set_measurement_result(a[3], False)
+    eng.set_measurement_result(a[2], False)
+    eng.set_measurement_result(a[1], False)
+    eng.set_measurement_result(a[0], True)
+    assert int(a) == 1
+
+
 def test_qureg_measure_exception():
     eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
     qureg = _qubit.Qureg()


### PR DESCRIPTION
I think this is the natural thing to do when asking for the `int` in a quregister. (Existing tests weren't changed because they happened to not check for this.)

A reasonable follow-up change would be to remove the len==1 constraint from `__bool__` and `__non_zero__`, and have them check if `__int__` is non-zero instead. I can do that in this PR if you want.