### PR TITLE
Edit tags directly instead of using CommandModifier in BasicEngine.allocate_qubit

### DIFF
--- a/projectq/cengines/_basics.py
+++ b/projectq/cengines/_basics.py
@@ -110,8 +110,9 @@ class BasicEngine(object):
         cmd = Command(self, Allocate, (qb,))
         if dirty:
             from projectq.meta import DirtyQubitTag
-            cmd.tags += [DirtyQubitTag()]
-            self.main_engine.dirty_qubits.add(qb[0].id)
+            if self.is_meta_tag_supported(DirtyQubitTag):
+                cmd.tags += [DirtyQubitTag()]
+                self.main_engine.dirty_qubits.add(qb[0].id)
         self.main_engine.active_qubits.add(qb[0])
         self.send([cmd])
         return qb


### PR DESCRIPTION
If the allocate command could somehow re-enter then this is not a no-op change, but there's no test checking for that behavior so I assume it doesn't happen?