### PR TITLE
Prevent Qubit.__del__ from running more than once

### DIFF
--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -303,7 +303,8 @@ def test_simulator_no_uncompute_exception(sim):
     H | qubit
     with pytest.raises(RuntimeError):
         qubit[0].__del__()
-    Measure | qubit
+    # If you wanted to keep using the qubit, you shouldn't have deleted it.
+    assert qubit[0].id == -1
 
 
 class MockSimulatorBackend(object):

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -116,10 +116,17 @@ class Qubit(BasicQubit):
     Thus the qubit is not copyable; only returns a reference to the same
     object.
     """
+    def __init__(self, engine, idx):
+        BasicQubit.__init__(self, engine, idx)
+        self._has_run_del = False
+
     def __del__(self):
         """
         Destroy the qubit and deallocate it (automatically).
         """
+        if self._has_run_del:
+            return
+        self._has_run_del = True
         self.engine.deallocate_qubit(self)
         self.id = -1
 

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -118,17 +118,16 @@ class Qubit(BasicQubit):
     """
     def __init__(self, engine, idx):
         BasicQubit.__init__(self, engine, idx)
-        self._has_run_del = False
 
     def __del__(self):
         """
         Destroy the qubit and deallocate it (automatically).
         """
-        if self._has_run_del:
+        if self.id == -1:
             return
-        self._has_run_del = True
-        self.engine.deallocate_qubit(self)
+        weak_copy = WeakQubitRef(self.engine, self.id)
         self.id = -1
+        self.engine.deallocate_qubit(weak_copy)
 
     def __copy__(self):
         """

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -116,9 +116,6 @@ class Qubit(BasicQubit):
     Thus the qubit is not copyable; only returns a reference to the same
     object.
     """
-    def __init__(self, engine, idx):
-        BasicQubit.__init__(self, engine, idx)
-
     def __del__(self):
         """
         Destroy the qubit and deallocate it (automatically).

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -175,3 +175,15 @@ def test_qureg_engine():
     assert eng1 == qureg.engine
     qureg.engine = eng2
     assert qureg[0].engine == eng2 and qureg[1].engine == eng2
+
+
+def test_idempotent_del():
+    rec = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=rec, engine_list=[])
+    q = eng.allocate_qubit()[0]
+    rec.received_commands = []
+    assert len(rec.received_commands) == 0
+    q.__del__()
+    assert len(rec.received_commands) == 1
+    q.__del__()
+    assert len(rec.received_commands) == 1


### PR DESCRIPTION
Currently, when the call to `engine.deallocate_qubit` fails, the `self.id = -1` line never runs. The failure can also resurrect the qubit object instance, so its del method gets scheduled to run again, and so an infinite error text loop closes.

Alternatively, the loop can be closed by "helpful" code triggered by the dealloc accidentally calling `__del__` on the qubit.

I've seen it happen (I injected a failure-on-tenth-iteration into LocalOptimizer than ran the Shor example). And this change fixed the problem.