### PR TITLE
Extract _send_rewritten_command from ComputeEngine.run_uncompute

### DIFF
--- a/projectq/_version.py
+++ b/projectq/_version.py
@@ -11,4 +11,4 @@
 #   limitations under the License.
 
 """Define version number here and read it from setup.py automatically"""
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/projectq/meta/_compute.py
+++ b/projectq/meta/_compute.py
@@ -87,8 +87,12 @@ class ComputeEngine(BasicEngine):
         cmd.tags.append(UncomputeTag())
         return cmd
 
-    def _send_rewritten_command(self, cmd, rewrite_id_map):
+    def _send_inverse_with_rewritten_qubits(self, cmd, rewrite_id_map):
         """
+        Rewrites the given command so it uses global qubit ids instead of
+        local-to-compute-block qubit ids, then forwards the command's inverse
+        to the next engine.
+
         Args:
             cmd (projectq.ops.Command):
             rewrite_id_map (dict[int, int]):
@@ -206,7 +210,9 @@ class ComputeEngine(BasicEngine):
                     self.send([self._add_uncompute_tag(cmd.get_inverse())])
 
             else:
-                self._send_rewritten_command(cmd, new_local_id)
+                # Forward the inverse command, but with local-to-compute-block
+                # qubit ids changed to the corresponding global qubit ids.
+                self._send_inverse_with_rewritten_qubits(cmd, new_local_id)
 
     def end_compute(self):
         """

--- a/projectq/meta/_compute.py
+++ b/projectq/meta/_compute.py
@@ -94,7 +94,7 @@ class ComputeEngine(BasicEngine):
             rewrite_id_map (dict[int, int]):
         """
 
-        if len(rewrite_id_map) != 0:
+        if rewrite_id_map:
             for qureg in cmd.all_qubits:
                 for qubit in qureg:
                     if qubit.id in rewrite_id_map:


### PR DESCRIPTION
- Dropped temporary lists because they were references not copies
- Merged id-rewritten into a single nested loop via Command.all_qubits

The `run_uncompute` function is *huge*. This extracts one of its pieces.