### PR TITLE
Add a first version of time evolution emulation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
   - pip$PY install -e .
 
 # command to run tests
-script: pytest projectq --cov projectq
+script: export OMP_NUM_THREADS=1 && pytest projectq --cov projectq
 
 after_success:
   - coveralls

--- a/projectq/backends/_sim/_cppkernels/simulator.hpp
+++ b/projectq/backends/_sim/_cppkernels/simulator.hpp
@@ -276,10 +276,10 @@ public:
                 tr += tdict[i].second;
             else{
                 td.push_back(tdict[i]);
-                op_nrm += std::norm(tdict[i].second);
+                op_nrm += std::abs(tdict[i].second);
             }
         }
-        unsigned s = std::sqrt(op_nrm) + 1.;
+        unsigned s = std::abs(time) * op_nrm + 1.;
         complex_type correction = std::exp(-time * I * tr / (double)s);
         auto output_state = vec_;
         for (unsigned i = 0; i < s; ++i){

--- a/projectq/backends/_sim/_cppsim.cpp
+++ b/projectq/backends/_sim/_cppsim.cpp
@@ -51,6 +51,7 @@ PYBIND11_PLUGIN(_cppsim) {
         .def("apply_controlled_gate", &Simulator::apply_controlled_gate<MatrixType>)
         .def("emulate_math", &emulate_math_wrapper<QuRegs>)
         .def("get_expectation_value", &Simulator::get_expectation_value)
+        .def("emulate_time_evolution", &Simulator::emulate_time_evolution)
         .def("run", &Simulator::run)
         .def("cheat", &Simulator::cheat)
         ;

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -251,7 +251,8 @@ class Simulator(object):
     def emulate_time_evolution(self, terms_dict, time, ids, ctrlids):
         """
         Applies exp(-i*time*H) to the wave function, i.e., evolves under
-        the Hamiltonian H for a given time.
+        the Hamiltonian H for a given time. The terms in the Hamiltonian
+        are not required to commute.
 
         This function computes the action of the matrix exponential using
         ideas from Al-Mohy and Higham, 2011.

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -334,7 +334,7 @@ class Simulator(object):
         """
         Applies a QubitOperator term to the state vector.
         (Helper function for time evolution & expectation)
-        
+
         Args:
             term: One term of QubitOperator.terms
             ids (list[int]): Term index to Qubit ID mapping

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -268,7 +268,7 @@ class Simulator(object):
         # terms:
         tr = sum([c for (t, c) in terms_dict if len(t) == 0])
         terms_dict = [(t, c) for (t, c) in terms_dict if len(t) > 0]
-        op_nrm = _np.sqrt(sum([abs(c)**2 for (_, c) in terms_dict]))
+        op_nrm = abs(time) * sum([abs(c) for (_, c) in terms_dict])
         # rescale the operator by s:
         s = int(op_nrm + 1.)
         correction = _np.exp(-1j * time * tr / float(s))

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -239,21 +239,59 @@ class Simulator(object):
         Returns:
             Expectation value
         """
-        X = [[0., 1.], [1., 0.]]
-        Y = [[0., -1j], [1j, 0.]]
-        Z = [[1., 0.], [0., -1.]]
-        gates = [X, Y, Z]
         expectation = 0.
         current_state = _np.copy(self._state)
         for (term, coefficient) in terms_dict:
-            for local_op in term:
-                qb_id = ids[local_op[0]]
-                self.apply_controlled_gate(gates[ord(local_op[1]) - ord('X')],
-                                           [qb_id], [])
+            self._apply_term(term, ids)
             delta = coefficient * _np.vdot(current_state, self._state).real
             expectation += delta
             self._state = _np.copy(current_state)
         return expectation
+
+    def emulate_time_evolution(self, terms_dict, time, ids, ctrlids):
+        """
+        Applies exp(-i*time*H) to the wave function, i.e., evolves under
+        the Hamiltonian H for a given time.
+
+        This function computes the action of the matrix exponential using
+        ideas from Al-Mohy and Higham, 2011.
+        TODO: Implement better estimates for s.
+
+        Args:
+            terms_dict (dict): Operator dictionary (see QubitOperator.terms)
+                defining the Hamiltonian.
+            time (scalar): Time to evolve for
+            ids (list): A list of qubit IDs to which to apply the evolution.
+            ctrlids (list): A list of control qubit IDs.
+        """
+        # Determine the (normalized) trace, which is nonzero only for identity
+        # terms:
+        tr = sum([c for (t, c) in terms_dict if len(t) == 0])
+        terms_dict = [(t, c) for (t, c) in terms_dict if len(t) > 0]
+        op_nrm = _np.sqrt(sum([abs(c)**2 for (_, c) in terms_dict]))
+        # rescale the operator by s:
+        s = int(op_nrm + 1.)
+        correction = _np.exp(-1j * time * tr / float(s))
+        output_state = _np.copy(self._state)
+        for i in range(s):
+            j = 0
+            nrm_change = 1.
+            while nrm_change > 1.e-12:
+                coeff = (-time * 1j) / float(s * (j + 1))
+                current_state = _np.copy(self._state)
+                update = 0j
+                for t, c in terms_dict:
+                    self._apply_term(t, ids, ctrlids)
+                    self._state *= c
+                    update += self._state
+                    self._state = _np.copy(current_state)
+                update *= coeff
+                self._state = update
+                output_state += update
+                nrm_change = _np.linalg.norm(update)
+                j += 1
+            output_state *= correction
+            self._state = _np.copy(output_state)
 
     def apply_controlled_gate(self, m, ids, ctrlids):
         """
@@ -291,3 +329,22 @@ class Simulator(object):
         Dummy function to implement the same interface as the c++ simulator.
         """
         pass
+
+    def _apply_term(self, term, ids, ctrlids=[]):
+        """
+        Applies a QubitOperator term to the state vector.
+        (Helper function for time evolution & expectation)
+        
+        Args:
+            term: One term of QubitOperator.terms
+            ids (list[int]): Term index to Qubit ID mapping
+            ctrlids (list[int]): Control qubit IDs
+        """
+        X = [[0., 1.], [1., 0.]]
+        Y = [[0., -1j], [1j, 0.]]
+        Z = [[1., 0.], [0., -1.]]
+        gates = [X, Y, Z]
+        for local_op in term:
+            qb_id = ids[local_op[0]]
+            self.apply_controlled_gate(gates[ord(local_op[1]) - ord('X')],
+                                       [qb_id], ctrlids)

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -98,7 +98,8 @@ class Simulator(BasicEngine):
         """
         if (cmd.gate == Measure or cmd.gate == Allocate
            or cmd.gate == Deallocate
-           or isinstance(cmd.gate, BasicMathGate)):
+           or isinstance(cmd.gate, BasicMathGate)
+           or isinstance(cmd.gate, TimeEvolution)):
             return True
         try:
             m = cmd.gate.matrix

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -26,7 +26,8 @@ from projectq.ops import (NOT,
                           FlushGate,
                           Allocate,
                           Deallocate,
-                          BasicMathGate)
+                          BasicMathGate,
+                          TimeEvolution)
 
 try:
     from ._cppsim import Simulator as SimulatorBackend
@@ -176,6 +177,13 @@ class Simulator(BasicEngine):
             math_fun = cmd.gate.get_math_function(cmd.qubits)
             self._simulator.emulate_math(math_fun, qubitids,
                                          [qb.id for qb in cmd.control_qubits])
+        elif isinstance(cmd.gate, TimeEvolution):
+            op = [(list(term), coeff) for (term, coeff)
+                  in cmd.gate.hamiltonian.terms.items()]
+            t = cmd.gate.time
+            qubitids = [qb.id for qb in cmd.qubits[0]]
+            ctrlids = [qb.id for qb in cmd.control_qubits]
+            self._simulator.emulate_time_evolution(op, t, qubitids, ctrlids)
         elif len(cmd.gate.matrix) == 2:
             matrix = cmd.gate.matrix
             self._simulator.apply_controlled_gate(matrix.tolist(),

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -15,7 +15,13 @@ Tests for projectq.backends._sim._simulator.py, using both the Python
 and the C++ simulator as backends.
 """
 
+import copy
+import numpy
 import pytest
+import random
+import scipy
+import scipy.sparse
+import scipy.sparse.linalg
 
 from projectq import MainEngine
 from projectq.cengines import DummyEngine
@@ -24,12 +30,15 @@ from projectq.ops import (H,
                           Y,
                           Z,
                           S,
+                          Rx,
+                          Ry,
                           CNOT,
                           Toffoli,
                           Measure,
                           BasicGate,
                           BasicMathGate,
-                          QubitOperator)
+                          QubitOperator,
+                          TimeEvolution)
 from projectq.meta import Control
 
 from projectq.backends import Simulator
@@ -236,6 +245,61 @@ def test_simulator_expectation(sim):
     op_id = .4 * QubitOperator()
     expectation = sim.get_expectation_value(op_id, qureg)
     assert .4 == pytest.approx(expectation)
+
+
+def test_simulator_time_evolution(sim):
+    N = 9 # number of qubits
+    time_to_evolve = 1.1 # time to evolve for
+    eng = MainEngine(sim, [])
+    qureg = eng.allocate_qureg(N)
+    # initialize in random wavefunction by applying some gates:
+    for qb in qureg:
+        Rx(random.random()) | qb
+        Ry(random.random()) | qb
+    eng.flush()
+    # Use cheat to get initial start wavefunction:
+    qubit_to_bit_map, init_wavefunction = copy.deepcopy(eng.backend.cheat())
+    Qop = QubitOperator
+    op = 0.3 * Qop("X0 Y1 Z2 Y3 X4")
+    op += 1.1 * Qop()
+    op += -1.4 * Qop("Y0 Z1 X3 Y5")
+    op += -1.1 * Qop("Y1 X2 X3 Y4")
+    import time
+    start = time.time()
+    TimeEvolution(time_to_evolve, op) | qureg
+    print(time.time()-start)
+    eng.flush()
+    qbit_to_bit_map, final_wavefunction = copy.deepcopy(eng.backend.cheat())
+    Measure | qureg
+    # Check manually:
+
+    def build_matrix(list_single_matrices):
+        res = list_single_matrices[0]
+        for i in range(1, len(list_single_matrices)):
+            res = scipy.sparse.kron(res, list_single_matrices[i])
+        return res
+    start = time.time()
+    id_sp = scipy.sparse.identity(2, format="csr", dtype=complex)
+    x_sp = scipy.sparse.csr_matrix([[0., 1.], [1., 0.]], dtype=complex)
+    y_sp = scipy.sparse.csr_matrix([[0., -1.j], [1.j, 0.]], dtype=complex)
+    z_sp = scipy.sparse.csr_matrix([[1., 0.], [0., -1.]], dtype=complex)
+    gates = [x_sp, y_sp, z_sp]
+
+    res_matrix = 0
+    for t, c in op.terms.items():
+        matrix = [id_sp] * N
+        for idx, gate in t:
+            matrix[qbit_to_bit_map[qureg[idx].id]] = gates[ord(gate) -
+                                                           ord('X')]
+        matrix.reverse()
+        res_matrix += build_matrix(matrix) * c
+    res_matrix *= -1j * time_to_evolve
+    
+    init_wavefunction = numpy.array(init_wavefunction, copy=False)
+    final_wavefunction = numpy.array(final_wavefunction, copy=False)
+    res = scipy.sparse.linalg.expm_multiply(res_matrix, init_wavefunction)
+    print(time.time()-start)
+    assert numpy.allclose(res, final_wavefunction)
 
 
 def test_simulator_no_uncompute_exception(sim):

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -248,8 +248,8 @@ def test_simulator_expectation(sim):
 
 
 def test_simulator_time_evolution(sim):
-    N = 9 # number of qubits
-    time_to_evolve = 1.1 # time to evolve for
+    N = 9  # number of qubits
+    time_to_evolve = 1.1  # time to evolve for
     eng = MainEngine(sim, [])
     qureg = eng.allocate_qureg(N)
     # initialize in random wavefunction by applying some gates:
@@ -264,10 +264,7 @@ def test_simulator_time_evolution(sim):
     op += 1.1 * Qop()
     op += -1.4 * Qop("Y0 Z1 X3 Y5")
     op += -1.1 * Qop("Y1 X2 X3 Y4")
-    import time
-    start = time.time()
     TimeEvolution(time_to_evolve, op) | qureg
-    print(time.time()-start)
     eng.flush()
     qbit_to_bit_map, final_wavefunction = copy.deepcopy(eng.backend.cheat())
     Measure | qureg
@@ -278,7 +275,6 @@ def test_simulator_time_evolution(sim):
         for i in range(1, len(list_single_matrices)):
             res = scipy.sparse.kron(res, list_single_matrices[i])
         return res
-    start = time.time()
     id_sp = scipy.sparse.identity(2, format="csr", dtype=complex)
     x_sp = scipy.sparse.csr_matrix([[0., 1.], [1., 0.]], dtype=complex)
     y_sp = scipy.sparse.csr_matrix([[0., -1.j], [1.j, 0.]], dtype=complex)
@@ -294,11 +290,10 @@ def test_simulator_time_evolution(sim):
         matrix.reverse()
         res_matrix += build_matrix(matrix) * c
     res_matrix *= -1j * time_to_evolve
-    
+
     init_wavefunction = numpy.array(init_wavefunction, copy=False)
     final_wavefunction = numpy.array(final_wavefunction, copy=False)
     res = scipy.sparse.linalg.expm_multiply(res_matrix, init_wavefunction)
-    print(time.time()-start)
     assert numpy.allclose(res, final_wavefunction)
 
 


### PR DESCRIPTION
This is the first version of the time evolution emulation feature of the simulator. It works but uses a very loose estimate to rescale the operator H when calculating exp(H). This results in long runtimes for operators featuring a large 1-norm. Later: Include tighter bounds by Al-Mohy & Higham, 2011.