### PR TITLE
Rename Command.all_qubits -> all_quregs

### DIFF
--- a/projectq/backends/_circuits/_drawer.py
+++ b/projectq/backends/_circuits/_drawer.py
@@ -233,7 +233,7 @@ class CircuitDrawer(BasicEngine):
                     m = int(m)
                     self.main_engine.set_measurement_result(qubit, m)
 
-        all_lines = [qb.id for qr in cmd.all_qubits for qb in qr]
+        all_lines = [qb.id for qr in cmd.all_quregs for qb in qr]
 
         gate = cmd.gate
         lines = [qb.id for qr in cmd.qubits for qb in qr]

--- a/projectq/cengines/_optimize.py
+++ b/projectq/cengines/_optimize.py
@@ -52,7 +52,7 @@ class LocalOptimizer(BasicEngine):
         for i in range(0, min(n, len(il))):  # loop over first n operations
             # send all gates before n-qubit gate for other qubits involved
             # --> recursively call send_helper
-            for qreg in il[i].all_qubits:  # loop over tuples of quregs
+            for qreg in il[i].all_quregs:  # loop over tuples of quregs
                 for qb in qreg:  # ... and qubits involved
                     Id = qb.id
                     if Id != idx:  # is a different qubit than the current one
@@ -138,7 +138,7 @@ class LocalOptimizer(BasicEngine):
 
             if inv == self._l[idx][i + 1]:
                 # determine index of this gate on all qubits
-                qubitids = [qb.id for sublist in self._l[idx][i].all_qubits
+                qubitids = [qb.id for sublist in self._l[idx][i].all_quregs
                             for qb in sublist]
                 gid = self._get_gate_indices(idx, i, qubitids)
                 # check that there are no other gates between this and its
@@ -163,7 +163,7 @@ class LocalOptimizer(BasicEngine):
                 merged_command = self._l[idx][i].get_merged(
                     self._l[idx][i + 1])
                 # determine index of this gate on all qubits
-                qubitids = [qb.id for sublist in self._l[idx][i].all_qubits
+                qubitids = [qb.id for sublist in self._l[idx][i].all_quregs
                             for qb in sublist]
                 gid = self._get_gate_indices(idx, i, qubitids)
 
@@ -211,7 +211,7 @@ class LocalOptimizer(BasicEngine):
         involved.
         """
         # are there qubit ids that haven't been added to the list?
-        idlist = [qubit.id for sublist in cmd.all_qubits for qubit in sublist]
+        idlist = [qubit.id for sublist in cmd.all_quregs for qubit in sublist]
         maxidx = int(0)
         for ID in idlist:
             maxidx = max(maxidx, ID)

--- a/projectq/cengines/_testengine.py
+++ b/projectq/cengines/_testengine.py
@@ -33,7 +33,7 @@ class CompareEngine(BasicEngine):
 
     def cache_cmd(self, cmd):
         # are there qubit ids that haven't been added to the list?
-        all_qubit_id_list = [qubit.id for qureg in cmd.all_qubits
+        all_qubit_id_list = [qubit.id for qureg in cmd.all_quregs
                              for qubit in qureg]
         maxidx = int(0)
         for qubit_id in all_qubit_id_list:

--- a/projectq/ops/_command.py
+++ b/projectq/ops/_command.py
@@ -78,7 +78,7 @@ class Command(object):
           is from the inner scope while tag[1] is from the other scope as the
           other scope receives the command after the inner scope LoopEngine
           and hence adds its LoopTag to the end.
-        all_qubits: A tuple of control_qubits + qubits
+        all_quregs: A tuple of control_qubits + qubits
     """
 
     def __init__(self, engine, gate, qubits, controls=(), tags=()):
@@ -159,7 +159,7 @@ class Command(object):
             NotMergeable: if the gates don't supply a get_merged()-function
                 or can't be merged for other reasons.
         """
-        if (self.tags == other.tags and self.all_qubits == other.all_qubits and
+        if (self.tags == other.tags and self.all_quregs == other.all_quregs and
                 self.engine == other.engine):
             return Command(self.engine,
                            self.gate.get_merged(other.gate),
@@ -240,7 +240,7 @@ class Command(object):
         self._control_qubits = sorted(self._control_qubits, key=lambda x: x.id)
 
     @property
-    def all_qubits(self):
+    def all_quregs(self):
         """
         Get all qubits (gate and control qubits).
 
@@ -287,7 +287,7 @@ class Command(object):
            self.gate == other.gate and
            self.tags == other.tags and
            self.engine == other.engine and
-           self.all_qubits == other.all_qubits):
+           self.all_quregs == other.all_quregs):
             return True
         return False
 

--- a/projectq/ops/_command_test.py
+++ b/projectq/ops/_command_test.py
@@ -172,14 +172,14 @@ def test_commmand_add_control_qubits(main_engine):
     assert cmd.control_qubits[1].id == 2
 
 
-def test_command_all_qubits(main_engine):
+def test_command_all_quregs(main_engine):
     qubit0 = Qureg([Qubit(main_engine, 0)])
     qubit1 = Qureg([Qubit(main_engine, 1)])
     cmd = _command.Command(main_engine, Rx(0.5), (qubit0,))
     cmd.add_control_qubits(qubit1)
-    all_qubits = cmd.all_qubits
-    assert all_qubits[0][0].id == 1
-    assert all_qubits[1][0].id == 0
+    all_quregs = cmd.all_quregs
+    assert all_quregs[0][0].id == 1
+    assert all_quregs[1][0].id == 0
 
 
 def test_command_engine(main_engine):


### PR DESCRIPTION
There are many other cases where qubit should be qureg, but this one was easily fixed by search-and-replace.

Note that this will merge-conflict with other pending PRs.