### PR TITLE
Fix sparsity problems which cause warnings by switching to csc matrices

### DIFF
--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -87,7 +87,7 @@ class Simulator(BasicEngine):
         """
         Specialized implementation of is_available: The simulator can deal
         with all arbitrarily-controlled single-qubit gates which provide a
-        gate-matrix (via gate.get_matrix()).
+        gate-matrix (via gate.matrix).
 
         Args:
             cmd (Command): Command for which to check availability (single-

--- a/projectq/setups/decompositions/time_evolution.py
+++ b/projectq/setups/decompositions/time_evolution.py
@@ -90,7 +90,7 @@ def _decompose_time_evolution_individual_terms(cmd):
     check_indices = set()
 
     # Check that hamiltonian is not identity term,
-    # Previous or operator should have apply a global phase instead:
+    # Previous __or__ operator should have apply a global phase instead:
     assert not term == ()
 
     # hamiltonian has only a single local operator

--- a/projectq/setups/decompositions/time_evolution_test.py
+++ b/projectq/setups/decompositions/time_evolution_test.py
@@ -178,14 +178,14 @@ def test_decompose_individual_terms():
         res = list_single_matrices[0]
         for i in range(1, len(list_single_matrices)):
             res = sps.kron(res, list_single_matrices[i])
-        return res
+        return res.tocsc()
 
-    id_sp = sps.identity(2, format="csr", dtype=complex)
-    x_sp = sps.csr_matrix([[0., 1.], [1., 0.]], dtype=complex)
-    y_sp = sps.csr_matrix([[0., -1.j], [1.j, 0.]], dtype=complex)
-    z_sp = sps.csr_matrix([[1., 0.], [0., -1.]], dtype=complex)
+    id_sp = sps.identity(2, format="csc", dtype=complex)
+    x_sp = sps.csc_matrix([[0., 1.], [1., 0.]], dtype=complex)
+    y_sp = sps.csc_matrix([[0., -1.j], [1.j, 0.]], dtype=complex)
+    z_sp = sps.csc_matrix([[1., 0.], [0., -1.]], dtype=complex)
 
-    matrix1 = (sps.identity(2**5, format="csr", dtype=complex) * 0.6 *
+    matrix1 = (sps.identity(2**5, format="csc", dtype=complex) * 0.6 *
                1.1 * -1.0j)
     step1 = scipy.sparse.linalg.expm(matrix1).dot(init_wavefunction)
     assert numpy.allclose(step1, final_wavefunction1)


### PR DESCRIPTION
* Fix two docstrings
* Fixed sparsity warnings by switching to csc matrices