### PR TITLE
AutoReplacer checks parent class for replacements

### DIFF
--- a/projectq/cengines/_replacer/_replacer.py
+++ b/projectq/cengines/_replacer/_replacer.py
@@ -133,7 +133,9 @@ class AutoReplacer(BasicEngine):
             # the gate class of the inverse gate. If nothing is found, do the 
             # same for the first parent class, etc.
             gate_mro = type(cmd.gate).mro()[:-1]
-            inverse_mro = type(get_inverse(cmd.gate)).mro()[:-1]
+            # If gate does not have an inverse it's parent classes are 
+            # DaggeredGate, BasicGate, object. Hence don't check the last two
+            inverse_mro = type(get_inverse(cmd.gate)).mro()[:-2]
             rules = self.decompositionRuleSet.decompositions
             for level in range(max(len(gate_mro), len(inverse_mro))):
                 # Check for forward rules

--- a/projectq/cengines/_replacer/_replacer.py
+++ b/projectq/cengines/_replacer/_replacer.py
@@ -128,38 +128,36 @@ class AutoReplacer(BasicEngine):
             # check for decomposition rules
             decomp_list = []
             potential_decomps = []
-            inv_list = []
 
-            # check for forward rules
-            cls = cmd.gate.__class__.__name__
-            try:
-                potential_decomps = [
-                    d for d in self.decompositionRuleSet.decompositions[cls]
-                ]
-            except KeyError:
-                pass
-            # check for rules implementing the inverse gate
-            # and run them in reverse
-            inv_cls = get_inverse(cmd.gate).__class__.__name__
-            try:
-                potential_decomps += [
-                    d.get_inverse_decomposition()
-                    for d in self.decompositionRuleSet.decompositions[inv_cls]
-                ]
-            except KeyError:
-                pass
-            # throw out the ones which don't recognize the command
-            for d in potential_decomps:
-                if d.check(cmd):
-                    decomp_list.append(d)
-
-            # If nothing found so far, check recursively parent classes:
-            if len(decomp_list) == 0:
-                for parent_class in type(cmd.gate).mro()[1:-1]:
-                    name = parent_class.__name__
+            # First check for a decomposition rules of the gate class, then
+            # the gate class of the inverse gate. If nothing is found, do the 
+            # same for the first parent class, etc.
+            gate_mro = type(cmd.gate).mro()[:-1]
+            inverse_mro = type(get_inverse(cmd.gate)).mro()[:-1]
+            rules = self.decompositionRuleSet.decompositions
+            for level in range(max(len(gate_mro), len(inverse_mro))):
+                # Check for forward rules
+                if level < len(gate_mro):
+                    class_name = gate_mro[level].__name__
                     try:
-                        rules = self.decompositionRuleSet.decompositions[name]
-                        potential_decomps = [d for d in rules]
+                        potential_decomps = [d for d in rules[class_name]]
+                    except KeyError:
+                        pass
+                    # throw out the ones which don't recognize the command
+                    for d in potential_decomps:
+                        if d.check(cmd):
+                            decomp_list.append(d)
+                    if len(decomp_list) != 0:
+                        break
+                # Check for rules implementing the inverse gate
+                # and run them in reverse
+                if level < len(inverse_mro):
+                    inv_class_name = inverse_mro[level].__name__
+                    try:
+                        potential_decomps += [
+                            d.get_inverse_decomposition()
+                            for d in rules[inv_class_name]
+                        ]
                     except KeyError:
                         pass
                     # throw out the ones which don't recognize the command

--- a/projectq/cengines/_replacer/_replacer.py
+++ b/projectq/cengines/_replacer/_replacer.py
@@ -151,9 +151,25 @@ class AutoReplacer(BasicEngine):
                 if d.check(cmd):
                     decomp_list.append(d)
 
+            # If nothing found so far, check recursively parent classes:
             if len(decomp_list) == 0:
-                raise NoGateDecompositionError("\nNo replacement found for "
-                                               + str(cmd) + "!")
+                for parent_class in type(cmd.gate).mro()[1:-1]:
+                    name = parent_class.__name__
+                    try:
+                        rules = self.decompositionRuleSet.decompositions[name]
+                        potential_decomps = [d for d in rules]
+                    except KeyError:
+                        pass
+                    # throw out the ones which don't recognize the command
+                    for d in potential_decomps:
+                        if d.check(cmd):
+                            decomp_list.append(d)
+                    if len(decomp_list) != 0:
+                        break
+
+            if len(decomp_list) == 0:
+                raise NoGateDecompositionError("\nNo replacement found for " +
+                                               str(cmd) + "!")
 
             # use decomposition chooser to determine the best decomposition
             chosen_decomp = self._decomp_chooser(cmd, decomp_list)

--- a/projectq/cengines/_replacer/_replacer_test.py
+++ b/projectq/cengines/_replacer/_replacer_test.py
@@ -222,3 +222,5 @@ def test_auto_replacer_searches_parent_class_for_rule():
     qb = eng.allocate_qubit()
     DerivedSomeGate() | qb
     eng.flush()
+    received_gate = backend.received_commands[1].gate
+    assert received_gate == X or received_gate == H


### PR DESCRIPTION
* If `AutoReplacer` doesn't find a decomposition rule for a gate class, it checks if there are decomposition rules for the parent classes which might work
* Important change for rules which only require a gate matrix and hence the rule works for all `BasicGate` instances