### PR TITLE
Bugfix set_wavefunction in pysim

### DIFF
--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -469,7 +469,7 @@ class Simulator(object):
                                " Please make sure all qubits have been "
                                "allocated previously (call eng.flush()).")
 
-        self._state = _np.array(wavefunction)
+        self._state = _np.array(wavefunction, dtype=_np.complex128)
         self._map = {ordering[i]: i for i in range(len(ordering))}
 
     def collapse_wavefunction(self, ids, values):

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -466,6 +466,18 @@ def test_simulator_set_wavefunction(sim):
     Measure | qubits
 
 
+def test_simulator_set_wavefunction_always_complex(sim):
+    """ Checks that wavefunction is always complex """
+    eng = MainEngine(sim)
+    qubit = eng.allocate_qubit()
+    eng.flush()
+    wf = [1., 0]
+    eng.backend.set_wavefunction(wf, qubit)
+    Y | qubit
+    eng.flush()
+    assert eng.backend.get_amplitude('1', qubit) == pytest.approx(1j)
+
+
 def test_simulator_collapse_wavefunction(sim):
     eng = MainEngine(sim)
     qubits = eng.allocate_qureg(4)


### PR DESCRIPTION
If the user specifies a real valued wavefunction, then the internal state of the simulator is changed to numpy float and hence it ignores the complex parts of gates but it always gave a warning if it did.
* Fixed
* Added a test to check for this bug