### PR TITLE
Minor cleanup in LocalOptimizer._optimize

### DIFF
--- a/projectq/cengines/_optimize.py
+++ b/projectq/cengines/_optimize.py
@@ -103,9 +103,9 @@ class LocalOptimizer(BasicEngine):
                                     for prev_cmd in self._l[idx][:i]
                                     if prev_cmd == cmd)
         indices = []
-        for k in range(N):
+        for Id in IDs:
             identical_indices = [i
-                                 for i, c in enumerate(self._l[IDs[k]])
+                                 for i, c in enumerate(self._l[Id])
                                  if c == cmd]
             indices.append(identical_indices[num_identical_to_skip])
         return indices


### PR DESCRIPTION
- Use slicing and a comprehension instead of index twiddling to count identical gates
- Separate match-finding from match-picking