### PR TITLE
Simplify BasicEngine.deallocate_qubit

### DIFF
--- a/projectq/cengines/_basics.py
+++ b/projectq/cengines/_basics.py
@@ -150,22 +150,17 @@ class BasicEngine(object):
         Args:
             qubit (BasicQubit): Qubit to deallocate.
         """
-        if qubit.id != -1:
-            if qubit.id not in self.main_engine.dirty_qubits:
-                self.send([Command(self, Deallocate, ([qubit],))])
-            else:
-                from projectq.meta import DirtyQubitTag
-                oldnext = self.next_engine
 
-                def cmd_modifier(cmd):
-                    assert(cmd.gate == Deallocate)
-                    cmd.tags += [DirtyQubitTag()]
-                    return cmd
-                self.next_engine = projectq.cengines.CommandModifier(
-                    cmd_modifier)
-                self.next_engine.next_engine = oldnext
-                self.send([Command(self, Deallocate, ([qubit],))])
-                self.next_engine = oldnext
+        # Already deallocated?
+        if qubit.id == -1:
+            return
+
+        from projectq.meta import DirtyQubitTag
+        is_dirty = qubit.id in self.main_engine.dirty_qubits
+        self.send([Command(self,
+                           Deallocate,
+                           (Qureg([qubit]),),
+                           tags=[DirtyQubitTag()] if is_dirty else [])])
 
     def is_meta_tag_supported(self, meta_tag):
         """


### PR DESCRIPTION
- Use guard statement instead of indenting
- Specify dirty tag via `Command.__init__` instead of via CommandModifier
- Merge clean/dirty cases.