### PR TITLE
Combine sequential ids into ranges when describing quantum registers

### DIFF
--- a/projectq/cengines/_testengine_test.py
+++ b/projectq/cengines/_testengine_test.py
@@ -27,9 +27,9 @@ def test_compare_engine_str():
     H | qb0
     CNOT | (qb0, qb1)
     eng.flush()
-    expected = ("Qubit 0 : Allocate | Qubit[0], H | Qubit[0], " +
-                "CX | ( Qubit[0], Qubit[1] )\nQubit 1 : Allocate | Qubit[1]," +
-                " CX | ( Qubit[0], Qubit[1] )\n")
+    expected = ("Qubit 0 : Allocate | Qureg[0], H | Qureg[0], " +
+                "CX | ( Qureg[0], Qureg[1] )\nQubit 1 : Allocate | Qureg[1]," +
+                " CX | ( Qureg[0], Qureg[1] )\n")
     assert str(compare_engine) == expected
 
 

--- a/projectq/ops/_command_test.py
+++ b/projectq/ops/_command_test.py
@@ -233,6 +233,6 @@ def test_command_str():
     cmd = _command.Command(main_engine, Rx(0.5), (qubit,))
     cmd.tags = ["TestTag"]
     cmd.add_control_qubits(ctrl_qubit)
-    assert str(cmd) == "CRx(0.5) | ( Qubit[1], Qubit[0] )"
+    assert str(cmd) == "CRx(0.5) | ( Qureg[1], Qureg[0] )"
     cmd2 = _command.Command(main_engine, Rx(0.5), (qubit,))
-    assert str(cmd2) == "Rx(0.5) | Qubit[0]"
+    assert str(cmd2) == "Rx(0.5) | Qureg[0]"

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -207,10 +207,27 @@ class Qureg(list):
         """
         Get string representation of a quantum register.
         """
-        if len(self) == 1:
-            return "Qubit[" + str(self[0]) + "]"
-        else:
-            return "Qureg" + str([q.id for q in self])
+        if len(self) == 0:
+            return "Qureg[]"
+
+        ids = [q.id for q in self[1:]]
+        ids.append(None)  # Forces a flush on last loop iteration.
+
+        out_list = []
+        start_id = self[0].id
+        count = 1
+        for qubit_id in ids:
+            if qubit_id == start_id + count:
+                count += 1
+                continue
+
+            out_list.append('{}-{}'.format(start_id, start_id + count - 1)
+                            if count > 1
+                            else '{}'.format(start_id))
+            start_id = qubit_id
+            count = 1
+
+        return "Qureg[{}]".format(', '.join(out_list))
 
     @property
     def engine(self):

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -124,15 +124,26 @@ def test_weak_qubit_ref():
         qubit.__del__()
 
 
-@pytest.mark.parametrize("qubit_ids, expected",
-                         [([10], "Qubit[10]"), ([1, 2, 3], "Qureg[1, 2, 3]")])
-def test_qureg(qubit_ids, expected):
-    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-    qureg = _qubit.Qureg()
-    for qubit_id in qubit_ids:
-        qubit = _qubit.Qubit(eng, qubit_id)
-        qureg.append(qubit)
-    assert str(qureg) == expected
+def test_qureg_str():
+    assert str(_qubit.Qureg([])) == 'Qureg[]'
+    eng = MainEngine(backend=DummyEngine(), engine_list=[])
+    a = eng.allocate_qureg(10)
+    b = eng.allocate_qureg(50)
+    c = eng.allocate_qubit()
+    d = eng.allocate_qubit()
+    e = eng.allocate_qubit()
+    assert str(a) == 'Qureg[0-9]'
+    assert str(b) == 'Qureg[10-59]'
+    assert str(c) == 'Qureg[60]'
+    assert str(d) == 'Qureg[61]'
+    assert str(e) == 'Qureg[62]'
+    assert str(_qubit.Qureg(c + e)) == 'Qureg[60, 62]'
+    assert str(_qubit.Qureg(a + b)) == 'Qureg[0-59]'
+    assert str(_qubit.Qureg(a + b + c)) == 'Qureg[0-60]'
+    assert str(_qubit.Qureg(a + b + d)) == 'Qureg[0-59, 61]'
+    assert str(_qubit.Qureg(a + b + e)) == 'Qureg[0-59, 62]'
+    assert str(_qubit.Qureg(b + a)) == 'Qureg[10-59, 0-9]'
+    assert str(_qubit.Qureg(e + b + a)) == 'Qureg[62, 10-59, 0-9]'
 
 
 def test_qureg_measure_if_qubit():


### PR DESCRIPTION
When debugging code that generates large circuits, the size of the Qureg descriptions becomes a problem. But most Quregs are sequential, or nearly sequential, and so can be described succinctly as a union of ranges.

For example, instead of:

```
Qureg[0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
```

the code will now say:

```
Qureg[0-6, 8-31]
```