### PR TITLE
Decompose multi-controlled gates into single controlled gates

### DIFF
--- a/projectq/setups/decompositions/__init__.py
+++ b/projectq/setups/decompositions/__init__.py
@@ -24,6 +24,7 @@ from . import (crz2cxandrz,
 all_defined_decomposition_rules = [
     rule
     for module in [crz2cxandrz,
+                   cnu2toffoliandcu,
                    entangle,
                    globalphase,
                    ph2r,

--- a/projectq/setups/decompositions/__init__.py
+++ b/projectq/setups/decompositions/__init__.py
@@ -11,6 +11,7 @@
 #   limitations under the License.
 
 from . import (crz2cxandrz,
+               cnu2toffoliandcu,
                entangle,
                globalphase,
                ph2r,

--- a/projectq/setups/decompositions/cnu2toffoliandcu.py
+++ b/projectq/setups/decompositions/cnu2toffoliandcu.py
@@ -1,0 +1,68 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""
+Registers a decomposition rule for multi-controlled gates.
+
+Implements the decomposition of Nielsen and Chuang (Fig. 4.10) which
+decomposes a C^n(U) gate into a sequence of 2 * (n-1) Toffoli gates and one
+C(U) gate by using (n-1) ancilla qubits and circuit depth of 2n-1.
+"""
+
+from projectq.cengines import DecompositionRule
+from projectq.meta import get_control_count, Compute, Control, Uncompute
+from projectq.ops import BasicGate, Toffoli, XGate
+
+
+def _recognize_CnU(cmd):
+    """ 
+    Recognize an arbitrary gate which has n>=2 control qubits, except a
+    Toffoli gate.
+    """
+    if get_control_count(cmd) == 2:
+        if not isinstance(cmd.gate, XGate):
+            return True
+    elif get_control_count(cmd) > 2:
+        return True
+    return False
+
+
+def _decompose_CnU(cmd):
+    """ 
+    Decompose a multi-controlled gate U into a single-controlled U.
+
+    It uses (n-1) work qubits and 2 * (n-1) Toffoli gates.
+    """
+    eng = cmd.engine
+    qubits = cmd.qubits
+    ctrl_qureg = cmd.control_qubits
+    gate = cmd.gate
+    n = get_control_count(cmd)
+    ancilla_qureg = eng.allocate_qureg(n-1)
+
+    with Compute(eng):
+        Toffoli | (ctrl_qureg[0], ctrl_qureg[1], ancilla_qureg[0])
+        for ctrl_index in range(2,n):
+            Toffoli | (ctrl_qureg[ctrl_index], ancilla_qureg[ctrl_index-2],
+                       ancilla_qureg[ctrl_index-1])
+
+    with Control(eng, ancilla_qureg[-1]):
+        gate | qubits
+
+    Uncompute(eng)
+
+
+all_defined_decomposition_rules = [
+    DecompositionRule(BasicGate, _decompose_CnU, _recognize_CnU)
+]

--- a/projectq/setups/decompositions/cnu2toffoliandcu_test.py
+++ b/projectq/setups/decompositions/cnu2toffoliandcu_test.py
@@ -1,0 +1,125 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"Tests for projectq.setups.decompositions.cnu2toffoliandcu."
+
+import pytest
+
+from projectq.backends import Simulator
+from projectq.cengines import (AutoReplacer, DecompositionRuleSet,
+                               DummyEngine, InstructionFilter, MainEngine)
+from projectq.meta import Control
+from projectq.ops import (ClassicalInstructionGate, Measure, Ph, QFT, Rx, Ry,
+                          X, XGate)
+
+from . import cnu2toffoliandcu
+
+
+def test_recognize_correct_gates():
+    saving_backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=saving_backend)
+    qubit = eng.allocate_qubit()
+    ctrl_qureg = eng.allocate_qureg(2)
+    ctrl_qureg2 = eng.allocate_qureg(3)
+    eng.flush()
+    with Control(eng, ctrl_qureg):
+        Ph(0.1) | qubit
+        Ry(0.2) | qubit
+    with Control(eng, ctrl_qureg2):
+        QFT | qubit + ctrl_qureg
+        X | qubit
+    eng.flush()  # To make sure gates arrive before deallocate gates
+    eng.flush(deallocate_qubits=True)
+    # Don't test initial 6 allocate and flush and trailing deallocate
+    # and two flush gates.
+    for cmd in saving_backend.received_commands[7:-8]:
+        assert cnu2toffoliandcu._recognize_CnU(cmd)
+
+
+def test_recognize_incorrect_gates():
+    saving_backend = DummyEngine(save_commands=True)
+    eng = MainEngine(backend=saving_backend)
+    qubit = eng.allocate_qubit()
+    ctrl_qubit = eng.allocate_qubit()
+    ctrl_qureg = eng.allocate_qureg(2)
+    eng.flush()
+    with Control(eng, ctrl_qubit):
+        Rx(0.3) | qubit
+    X | qubit
+    with Control(eng, ctrl_qureg):
+        X | qubit
+    eng.flush(deallocate_qubits=True)
+    for cmd in saving_backend.received_commands:
+        assert not cnu2toffoliandcu._recognize_CnU(cmd)
+
+
+def _decomp_gates(eng, cmd):
+    g = cmd.gate
+    if isinstance(g, ClassicalInstructionGate):
+        return True
+    if len(cmd.control_qubits) <= 1:
+        return True
+    if len(cmd.control_qubits) == 2 and isinstance(cmd.gate, XGate):
+        return True
+    return False
+
+
+def test_decomposition():
+    for basis_state_index in range(0,16):
+        basis_state = [0] * 16
+        basis_state[basis_state_index] = 1.
+        correct_eng = MainEngine(backend=Simulator(), engine_list=[])
+
+        rule_set = DecompositionRuleSet(modules=[cnu2toffoliandcu])
+        test_eng = MainEngine(backend=Simulator(),
+                              engine_list=[AutoReplacer(rule_set),
+                                           InstructionFilter(_decomp_gates)])
+        test_sim = test_eng.backend
+        correct_sim = correct_eng.backend
+        correct_qb = correct_eng.allocate_qubit()
+        correct_ctrl_qureg = correct_eng.allocate_qureg(3)
+        correct_eng.flush()
+        test_qb = test_eng.allocate_qubit()
+        test_ctrl_qureg = test_eng.allocate_qureg(3)
+        test_eng.flush()
+
+        correct_sim.set_wavefunction(basis_state, correct_qb +
+                                     correct_ctrl_qureg)
+        test_sim.set_wavefunction(basis_state, test_qb + test_ctrl_qureg)
+
+        with Control(test_eng, test_ctrl_qureg[:2]):
+            Rx(0.4) | test_qb
+        with Control(test_eng, test_ctrl_qureg):
+            Ry(0.6) | test_qb
+
+        with Control(correct_eng, correct_ctrl_qureg[:2]):
+            Rx(0.4) | correct_qb
+        with Control(correct_eng, correct_ctrl_qureg):
+            Ry(0.6) | correct_qb
+
+        test_eng.flush()
+        correct_eng.flush()
+
+        for fstate in ['0000', '0001', '0010', '0011', '0100', '0101', '0110',
+                       '0111', '1000', '1001', '1010', '1011', '1100', '1101',
+                       '1110', '1111']:
+            test = test_sim.get_amplitude(fstate, test_qb + test_ctrl_qureg)
+            correct = correct_sim.get_amplitude(fstate, correct_qb +
+                                                correct_ctrl_qureg)
+            assert correct == pytest.approx(test, rel=1e-12, abs=1e-12)
+
+        Measure | test_qb + test_ctrl_qureg
+        Measure | correct_qb + correct_ctrl_qureg
+        test_eng.flush(deallocate_qubits=True)
+        correct_eng.flush(deallocate_qubits=True)


### PR DESCRIPTION
* Decomposes multi-controlled gates into single controlled gates
* Uses (n-1) ancilla qubits and 2 * (n-1) Toffoli gates
* Note: We should maybe later separate this rule from the others. It should only be used for hardware, e.g. the IBM setup. There it would make sense to have a first `FilterEngine` which sorts out all gates which have more than 1 control qubit and have an `AutoReplacer` in front of it with this rule (and hopefully soon some more) before an AutoReplacer works on the other rules...

This PR comes after #150 