### PR TITLE
Small change to fix TypeErrors in TimeEvolution

### DIFF
--- a/projectq/ops/_time_evolution.py
+++ b/projectq/ops/_time_evolution.py
@@ -74,7 +74,7 @@ class TimeEvolution(BasicGate):
         for term in hamiltonian.terms:
             if self.hamiltonian.terms[term].imag == 0:
                 self.hamiltonian.terms[term] = float(
-                    self.hamiltonian.terms[term])
+                    self.hamiltonian.terms[term].real)
             else:
                 raise NotHermitianOperatorError("hamiltonian must be "
                                                 "hermitian and hence only "


### PR DESCRIPTION
The existing code can cause TypeErrors (can't convert complex to float). This should fix them for line 77. Lines 127 and 130 have the same structure but should be fine, though I suspect the casts to float there aren't necessary.