### PR TITLE
Added new test for Compute Uncompute

### DIFF
--- a/projectq/meta/_compute.py
+++ b/projectq/meta/_compute.py
@@ -127,7 +127,7 @@ class ComputeEngine(BasicEngine):
                     for active_qubit in self.main_engine.active_qubits:
                         if active_qubit.id == qubit_id:
                             active_qubit.id = -1
-                            del active_qubit
+                            active_qubit.__del__()
                             qubit_found = True
                             break
                     if not qubit_found:
@@ -181,7 +181,7 @@ class ComputeEngine(BasicEngine):
                     for active_qubit in self.main_engine.active_qubits:
                         if active_qubit.id == qubit_id:
                             active_qubit.id = -1
-                            del active_qubit
+                            active_qubit.__del__()
                             qubit_found = True
                             break
                     if not qubit_found:

--- a/projectq/meta/_compute_test.py
+++ b/projectq/meta/_compute_test.py
@@ -161,7 +161,7 @@ def test_automatic_deallocation_of_qubit_in_uncompute():
         ancilla = eng.allocate_qubit()
         assert ancilla[0].id != -1
         Rx(0.6) | ancilla
-    # Test that ancilla qubit has been register in MainEngine.active_qubits
+    # Test that ancilla qubit has been registered in MainEngine.active_qubits
     assert ancilla[0] in eng.active_qubits
     _compute.Uncompute(eng)
     # Test that ancilla id has been set to -1
@@ -170,6 +170,8 @@ def test_automatic_deallocation_of_qubit_in_uncompute():
     assert not ancilla[0] in eng.active_qubits
     assert backend.received_commands[1].gate == Rx(0.6)
     assert backend.received_commands[2].gate == Rx(-0.6)
+    # Test that there are no two deallocate gates sent
+    assert len(backend.received_commands) == 4
 
 
 def test_compute_uncompute_no_additional_qubits():

--- a/projectq/meta/_compute_test.py
+++ b/projectq/meta/_compute_test.py
@@ -170,7 +170,7 @@ def test_automatic_deallocation_of_qubit_in_uncompute():
     assert not ancilla[0] in eng.active_qubits
     assert backend.received_commands[1].gate == Rx(0.6)
     assert backend.received_commands[2].gate == Rx(-0.6)
-    # Test that there are no two deallocate gates sent
+    # Test that there are no additional deallocate gates
     assert len(backend.received_commands) == 4
 
 


### PR DESCRIPTION
Checks that `Uncompute(eng)` does not send two `Deallocate` gates when deallocating in fact only one qubit.