### PR TITLE
AutoReplacer checks parent class for replacements. Simplify Compute.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
   - pip$PY install -e .
 
 # command to run tests
-script: export OMP_NUM_THREADS=1 && pytest projectq --cov projectq
+script: export OMP_NUM_THREADS=1 && pytest -W error projectq --cov projectq
 
 after_success:
   - coveralls

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ ProjectQ - An open source software framework for quantum computing
 
 ProjectQ is an open source effort for quantum computing.
 
-The first version (v0.1) features a compilation framework capable of
+It features a compilation framework capable of
 targeting various types of hardware, a high-performance quantum computer
 simulator with emulation capabilities, and various compiler plug-ins.
 This allows users to
@@ -29,7 +29,9 @@ This allows users to
 Getting started
 ---------------
 
-To start using ProjectQ, simply follow the installation instructions in the `tutorials <http://projectq.readthedocs.io/en/latest/tutorials.html>`__. There, you will also find OS-specific hints, a small introduction to the ProjectQ syntax, and a few `code examples <http://projectq.readthedocs.io/en/latest/examples.html>`__. Also, make sure to check out the `ProjectQ
+To start using ProjectQ, simply follow the installation instructions in the `tutorials <http://projectq.readthedocs.io/en/latest/tutorials.html>`__. There, you will also find OS-specific hints, a small introduction to the ProjectQ syntax, and a few `code examples <http://projectq.readthedocs.io/en/latest/examples.html>`__. More example codes and tutorials can be found in the examples folder `here <https://github.com/ProjectQ-Framework/ProjectQ/tree/develop/examples>`__ on GitHub.
+
+Also, make sure to check out the `ProjectQ
 website <http://www.projectq.ch>`__ and the detailed `code documentation <http://projectq.readthedocs.io/en/latest/>`__.
 
 How to contribute

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@ ProjectQ - An open source software framework for quantum computing
 .. image:: https://coveralls.io/repos/github/ProjectQ-Framework/ProjectQ/badge.svg
     :target: https://coveralls.io/github/ProjectQ-Framework/ProjectQ
 
+.. image:: https://readthedocs.org/projects/projectq/badge/?version=latest
+    :target: http://projectq.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
 
 ProjectQ is an open source effort for quantum computing.
 
@@ -26,8 +29,8 @@ This allows users to
 Getting started
 ---------------
 
-To start using ProjectQ, simply follow the installation instructions in the `tutorials <http://projectq.ch/docs/tutorials.html>`__. There, you will also find OS-specific hints, a small introduction to the ProjectQ syntax, and a few `code examples <http://projectq.ch/docs/examples.html>`__. Also, make sure to check out the `ProjectQ
-website <http://www.projectq.ch>`__ and the detailed `code documentation <http://projectq.ch/docs/>`__.
+To start using ProjectQ, simply follow the installation instructions in the `tutorials <http://projectq.readthedocs.io/en/latest/tutorials.html>`__. There, you will also find OS-specific hints, a small introduction to the ProjectQ syntax, and a few `code examples <http://projectq.readthedocs.io/en/latest/examples.html>`__. Also, make sure to check out the `ProjectQ
+website <http://www.projectq.ch>`__ and the detailed `code documentation <http://projectq.readthedocs.io/en/latest/>`__.
 
 How to contribute
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,12 @@ ProjectQ - An open source software framework for quantum computing
     :target: http://projectq.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 
+.. image:: https://badge.fury.io/py/projectq.svg
+    :target: https://badge.fury.io/py/projectq
+    
+.. image:: https://img.shields.io/badge/python-2.7%2C%203.3%2C%203.4%2C%203.5%2C%203.6-brightgreen.svg
+
+
 ProjectQ is an open source effort for quantum computing.
 
 It features a compilation framework capable of

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,0 +1,27 @@
+Documentation  
+=============
+
+.. image:: https://readthedocs.org/projects/projectq/badge/?version=latest
+    :target: http://projectq.readthedocs.io/en/latest/?badge=latest
+    :alt: Documentation Status
+
+
+Our detailed code documentation can be found online at `Read the Docs <http://projectq.readthedocs.io/en/latest/>`__ and gets updated automatically. Besides the latest code documentation, there are also previous and offline versions available for download.
+
+Building the docs locally
+-------------------------
+
+Before submitting new code, please make sure that the new or changed docstrings render nicely by building the docs manually. To this end, one has to install sphinx and the Read the Docs theme:
+
+.. code-block:: bash
+
+    python -m pip install sphinx
+    python -m pip install sphinx_rtd_theme
+
+To build the documentation, navigate to this folder and execute:
+
+.. code-block:: bash
+
+    make clean html
+
+Open _build/html/index.html to view the docs.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,9 +17,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -22,6 +22,8 @@ or, alternatively, `clone/download <https://github.com/projectq-framework>`_ thi
 	cd /home/projectq
 	python -m pip install --user .
 
+ProjectQ comes with a high-performance quantum simulator written in C++. Please see the detailed OS specific installation instructions below to make sure that you are installing the fastest version.
+
 .. note::
 	The setup will try to build a C++-Simulator, which is much faster than the Python implementation. If it fails, you may use the `--without-cppsimulator` parameter, i.e., 
 	
@@ -48,6 +50,7 @@ Detailed instructions and OS-specific hints
 -------------------------------------------
 
 **Ubuntu**:
+
 	After having installed the build tools (for g++):
 
 	.. code-block:: bash
@@ -70,21 +73,47 @@ Detailed instructions and OS-specific hints
 
 
 **Windows**:
+
 	It is easiest to install a pre-compiled version of Python, including numpy and many more useful packages. One way to do so is using, e.g., the Python3.5 installers from `python.org <https://www.python.org/downloads>`_ or `ANACONDA <https://www.continuum.io/downloads>`_. Installing ProjectQ right away will succeed for the (slow) Python simulator (i.e., with the `--without-cppsimulator` flag). For a compiled version of the simulator, install the Visual C++ Build Tools and the Microsoft Windows SDK prior to doing a pip install. The built simulator will not support multi-threading due to the limited OpenMP support of msvc.
 
 	Should you want to run multi-threaded simulations, you can install a compiler which supports newer OpenMP versions, such as MinGW GCC and then manually build the C++ simulator with OpenMP enabled.
 
 
 **macOS**:
+
 	These are the steps to install ProjectQ on a new Mac:
 
-	Install XCode:
+	In order to install the fast C++ simulator, we require that your system has a C++ compiler (see option 3 below on how to only install the slower Python simulator via the `--without-cppsimulator` parameter)
+
+	Below you will find two options to install the fast C++ simulator. The first one is the easiest and requires only the standard compiler which Apple distributes with XCode. The second option uses macports to install the simulator with additional support for multi-threading by using OpenMP, which makes it slightly faster. We show how to install the required C++ compiler (clang) which supports OpenMP and additionally, we show how to install a newer python version.
+
+.. note::
+	Depending on your system you might need to use `sudo` for the installation.
+
+1. Installation using XCode and the default python:
+
+	Install XCode by opening a terminal and running the following command:
 
 	.. code-block:: bash
 
 		xcode-select --install
 
-	Next, you need to install Python and pip. One way of doing so is using macports to install Python 3.5 and the corresponding version of pip. Visit `macports.org <https://www.macports.org/install.php>`_ and install the latest version (afterwards open a new terminal). Then, use macports to install Python 3.5 by
+	Next, you will need to install Python and pip. See option 2 for information on how to install a newer python version with macports. Here, we are using the standard python which is preinstalled with macOS. Pip can be installed by:
+
+	.. code-block:: bash
+
+		sudo easy_install pip
+
+	Now, you can install ProjectQ with the C++ simulator using the standard command:
+
+	.. code-block:: bash
+
+		python -m pip install --user projectq
+
+
+2. Installation using macports:
+
+	Either use the standard python and install pip as shown in option 1 or better use macports to install a newer python version, e.g., Python 3.5 and the corresponding pip. Visit `macports.org <https://www.macports.org/install.php>`_ and install the latest version (afterwards open a new terminal). Then, use macports to install Python 3.5 by
 
 	.. code-block:: bash
 
@@ -102,7 +131,7 @@ Detailed instructions and OS-specific hints
 
 		sudo port install py35-pip
 
-	Next, we can install ProjectQ with the high performance simulator written in C++. Therefore, we first need to install a suitable compiler which supports OpenMP and instrinsics. One option is to install clang 3.9 also using macports (note: gcc installed via macports does not work as the gcc compiler claims to support instrinsics, while the assembler of gcc does not support it)
+	Next, we can install ProjectQ with the high performance simulator written in C++. First, we will need to install a suitable compiler with support for **C++11**, OpenMP, and instrinsics. The best option is to install clang 3.9 also using macports (note: gcc installed via macports does not work)
 
 	.. code-block:: bash
 
@@ -114,27 +143,21 @@ Detailed instructions and OS-specific hints
 
 		env CC=clang-mp-3.9 env CXX=clang++-mp-3.9 python3.5 -m pip install --user projectq
 
-	If you don't want to install clang 3.9, you can try and specify your preferred compiler by changing CC and CXX in the above command (the compiler must support **C++11**). 
+3. Installation with only the slow Python simulator:
 
-	Should something go wrong when compiling the C++ simulator extension in one of the above installation procedures, 
-	you can turn off this feature using the ``--without-cppsimulator`` 
-	parameter (note: this only works if one of the above installation methods has been tried and hence 
-	all requirements are now installed), i.e.,
-
-	.. code-block:: bash
-	
-		python3.5 -m pip install --user --global-option=--without-cppsimulator projectq
-
-	While this simulator works fine for small examples, it is suggested to install the high performance simulator written in C++. 
+	While this simulator works fine for small examples, it is suggested to install the high performance simulator written in C++.
 
 	If you just want to install ProjectQ with the (slow) Python simulator and no compiler, then first try to install ProjectQ with the default compiler 
 
 	.. code-block:: bash
 
-		python3.5 -m pip install --user projectq
+		python -m pip install --user projectq
 
-	which most likely will fail and then use the command above using the ``--without-cppsimulator`` 
-	parameter.
+	which most likely will fail. Then, try again with the flag ``--without-cppsimulator``:
+
+	.. code-block:: bash
+
+		python -m pip install --user --global-option=--without-cppsimulator projectq
 
 
 The ProjectQ syntax

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -40,6 +40,9 @@ or, alternatively, `clone/download <https://github.com/projectq-framework>`_ thi
 
 	Please note that the compiler you specify must support **C++11**!
 
+.. note::
+	Please use pip version v6.1.0 or higher as this ensures that dependencies are installed in the `correct order <https://pip.pypa.io/en/stable/reference/pip_install/#installation-order>`_.
+
 
 Detailed instructions and OS-specific hints
 -------------------------------------------

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -45,6 +45,9 @@ ProjectQ comes with a high-performance quantum simulator written in C++. Please 
 .. note::
 	Please use pip version v6.1.0 or higher as this ensures that dependencies are installed in the `correct order <https://pip.pypa.io/en/stable/reference/pip_install/#installation-order>`_.
 
+.. note::
+	ProjectQ should be installed on each computer individually as the C++ simulator compilation creates binaries which are optimized for the specific hardware on which it is being installed (potentially using our AVX version and `-march=native`). Therefore, sharing the same ProjectQ installation across different hardware can cause problems.
+
 
 Detailed instructions and OS-specific hints
 -------------------------------------------

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,0 +1,24 @@
+Examples and Tutorials
+======================
+
+This folder contains a collection of **examples** and **tutorials** for how to use ProjectQ. They offer a great way to get started. While this collection is growing, it will never be possible to cover everything. Therefore, we refer the readers to also have a look at:
+
+* Our complete **code documentation** which can be found online `here <http://projectq.readthedocs.io/en/latest/>`__. Besides the newest version of the documentation it also provides older versions. Moreover, these docs can be downloaded for offline usage.
+
+* Our **unit tests**. More than 99% of all lines of code are covered with various unit tests since the first release. Tests are really important to us. Therefore, if you are wondering how a specific feature can be used, have a look at the **unit tests**, where you can find plenty of examples. Finding the unit tests is very easy: E.g., the tests of the simulator implemented in *ProjectQ/projectq/backends/_sim/_simulator.py* can all be found in the same folder in the file *ProjectQ/projectq/backends/_sim/_simulator_test.py*.
+
+Getting started / background information
+----------------------------------------
+
+It might be a good starting point to have a look at our paper which explains the goals of the ProjectQ framework and also gives a good overview:
+
+* Damian S. Steiger, Thomas Häner, and Matthias Troyer "ProjectQ: An Open Source Software Framework for Quantum Computing" `[arxiv:1612.08091] <https://arxiv.org/abs/1612.08091>`__
+
+Examples and tutorials in this folder
+-------------------------------------
+
+1. Some of the files in this folder are explained in the `documentation <http://projectq.readthedocs.io/en/latest/examples.html>`__.
+
+2. Take a look at the *simulator_tutorial.ipynb* for a detailed introduction to most of the features of our high performance quantum simulator.
+
+3. Running on the IBM QE chip is explained in more details in *ibm_entangle.ipynb*.

--- a/examples/shor.py
+++ b/examples/shor.py
@@ -3,7 +3,11 @@ from __future__ import print_function
 import math
 import random
 import sys
-from fractions import Fraction, gcd
+from fractions import Fraction
+try:
+    from math import gcd
+except ImportError:
+    from fractions import gcd
 
 from builtins import input
 

--- a/examples/simulator_tutorial.ipynb
+++ b/examples/simulator_tutorial.ipynb
@@ -1,0 +1,858 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "# ProjectQ Simulator Tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "The aim of this tutorial is to introduce some of the basic and more advanced features of the ProjectQ simulator. Please note that all the simulator features can be found in our [code documentation](http://projectq.readthedocs.io/en/latest/projectq.backends.html#projectq.backends.Simulator).\n",
+    "\n",
+    "Contents:\n",
+    "\n",
+    "* [Introduction](#Introduction)\n",
+    "* [Installation](#Installation)\n",
+    "* [Basics](#Basics)\n",
+    "* [Advanced features](#Advanced_features)\n",
+    "* [Improving the speed of the ProjectQ simulator](#improve_speed)\n",
+    "\n",
+    "# Introduction <a id=\"Introduction\"></a>\n",
+    "Our simulator can be used to simulate any circuit model quantum algorithm. This requires storing the state, also called wavefunction, of all qubits which requires storing 2<sup>n</sup> complex values (each of size 16 bytes) for an *n*-qubit algorithm. This can get very expensive in terms of required RAM:\n",
+    "\n",
+    "Number of qubits *n*| Required RAM to store wavefunction\n",
+    "------------------- | ----------------------------------\n",
+    "10 | 16 KByte\n",
+    "20 | 16 MByte\n",
+    "30 | 16 GByte\n",
+    "31 | 32 GByte\n",
+    "32 | 64 GByte\n",
+    "40 | 16 TByte\n",
+    "45 | 512 TByte ([world's largest quantum computer simulation](https://arxiv.org/abs/1704.01127))\n",
+    "\n",
+    "The number of qubits you can simulate with the ProjectQ simulator is only limited by the amount of RAM in your notebook or workstation. Applying quantum gates is expensive as we have to potentially update each individual value in the full wavefunction. Therefore, we have implemented a high-performance simulator which is significantly faster than other simulators (see our papers for a detailed comparison [[1]](https://arxiv.org/abs/1612.08091), [[2]](https://arxiv.org/abs/1604.06460)). The performance of such simulators is hardware-dependent and therefore we have decided to provide 4 different versions. A simulator implemented in C++ which uses multi-threading (OpenMP) and instrinsics, a C++ simulator which uses intrinsics, a C++ simulator, and a slower simulator which only uses Python. During the installation we try to install the fastest of these options given your hardware and available compiler.\n",
+    "\n",
+    "Our simulator is simultaneously also a quantum emulator. This concept was first introduced by us in [[2]](https://arxiv.org/abs/1604.06460). A quantum emulator takes classical shortcuts when performing the simulation and hence can be orders of magnitude faster. E.g., for simulating Shor's algorithm, we only require to store the wavefunction of *n+1* qubits while the algorithm on a real quantum computer would require *2n+O(1)* qubits. Using these emulation capabilities, we can easily emulate Shor's algorithm for factoring, e.g., 4028033 = 2003 · 2011 on a notebook [[1]](https://arxiv.org/abs/1612.08091)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "# Installation <a id=\"Installation\"></a>\n",
+    "\n",
+    "Please follow the [installation instructions](http://projectq.readthedocs.io/en/latest/tutorials.html#getting-started) in the docs. The Python interface to all our different simulators (C++ or native Python) is identical. The different versions only differ in performance. If you have a C++ compiler installed on your system, the setup will try to install the faster C++ simulator. To figure out which simulator is installed just execute the following code after installing ProjectQ:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import projectq\n",
+    "eng = projectq.MainEngine() # This loads the simulator as it is the default backend"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "If you now see the following message\n",
+    "```\n",
+    "(Note: This is the (slow) Python simulator.)\n",
+    "```\n",
+    "you are using the slow Python simulator and we would recommend to reinstall ProjectQ with the C++ simulator following the [installation instructions](http://projectq.readthedocs.io/en/latest/tutorials.html#getting-started). If this message doesn't show up, then you are using one of the fast C++ simulator versions. Which one exactly depends on your compiler and hardware."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "# Basics <a id=\"Basics\"></a>\n",
+    "\n",
+    "To write a quantum program, we need to create a compiler called `MainEngine` and provide a backend for which the compiler should compile the quantum program. In this tutorial we are focused on the simulator as a backend. We can create a compiler with a simulator backend by importing the simulator class and creating a simulator instance which is passed to the `MainEngine`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "from projectq.backends import Simulator\n",
+    "eng = projectq.MainEngine(backend=Simulator())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Note that the `MainEngine` contains the simulator as the default backend, hence one can equivalently just do:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "eng = projectq.MainEngine()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "In order to simulate the probabilistic measurement process, the simulator internally requires a random number generator. When creating a simulator instance, one can provide a random seed in order to create reproducible results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "eng = projectq.MainEngine(backend=Simulator(rnd_seed=10))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Let's write a simple test program which allocates a qubit in state |0>, performs a Hadamard gate which puts it into a superposition 1/sqrt(2) * ( |0> + |1>) and then measure the qubit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "import projectq\n",
+    "from projectq.ops import Measure, H\n",
+    "\n",
+    "eng = projectq.MainEngine()\n",
+    "qubit = eng.allocate_qubit() # Allocate a qubit from the compiler (MainEngine object)\n",
+    "H | qubit\n",
+    "Measure | qubit # Measures the qubit in the Z basis and collapses it into either |0> or |1>\n",
+    "eng.flush() # Tells the compiler (MainEninge) compile all above gates and send it to the simulator backend\n",
+    "print(int(qubit)) # The measurement result can be accessed by converting the qubit object to a bool or int\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "This program randomly outputs 0 or 1. Note that the measurement does *not* return for example a probability of measuring 0 or 1 (see below how this could be achieved). The reason for this is that a program written in our high-level syntax should be independent of the backend. In other words, the code can be executed either by our simulator or by exchanging only the MainEngine's backend by a real device which cannot return a probability but only one value. See the other examples on GitHub of how to execute code on the IBM quantum chip.\n",
+    "\n",
+    "### Important note on eng.flush()\n",
+    "Note that we have used eng.flush() which tells the compiler to send all the instructions to the backend. In a simplified version, when the Python interpreter executes a gate (e.g. the above lines with H, or Measure), this gate is sent to the compiler (MainEngine), where it is cached. Compilation and optimization of cached gates happens irregularly, e.g., an optimizer in the compiler might wait for 5 gates before it starts the optimization process. Therefore, if we require the result of a quantum program, we need to call eng.flush() which tells the compiler to compile and send all cached gates to the backend for execution. eng.flush() is therefore necessary when accessing the measurement result by converting the qubit object to an int or bool. Or when using the advanced features below, where we want to access properties of the wavefunction at a specific point in the quantum algorithm.\n",
+    "\n",
+    "The above statement is not entirely correct as for example there is no eng.flush() strictly required before accessing the measurement result. The reason is that the measurement gate in our compiler is not cached but is sent directly to the local simulator backend because it would allow for performance optimizations by shrinking the wavefunction. However, this is not a feature which your code should/can rely on and therefore you should always use eng.flush()."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Important debugging feature of our simulator\n",
+    "\n",
+    "When a qubit goes out of scope, it gets deallocated automatically. If the backend is a simulator, it checks that the qubit was in a classical state and otherwise it raises an exception. This is an important debugging feature as in many quantum algorithms, ancilla qubits are used for intermediate results and then \"uncomputed\" back into state |0>. If such ancilla qubits now go out of scope, the simulator throws an error if they are not in either state |0> or |1>, as this is most likely a bug in the user code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Exception ignored in: <bound method Qubit.__del__ of <projectq.types._qubit.Qubit object at 0x110bcfc88>>\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/types/_qubit.py\", line 127, in __del__\n",
+      "    self.engine.deallocate_qubit(weak_copy)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 151, in deallocate_qubit\n",
+      "    tags=[DirtyQubitTag()] if is_dirty else [])])\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
+      "    self.next_engine.receive(command_list)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_tagremover.py\", line 56, in receive\n",
+      "    self.send([cmd])\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
+      "    self.next_engine.receive(command_list)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 237, in receive\n",
+      "    self._cache_cmd(cmd)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 223, in _cache_cmd\n",
+      "    self._check_and_send()\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 201, in _check_and_send\n",
+      "    self._send_qubit_pipeline(i, len(self._l[i]))\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 80, in _send_qubit_pipeline\n",
+      "    self.send([il[i]])\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
+      "    self.next_engine.receive(command_list)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_replacer/_replacer.py\", line 195, in receive\n",
+      "    self._process_command(cmd)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_replacer/_replacer.py\", line 123, in _process_command\n",
+      "    self.send([cmd])\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
+      "    self.next_engine.receive(command_list)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_tagremover.py\", line 56, in receive\n",
+      "    self.send([cmd])\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
+      "    self.next_engine.receive(command_list)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 237, in receive\n",
+      "    self._cache_cmd(cmd)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 223, in _cache_cmd\n",
+      "    self._check_and_send()\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 201, in _check_and_send\n",
+      "    self._send_qubit_pipeline(i, len(self._l[i]))\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 80, in _send_qubit_pipeline\n",
+      "    self.send([il[i]])\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
+      "    self.next_engine.receive(command_list)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/backends/_sim/_simulator.py\", line 317, in receive\n",
+      "    self._handle(cmd)\n",
+      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/backends/_sim/_simulator.py\", line 275, in _handle\n",
+      "    self._simulator.deallocate_qubit(ID)\n",
+      "RuntimeError: Error: Qubit has not been measured / uncomputed! There is most likely a bug in your code.\n"
+     ]
+    }
+   ],
+   "source": [
+    "def test_program(eng):\n",
+    "    # Do something\n",
+    "    ancilla = eng.allocate_qubit()\n",
+    "    H | ancilla\n",
+    "    # Use the ancilla for something\n",
+    "    # Here the ancilla is not reset to a classical state but still in a superposition and will go out of scope\n",
+    "test_program(eng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "It will create a long error message. At the bottom it says the reason: *Error: Qubit has not been measured / uncomputed! There is most likely a bug in your code.*\n",
+    "\n",
+    "If you are using a qubit as an ancilla which should have been reset, this is a great feature which automatically checks the correctness of the uncomputation if the simulator is used as a backend. Should you wish to deallocate qubits which might be in a superposition, always apply a measurement gate in order to avoid this error message:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "from projectq.ops import All\n",
+    "def test_program_2(eng):\n",
+    "    # Do something\n",
+    "    ancillas = eng.allocate_qureg(3) # allocates a quantum register with 3 qubits\n",
+    "    All(H) | ancillas # applies a Hadamard gate to each of the 3 ancilla qubits\n",
+    "    Measure | ancillas # Measures all ancilla qubits such that we don't get\n",
+    "                            #an error message when they are deallocated\n",
+    "    # Here the ancillas will go out of scope but because of the measurement, they are in a classical state\n",
+    "test_program_2(eng)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "# Advanced features <a id=\"Advanced_features\"></a>\n",
+    "\n",
+    "Here we will show some features which are unique to a simulator backend which has access to the full wavefunction. Note that using these features in your code will prohibit the code to run on a real quantum device. Therefore instead of, e.g., using the feature to ininitialize the wavefunction into a specific state, you could execute a small quantum circuit which prepares the desired state and hence the code can be run on both the simulator and on actual hardware. \n",
+    "\n",
+    "For details on the simulator please see the [code documentation](http://projectq.readthedocs.io/en/latest/projectq.backends.html#projectq.backends.Simulator).\n",
+    "\n",
+    "In order to use the features of the simulator backend, we need to have a reference to access it. This can be achieved by creating a simulator instance and keeping a reference to it before passing it to the MainEngine:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "sim = Simulator(rnd_seed=5) # We can now always access the simulator via the \"sim\" variable\n",
+    "eng = projectq.MainEngine(backend=sim)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Alternatively, one can access the simulator by accessing the backend of the compiler (MainEngine):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "assert id(sim) == id(eng.backend)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Amplitude\n",
+    "One can access the complex amplitude of a specific state as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Amplitude saved in amp_before: (1+0j)\n",
+      "Amplitude saved in amp_after: (0.7071067811865475+0j)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from projectq.ops import H, Measure\n",
+    "\n",
+    "eng = projectq.MainEngine()\n",
+    "qubit = eng.allocate_qubit()\n",
+    "qubit2 = eng.allocate_qubit()\n",
+    "eng.flush() # sends the allocation of the two qubits to the simulator (only needed to showcase the stuff below)\n",
+    "\n",
+    "H | qubit # Put this qubit into a superposition\n",
+    "\n",
+    "# qubit is a list with one qubit, qubit2 is another list with one qubit object\n",
+    "# qubit + qubit2 creates a list containing both qubits. Equivalently, one could write [qubit[0], qubit2[0]]\n",
+    "# get_amplitude requires that one provides a list/qureg of all qubits such that it can determine the order\n",
+    "\n",
+    "amp_before = eng.backend.get_amplitude('00', qubit + qubit2)\n",
+    "\n",
+    "# Amplitude will be 1 as Hadamard gate is not yet executed on the simulator backend\n",
+    "# We forgot the eng.flush()!\n",
+    "print(\"Amplitude saved in amp_before: {}\".format(amp_before))\n",
+    "\n",
+    "eng.flush() # Makes sure that all the gates are sent to the backend and executed\n",
+    "\n",
+    "amp_after = eng.backend.get_amplitude('00', qubit + qubit2)\n",
+    "\n",
+    "# Amplitude will be 1/sqrt(2) as Hadamard gate was executed on the simulator backend\n",
+    "print(\"Amplitude saved in amp_after: {}\".format(amp_after))\n",
+    "\n",
+    "# To avoid triggering the warning of deallocating qubits which are in a superposition\n",
+    "Measure | qubit\n",
+    "Measure | qubit2\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "**NOTE**: One always has to call eng.flush() before accessing the amplitude as otherwise some of the gates might not have been sent and executed on the simulator. Also don't forget in such an example to measure all the qubits in the end in order to avoid the above mentioned debugging error message of deallocating qubits which are not in a classical state."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Probability\n",
+    "\n",
+    "One can access the probability of measuring one or more qubits in a specified state by the following method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Probability to measure 11: 0.0\n",
+      "Probability to measure 00: 0.4999999999999999\n",
+      "Probability to measure 01: 0.0\n",
+      "Probability to measure 10: 0.4999999999999999\n",
+      "Probability that second qubit is in state 0: 0.9999999999999998\n"
+     ]
+    }
+   ],
+   "source": [
+    "import projectq\n",
+    "from projectq.ops import H, Measure, CNOT, All\n",
+    "\n",
+    "eng = projectq.MainEngine()\n",
+    "qureg = eng.allocate_qureg(2)\n",
+    "H | qureg[0]\n",
+    "eng.flush()\n",
+    "\n",
+    "prob11 = eng.backend.get_probability('11', qureg)\n",
+    "prob10 = eng.backend.get_probability('10', qureg)\n",
+    "prob01 = eng.backend.get_probability('01', qureg)\n",
+    "prob00 = eng.backend.get_probability('00', qureg)\n",
+    "prob_second_0 = eng.backend.get_probability('0', [qureg[1]])\n",
+    "\n",
+    "print(\"Probability to measure 11: {}\".format(prob11))\n",
+    "print(\"Probability to measure 00: {}\".format(prob00))\n",
+    "print(\"Probability to measure 01: {}\".format(prob01))\n",
+    "print(\"Probability to measure 10: {}\".format(prob10))\n",
+    "print(\"Probability that second qubit is in state 0: {}\".format(prob_second_0))\n",
+    "\n",
+    "Measure | qureg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Expectation value\n",
+    "\n",
+    "We can use the QubitOperator objects to build a Hamiltonian and access the expectation value of this Hamiltonian:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Expectation value = <Psi|Z0|Psi> = -0.9999999999999998\n",
+      "Expectation value = <Psi|-0.5 X1 + 1.0 Z0 X1|Psi> = -1.4999999999999996\n"
+     ]
+    }
+   ],
+   "source": [
+    "import projectq\n",
+    "from projectq.ops import H, Measure, CNOT, All, QubitOperator, X, Y\n",
+    "\n",
+    "eng = projectq.MainEngine()\n",
+    "qureg = eng.allocate_qureg(3)\n",
+    "X | qureg[0]\n",
+    "H | qureg[1]\n",
+    "eng.flush()\n",
+    "op0 = QubitOperator('Z0') # Z applied to qureg[0] tensor identity on qureg[1], qureg[2]\n",
+    "expectation = eng.backend.get_expectation_value(op0, qureg)\n",
+    "print(\"Expectation value = <Psi|Z0|Psi> = {}\".format(expectation))\n",
+    "\n",
+    "op_sum = QubitOperator('Z0 X1') - 0.5 * QubitOperator('X1')\n",
+    "expectation2 = eng.backend.get_expectation_value(op_sum, qureg)\n",
+    "print(\"Expectation value = <Psi|-0.5 X1 + 1.0 Z0 X1|Psi> = {}\".format(expectation2))\n",
+    "\n",
+    "Measure | qureg # To avoid error message of deallocating qubits in a superposition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Collapse Wavefunction (Post select measurement outcome)\n",
+    "\n",
+    "For debugging purposes, one might want to check the algorithm for cases where an intermediate measurement outcome was, e.g., 1. Instead of running many simulations and post selecting only those with the desired intermediate measurement outcome, our simulator allows to force a specific measurement outcome. Note that this is only possible if the desired state has non-zero amplitude, otherwise the simulator will throw an error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "First qubit measured in state: 1 and second qubit in state: 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "import projectq\n",
+    "from projectq.ops import H, Measure\n",
+    "\n",
+    "eng = projectq.MainEngine()\n",
+    "qureg = eng.allocate_qureg(2)\n",
+    "\n",
+    "# Create an entangled state:\n",
+    "H | qureg[0]\n",
+    "CNOT | (qureg[0], qureg[1])\n",
+    "# qureg is now in state 1/sqrt(2) * (|00> + |11>)\n",
+    "Measure | qureg[0]\n",
+    "Measure | qureg[1]\n",
+    "eng.flush() # required such that all above gates are executed before accessing the measurement result\n",
+    "\n",
+    "print(\"First qubit measured in state: {} and second qubit in state: {}\".format(int(qureg[0]), int(qureg[1])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Running the above circuit will either produce both qubits in state 0 or both qubits in state 1. Suppose I want to check the outcome if the first qubit was measured in state 0. This can be achieve by telling the simulator backend to collapse the wavefunction for the first qubit to be in state 0:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "After forcing a measurement outcome of the first qubit to be 0, \n",
+      "the second qubit is in state 0 with probability: 1.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "import projectq\n",
+    "from projectq.ops import H, CNOT\n",
+    "\n",
+    "eng = projectq.MainEngine()\n",
+    "qureg = eng.allocate_qureg(2)\n",
+    "\n",
+    "# Create an entangled state:\n",
+    "H | qureg[0]\n",
+    "CNOT | (qureg[0], qureg[1])\n",
+    "# qureg is now in state 1/sqrt(2) * (|00> + |11>)\n",
+    "eng.flush() # required such that all above gates are executed before collapsing the wavefunction\n",
+    "\n",
+    "# We want to check what happens to the second qubit if the first qubit (qureg[0]) is measured to be 0\n",
+    "eng.backend.collapse_wavefunction([qureg[0]], [0])\n",
+    "\n",
+    "# Check the probability that the second qubit is measured to be 0:\n",
+    "prob_0 = eng.backend.get_probability('0', [qureg[1]])\n",
+    "\n",
+    "print(\"After forcing a measurement outcome of the first qubit to be 0, \\n\"\n",
+    "      \"the second qubit is in state 0 with probability: {}\".format(prob_0))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Set wavefunction to a specific state\n",
+    "\n",
+    "It is possible to set the state of the simulator to any arbitrary wavefunction. In a first step one needs to allocate all the required qubits (don't forget to call `eng.flush()`), and then one can use this method to set the wavefunction. Note that this only works if the provided wavefunction is the wavefunction of all allocated qubits. In addition, the wavefunction needs to be normalized. Here is an example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "import projectq\n",
+    "from projectq.ops import H\n",
+    "\n",
+    "eng = projectq.MainEngine()\n",
+    "qureg = eng.allocate_qureg(2)\n",
+    "eng.flush()\n",
+    "\n",
+    "eng.backend.set_wavefunction([1/math.sqrt(2), 1/math.sqrt(2), 0, 0], qureg)\n",
+    "\n",
+    "H | qureg[0]\n",
+    "# At this point both qubits are back in the state 00 and hence there will be no exception thrown\n",
+    "# when the qureg is deallocated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Cheat / Accessing the wavefunction\n",
+    "\n",
+    "Cheat is the original method to access and manipulate the full wavefunction. Calling cheat with the C++ simulator returns a copy of the full wavefunction plus the mapping of which qubit is at which bit position. The Python simulator returns a reference. If possible we are planning to change the C++ simulator to also return a reference which currently is not possible due to the python export. Please keep this difference in mind when writing code. If you require a copy, it is safest to make a copy of the objects returned by the `cheat` method.\n",
+    "\n",
+    "When qubits are allocated in the code, each of the qubits gets a unique integer id. This id is important in order to understand the wavefunction returned by `cheat`. The wavefunction is a numpy array of length 2<sup>n</sup>, where n is the number of qubits. Which bitlocation a specific qubit in the wavefunction has is not predefined (e.g. by the order of qubit allocation) but is rather chosen depending on the compiler optimizations and the simulator. Therefore, `cheat` also returns a dictionary containing the mapping of qubit id to bit location in the wavefunction. Here is a small example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The full wavefunction is: [(0.9751703272018158+0j), -0.09784339500725571j, -0.19767681165408385j, (-0.019833838076209875+0j)]\n",
+      "qubit1 has bit-location 0\n",
+      "qubit2 has bit-location 1\n",
+      "Amplitude of state qubit1 in state 0 and qubit2 in state 1: -0.19767681165408385j\n",
+      "Accessing same amplitude but using get_amplitude instead: -0.19767681165408385j\n"
+     ]
+    }
+   ],
+   "source": [
+    "import copy\n",
+    "import projectq\n",
+    "from projectq.ops import Rx, Measure, All\n",
+    "\n",
+    "eng = projectq.MainEngine()\n",
+    "qubit1 = eng.allocate_qubit()\n",
+    "qubit2 = eng.allocate_qubit()\n",
+    "Rx(0.2) | qubit1\n",
+    "Rx(0.4) | qubit2\n",
+    "eng.flush() # In order to have all the above gates sent to the simulator and executed\n",
+    "\n",
+    "# We save a copy of the wavefunction at this point in the algorithm. In order to make sure we get a copy\n",
+    "# also if the Python simulator is used, one should make a deepcopy:\n",
+    "mapping, wavefunction = copy.deepcopy(eng.backend.cheat())\n",
+    "\n",
+    "print(\"The full wavefunction is: {}\".format(wavefunction))\n",
+    "# Note: qubit1 is a qureg of length 1, i.e. a list containing one qubit objects, therefore the\n",
+    "#       unique qubit id can be accessed via qubit1[0].id\n",
+    "print(\"qubit1 has bit-location {}\".format(mapping[qubit1[0].id]))\n",
+    "print(\"qubit2 has bit-location {}\".format(mapping[qubit2[0].id]))\n",
+    "\n",
+    "# Suppose we want to know the amplitude of the qubit1 in state 0 and qubit2 in state 1:\n",
+    "state = 0 + (1 << mapping[qubit2[0].id])\n",
+    "print(\"Amplitude of state qubit1 in state 0 and qubit2 in state 1: {}\".format(wavefunction[state]))\n",
+    "# If one only wants to access one (or a few) amplitudes, get_amplitude provides an easier interface:\n",
+    "amplitude  = eng.backend.get_amplitude('01', qubit1 + qubit2)\n",
+    "print(\"Accessing same amplitude but using get_amplitude instead: {}\".format(amplitude))\n",
+    "\n",
+    "Measure | qubit1 + qubit2 # In order to not deallocate a qubit in a superposition state"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "# Improving the speed of the ProjectQ simulator <a id=\"improve_speed\"></a>\n",
+    "\n",
+    " * Please check the [installation instructions](http://projectq.readthedocs.io/en/latest/tutorials.html#getting-started) in order to install the fastest C++ simulator which uses instrinsics and multi-threading.\n",
+    " * For simulations with very few qubits, the speed is not limited by the simulator but rather by the compiler. If the compiler engines are not needed, e.g., if only native gates of the simulator are executed, then one can remove the compiler engines and obtain a speed-up:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import projectq\n",
+    "from projectq.backends import Simulator\n",
+    "eng = projectq.MainEngine(backend=Simulator(), engine_list=[]) # Removes the default compiler engines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "* As noted in the [code documentation](http://projectq.readthedocs.io/en/latest/projectq.backends.html#projectq.backends.Simulator), one can play around with the number of threads in order to increase the simulation speed. Execute the following statements in the terminal before running ProjectQ:\n",
+    "```\n",
+    "export OMP_NUM_THREADS=2\n",
+    "export OMP_PROC_BIND=spread\n",
+    "```\n",
+    "A good setting is to set the number of threads to the number of physical cores on your system.\n",
+    "\n",
+    "* The simulator has a feature called \"gate fusion\" in which case it combines smaller gates into larger ones in order to increase the speed of the simulation. If the simulator is faster with or without gate fusion depends on many parameters. By default it is currently turned off but one can turn it on and compare by:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import projectq\n",
+    "from projectq.backends import Simulator\n",
+    "eng = projectq.MainEngine(backend=Simulator(gate_fusion=True)) # Enables gate fusion"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "We'd like to refer interested readers to our paper on the [world's largest and fastest quantum computer simulation](https://arxiv.org/abs/1704.01127) for more details on how to optimize the speed of a quantum simulator."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/projectq/__init__.py
+++ b/projectq/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/_version.py
+++ b/projectq/_version.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/_version.py
+++ b/projectq/_version.py
@@ -11,4 +11,4 @@
 #   limitations under the License.
 
 """Define version number here and read it from setup.py automatically"""
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/projectq/_version.py
+++ b/projectq/_version.py
@@ -11,4 +11,4 @@
 #   limitations under the License.
 
 """Define version number here and read it from setup.py automatically"""
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/projectq/_version.py
+++ b/projectq/_version.py
@@ -11,4 +11,4 @@
 #   limitations under the License.
 
 """Define version number here and read it from setup.py automatically"""
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/projectq/backends/__init__.py
+++ b/projectq/backends/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_circuits/__init__.py
+++ b/projectq/backends/_circuits/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_circuits/_drawer.py
+++ b/projectq/backends/_circuits/_drawer.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_circuits/_drawer_test.py
+++ b/projectq/backends/_circuits/_drawer_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_circuits/_drawer_test.py
+++ b/projectq/backends/_circuits/_drawer_test.py
@@ -94,9 +94,9 @@ def test_drawer_qubitmapping():
     # invalid mapping should raise an error:
     invalid_mappings = [{3: 1, 0: 2}, {0: 1, 2: 1}]
     for invalid_mapping in invalid_mappings:
+        drawer = CircuitDrawer()
         with pytest.raises(RuntimeError):
             drawer.set_qubit_locations(invalid_mapping)
-            drawer = CircuitDrawer()
 
     eng = MainEngine(drawer, [])
     qubit = eng.allocate_qubit()

--- a/projectq/backends/_circuits/_to_latex.py
+++ b/projectq/backends/_circuits/_to_latex.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_circuits/_to_latex_test.py
+++ b/projectq/backends/_circuits/_to_latex_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_ibm/__init__.py
+++ b/projectq/backends/_ibm/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_ibm/_ibm.py
+++ b/projectq/backends/_ibm/_ibm.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_ibm/_ibm_http_client.py
+++ b/projectq/backends/_ibm/_ibm_http_client.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_ibm/_ibm_http_client_test.py
+++ b/projectq/backends/_ibm/_ibm_http_client_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_ibm/_ibm_test.py
+++ b/projectq/backends/_ibm/_ibm_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_printer.py
+++ b/projectq/backends/_printer.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_printer_test.py
+++ b/projectq/backends/_printer_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_resource.py
+++ b/projectq/backends/_resource.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_resource_test.py
+++ b/projectq/backends/_resource_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_sim/__init__.py
+++ b/projectq/backends/_sim/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_sim/_classical_simulator.py
+++ b/projectq/backends/_sim/_classical_simulator.py
@@ -27,7 +27,7 @@ class ClassicalSimulator(BasicEngine):
     """
     A simple introspective simulator that only permits classical operations.
 
-    Allows allocation, deallocation, measuring (no-pop), flushing (no-op),
+    Allows allocation, deallocation, measuring (no-op), flushing (no-op),
     controls, NOTs, and any BasicMathGate. Supports reading/writing directly
     from/to bits and registers of bits.
     """

--- a/projectq/backends/_sim/_classical_simulator.py
+++ b/projectq/backends/_sim/_classical_simulator.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_sim/_classical_simulator_test.py
+++ b/projectq/backends/_sim/_classical_simulator_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_sim/_classical_simulator_test.py
+++ b/projectq/backends/_sim/_classical_simulator_test.py
@@ -10,8 +10,12 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import pytest
+
 from projectq import MainEngine
-from projectq.ops import X, C, BasicMathGate
+from projectq.ops import (X, NOT, C, BasicMathGate, Measure, FlushGate,
+                          Allocate, Deallocate, Command, Y)
+from projectq.cengines import AutoReplacer, DecompositionRuleSet, DummyEngine
 from ._classical_simulator import ClassicalSimulator
 
 
@@ -103,3 +107,42 @@ def test_simulator_arithmetic():
     Sub() | (a, b)
     assert sim.read_register(a) == 11
     assert sim.read_register(b) == 24
+
+
+def test_write_register_value_error_exception():
+    sim = ClassicalSimulator()
+    eng = MainEngine(sim, [])
+    a = eng.allocate_qureg(3)
+    with pytest.raises(ValueError):
+        sim.write_register(a, -2)
+    sim.write_register(a, 7)
+    with pytest.raises(ValueError):
+        sim.write_register(a, 8)
+
+
+def test_available_gates():
+    sim = ClassicalSimulator()
+    eng = MainEngine(sim, [AutoReplacer(DecompositionRuleSet())])
+    a = eng.allocate_qubit()
+    X | a
+    NOT | a
+    Measure | a
+    eng.flush()
+
+
+def test_gates_are_forwarded_to_next_engine():
+    sim = ClassicalSimulator()
+    saving_eng = DummyEngine(save_commands=True)
+    eng = MainEngine(saving_eng, [sim])
+    a = eng.allocate_qubit()
+    X | a
+    a[0].__del__()
+    assert len(saving_eng.received_commands) == 3
+
+
+def test_wrong_gate():
+    sim = ClassicalSimulator()
+    eng = MainEngine(sim, [])
+    a = eng.allocate_qubit()
+    with pytest.raises(ValueError):
+        Y | a

--- a/projectq/backends/_sim/_cppkernels/fusion.hpp
+++ b/projectq/backends/_sim/_cppkernels/fusion.hpp
@@ -1,3 +1,5 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/projectq/backends/_sim/_cppkernels/intrin/cintrin.hpp
+++ b/projectq/backends/_sim/_cppkernels/intrin/cintrin.hpp
@@ -1,3 +1,5 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/projectq/backends/_sim/_cppkernels/intrin/kernel1.hpp
+++ b/projectq/backends/_sim/_cppkernels/intrin/kernel1.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, M const& m, M const& mt)
 {

--- a/projectq/backends/_sim/_cppkernels/intrin/kernel2.hpp
+++ b/projectq/backends/_sim/_cppkernels/intrin/kernel2.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, std::size_t d1, M const& m, M const& mt)
 {

--- a/projectq/backends/_sim/_cppkernels/intrin/kernel3.hpp
+++ b/projectq/backends/_sim/_cppkernels/intrin/kernel3.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, std::size_t d1, std::size_t d2, M const& m, M const& mt)
 {

--- a/projectq/backends/_sim/_cppkernels/intrin/kernel4.hpp
+++ b/projectq/backends/_sim/_cppkernels/intrin/kernel4.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, std::size_t d1, std::size_t d2, std::size_t d3, M const& m, M const& mt)
 {

--- a/projectq/backends/_sim/_cppkernels/intrin/kernel5.hpp
+++ b/projectq/backends/_sim/_cppkernels/intrin/kernel5.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, std::size_t d1, std::size_t d2, std::size_t d3, std::size_t d4, M const& m, M const& mt)
 {

--- a/projectq/backends/_sim/_cppkernels/intrin/kernels.hpp
+++ b/projectq/backends/_sim/_cppkernels/intrin/kernels.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <cmath>
 #include <cstdlib>
 #include <vector>

--- a/projectq/backends/_sim/_cppkernels/nointrin/kernel1.hpp
+++ b/projectq/backends/_sim/_cppkernels/nointrin/kernel1.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, M const& m)
 {

--- a/projectq/backends/_sim/_cppkernels/nointrin/kernel2.hpp
+++ b/projectq/backends/_sim/_cppkernels/nointrin/kernel2.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, std::size_t d1, M const& m)
 {

--- a/projectq/backends/_sim/_cppkernels/nointrin/kernel3.hpp
+++ b/projectq/backends/_sim/_cppkernels/nointrin/kernel3.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, std::size_t d1, std::size_t d2, M const& m)
 {

--- a/projectq/backends/_sim/_cppkernels/nointrin/kernel4.hpp
+++ b/projectq/backends/_sim/_cppkernels/nointrin/kernel4.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, std::size_t d1, std::size_t d2, std::size_t d3, M const& m)
 {

--- a/projectq/backends/_sim/_cppkernels/nointrin/kernel5.hpp
+++ b/projectq/backends/_sim/_cppkernels/nointrin/kernel5.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 template <class V, class M>
 inline void kernel_core(V &psi, std::size_t I, std::size_t d0, std::size_t d1, std::size_t d2, std::size_t d3, std::size_t d4, M const& m)
 {

--- a/projectq/backends/_sim/_cppkernels/nointrin/kernels.hpp
+++ b/projectq/backends/_sim/_cppkernels/nointrin/kernels.hpp
@@ -1,3 +1,17 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <cmath>
 #include <cstdlib>
 #include <vector>

--- a/projectq/backends/_sim/_cppkernels/simulator.hpp
+++ b/projectq/backends/_sim/_cppkernels/simulator.hpp
@@ -41,6 +41,7 @@ public:
     using RndEngine = std::mt19937;
     using Term = std::vector<std::pair<unsigned, char>>;
     using TermsDict = std::vector<std::pair<Term, calc_type>>;
+    using ComplexTermsDict = std::vector<std::pair<Term, complex_type>>;
 
     Simulator(unsigned seed = 1) : N_(0), vec_(1,0.), fusion_qubits_min_(4),
                                    fusion_qubits_max_(5), rnd_eng_(seed) {
@@ -203,7 +204,6 @@ public:
         }
         else
             fused_gates_ = fused_gates;
-        //run();
     }
 
     template <class F, class QuReg>
@@ -265,7 +265,7 @@ public:
         return expectation;
     }
 
-    void apply_qubit_operator(TermsDict const& td, std::vector<unsigned> const& ids){
+    void apply_qubit_operator(ComplexTermsDict const& td, std::vector<unsigned> const& ids){
         run();
         auto new_state = StateVector(vec_.size(), 0.);
         auto current_state = vec_;

--- a/projectq/backends/_sim/_cppkernels/simulator.hpp
+++ b/projectq/backends/_sim/_cppkernels/simulator.hpp
@@ -1,3 +1,5 @@
+// Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/projectq/backends/_sim/_cppkernels/simulator.hpp
+++ b/projectq/backends/_sim/_cppkernels/simulator.hpp
@@ -265,6 +265,22 @@ public:
         return expectation;
     }
 
+    void apply_qubit_operator(TermsDict const& td, std::vector<unsigned> const& ids){
+        run();
+        auto new_state = StateVector(vec_.size(), 0.);
+        auto current_state = vec_;
+        for (auto const& term : td){
+            auto const& coefficient = term.second;
+            apply_term(term.first, ids, {});
+            #pragma omp parallel for schedule(static)
+            for (std::size_t i = 0; i < vec_.size(); ++i){
+                new_state[i] += coefficient * vec_[i];
+                vec_[i] = current_state[i];
+            }
+        }
+        vec_ = std::move(new_state);
+    }
+
     calc_type get_probability(std::vector<bool> const& bit_string,
                               std::vector<unsigned> const& ids){
         run();

--- a/projectq/backends/_sim/_cppsim.cpp
+++ b/projectq/backends/_sim/_cppsim.cpp
@@ -52,6 +52,8 @@ PYBIND11_PLUGIN(_cppsim) {
         .def("emulate_math", &emulate_math_wrapper<QuRegs>)
         .def("get_expectation_value", &Simulator::get_expectation_value)
         .def("emulate_time_evolution", &Simulator::emulate_time_evolution)
+        .def("get_probability", &Simulator::get_probability)
+        .def("get_amplitude", &Simulator::get_amplitude)
         .def("run", &Simulator::run)
         .def("cheat", &Simulator::cheat)
         ;

--- a/projectq/backends/_sim/_cppsim.cpp
+++ b/projectq/backends/_sim/_cppsim.cpp
@@ -55,6 +55,7 @@ PYBIND11_PLUGIN(_cppsim) {
         .def("get_probability", &Simulator::get_probability)
         .def("get_amplitude", &Simulator::get_amplitude)
         .def("set_wavefunction", &Simulator::set_wavefunction)
+        .def("collapse_wavefunction", &Simulator::collapse_wavefunction)
         .def("run", &Simulator::run)
         .def("cheat", &Simulator::cheat)
         ;

--- a/projectq/backends/_sim/_cppsim.cpp
+++ b/projectq/backends/_sim/_cppsim.cpp
@@ -54,6 +54,7 @@ PYBIND11_PLUGIN(_cppsim) {
         .def("emulate_time_evolution", &Simulator::emulate_time_evolution)
         .def("get_probability", &Simulator::get_probability)
         .def("get_amplitude", &Simulator::get_amplitude)
+        .def("set_wavefunction", &Simulator::set_wavefunction)
         .def("run", &Simulator::run)
         .def("cheat", &Simulator::cheat)
         ;

--- a/projectq/backends/_sim/_cppsim.cpp
+++ b/projectq/backends/_sim/_cppsim.cpp
@@ -51,6 +51,7 @@ PYBIND11_PLUGIN(_cppsim) {
         .def("apply_controlled_gate", &Simulator::apply_controlled_gate<MatrixType>)
         .def("emulate_math", &emulate_math_wrapper<QuRegs>)
         .def("get_expectation_value", &Simulator::get_expectation_value)
+        .def("apply_qubit_operator", &Simulator::apply_qubit_operator)
         .def("emulate_time_evolution", &Simulator::emulate_time_evolution)
         .def("get_probability", &Simulator::get_probability)
         .def("get_amplitude", &Simulator::get_amplitude)

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -469,7 +469,7 @@ class Simulator(object):
                                " Please make sure all qubits have been "
                                "allocated previously (call eng.flush()).")
 
-        self._state = _np.array(wavefunction)
+        self._state = _np.array(wavefunction, dtype=_np.complex128)
         self._map = {ordering[i]: i for i in range(len(ordering))}
 
     def collapse_wavefunction(self, ids, values):

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -248,6 +248,23 @@ class Simulator(object):
             self._state = _np.copy(current_state)
         return expectation
 
+    def apply_qubit_operator(self, terms_dict, ids):
+        """
+        Apply a (possibly non-unitary) qubit operator to qubits.
+
+        Args:
+            terms_dict (dict): Operator dictionary (see QubitOperator.terms)
+            ids (list[int]): List of qubit ids upon which the operator acts.
+        """
+        new_state = _np.zeros_like(self._state)
+        current_state = _np.copy(self._state)
+        for (term, coefficient) in terms_dict:
+            self._apply_term(term, ids)
+            self._state *= coefficient
+            new_state += self._state
+            self._state = _np.copy(current_state)
+        self._state = new_state
+
     def get_probability(self, bit_string, ids):
         """
         Return the probability of the outcome `bit_string` when measuring

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -384,6 +384,28 @@ class Simulator(object):
                         self._state[id2],
                         m)
 
+    def set_wavefunction(self, wavefunction, ordering):
+        """
+        Set wavefunction and qubit ordering.
+
+        Args:
+            wavefunction (list[complex]): Array of complex amplitudes
+                describing the wavefunction (must be normalized).
+            ordering (list): List of ids describing the new ordering of qubits
+                (i.e., the ordering of the provided wavefunction).
+        """
+        # wavefunction contains 2^n values for n qubits
+        assert len(wavefunction) == (1 << len(ordering))
+        # all qubits must have been allocated before
+        if (not all([Id in self._map for Id in ordering])
+                or len(self._map) != len(ordering)):
+            raise RuntimeError("set_wavefunction(): Invalid mapping provided."
+                               " Please make sure all qubits have been "
+                               "allocated previously (call eng.flush()).")
+
+        self._state = _np.array(wavefunction)
+        self._map = {ordering[i]: i for i in range(len(ordering))}
+
     def run(self):
         """
         Dummy function to implement the same interface as the c++ simulator.

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -372,27 +372,41 @@ class Simulator(object):
 
     def apply_controlled_gate(self, m, ids, ctrlids):
         """
-        Applies the single qubit gate matrix m to the qubit with index ids[0],
+        Applies the k-qubit gate matrix m to the qubits with indices ids,
         using ctrlids as control qubits.
 
         Args:
-            m (list<list>): 2x2 complex matrix describing the single-qubit
+            m (list[list]): 2^k x 2^k complex matrix describing the k-qubit
                 gate.
-            ids (list): A list containing the qubit ID to which to apply the
+            ids (list): A list containing the qubit IDs to which to apply the
                 gate.
             ctrlids (list): A list of control qubit IDs (i.e., the gate is
                 only applied where these qubits are 1).
         """
-        ID = ids[0]
-        pos = self._map[ID]
-
         mask = self._get_control_mask(ctrlids)
+        if len(m) == 2:
+            pos = self._map[ids[0]]
+            self._single_qubit_gate(m, pos, mask)
+        else:
+            pos = [self._map[ID] for ID in ids]
+            self._multi_qubit_gate(m, pos, mask)
 
+    def _single_qubit_gate(self, m, pos, mask):
+        """
+        Applies the single qubit gate matrix m to the qubit at position `pos`
+        using `mask` to identify control qubits.
+
+        Args:
+            m (list[list]): 2x2 complex matrix describing the single-qubit
+                gate.
+            pos (int): Bit-position of the qubit.
+            mask (int): Bit-mask where set bits indicate control qubits.
+        """
         def kernel(u, d, m):
             return u * m[0][0] + d * m[0][1], u * m[1][0] + d * m[1][1]
 
         for i in range(0, len(self._state), (1 << (pos + 1))):
-            for j in range(0, 1 << pos):
+            for j in range(1 << pos):
                 if ((i + j) & mask) == mask:
                     id1 = i + j
                     id2 = id1 + (1 << pos)
@@ -400,6 +414,41 @@ class Simulator(object):
                         self._state[id1],
                         self._state[id2],
                         m)
+
+    def _multi_qubit_gate(self, m, pos, mask):
+        """
+        Applies the k-qubit gate matrix m to the qubits at `pos`
+        using `mask` to identify control qubits.
+
+        Args:
+            m (list[list]): 2^k x 2^k complex matrix describing the k-qubit
+                gate.
+            pos (list[int]): List of bit-positions of the qubits.
+            mask (int): Bit-mask where set bits indicate control qubits.
+        """
+        # follows the description in https://arxiv.org/abs/1704.01127
+        inactive = [p for p in range(len(self._map)) if p not in pos]
+
+        matrix = _np.matrix(m)
+        subvec = _np.zeros(1 << len(pos), dtype=complex)
+        subvec_idx = [0] * len(subvec)
+        for c in range(1 << len(inactive)):
+            # determine base index (state of inactive qubits)
+            base = 0
+            for i in range(len(inactive)):
+                base |= ((c >> i) & 1) << inactive[i]
+            # check the control mask
+            if mask != (base & mask):
+                continue
+            # now gather all elements involved in mat-vec mul
+            for x in range(len(subvec_idx)):
+                offset = 0
+                for i in range(len(pos)):
+                    offset |= ((x >> i) & 1) << pos[i]
+                subvec_idx[x] = base | offset
+                subvec[x] = self._state[subvec_idx[x]]
+            # perform mat-vec mul
+            self._state[subvec_idx] = matrix.dot(subvec)
 
     def set_wavefunction(self, wavefunction, ordering):
         """

--- a/projectq/backends/_sim/_pysim.py
+++ b/projectq/backends/_sim/_pysim.py
@@ -248,6 +248,65 @@ class Simulator(object):
             self._state = _np.copy(current_state)
         return expectation
 
+    def get_probability(self, bit_string, ids):
+        """
+        Return the probability of the outcome `bit_string` when measuring
+        the qubits given by the list of ids.
+
+        Args:
+            bit_string (list[bool|int]): Measurement outcome.
+            ids (list[int]): List of qubit ids determining the ordering.
+
+        Returns:
+            Probability of measuring the provided bit string.
+
+        Raises:
+            RuntimeError if an unknown qubit id was provided.
+        """
+        for i in range(len(ids)):
+            if ids[i] not in self._map:
+                raise RuntimeError("get_probability(): Unknown qubit id. "
+                                   "Please make sure you have called "
+                                   "eng.flush().")
+        mask = 0
+        bit_str = 0
+        for i in range(len(ids)):
+            mask |= (1 << self._map[ids[i]])
+            bit_str |= (bit_string[i] << self._map[ids[i]])
+        probability = 0.
+        for i in range(len(self._state)):
+            if (i & mask) == bit_str:
+                e = self._state[i]
+                probability += e.real**2 + e.imag**2
+        return probability
+
+    def get_amplitude(self, bit_string, ids):
+        """
+        Return the probability amplitude of the supplied `bit_string`.
+        The ordering is given by the list of qubit ids.
+
+        Args:
+            bit_string (list[bool|int]): Computational basis state
+            ids (list[int]): List of qubit ids determining the
+                ordering. Must contain all allocated qubits.
+
+        Returns:
+            Probability amplitude of the provided bit string.
+
+        Raises:
+            RuntimeError if the second argument is not a permutation of all
+            allocated qubits.
+        """
+        if not set(ids) == set(self._map):
+            raise RuntimeError("The second argument to get_amplitude() must"
+                               " be a permutation of all allocated qubits. "
+                               "Please make sure you have called "
+                               "eng.flush().")
+        index = 0
+        for i in range(len(ids)):
+            index |= (bit_string[i] << self._map[ids[i]])
+        return self._state[index]
+
     def emulate_time_evolution(self, terms_dict, time, ids, ctrlids):
         """
         Applies exp(-i*time*H) to the wave function, i.e., evolves under

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -87,7 +87,7 @@ class Simulator(BasicEngine):
         """
         Specialized implementation of is_available: The simulator can deal
         with all arbitrarily-controlled single-qubit gates which provide a
-        gate-matrix (via gate.get_matrix()).
+        gate-matrix (via gate.matrix).
 
         Args:
             cmd (Command): Command for which to check availability (single-

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -120,6 +120,11 @@ class Simulator(BasicEngine):
 
         Returns:
             Expectation value
+
+        Note:
+            Make sure all previous commands (especially allocations) have
+            passed through the compilation chain (call main_engine.flush() to
+            make sure).
         """
         operator = [(list(term), coeff) for (term, coeff)
                     in qubit_operator.terms.items()]
@@ -137,6 +142,11 @@ class Simulator(BasicEngine):
 
         Returns:
             Probability of measuring the provided bit string.
+
+        Note:
+            Make sure all previous commands (especially allocations) have
+            passed through the compilation chain (call main_engine.flush() to
+            make sure).
         """
         bit_string = [bool(int(b)) for b in bit_string]
         return self._simulator.get_probability(bit_string,
@@ -155,10 +165,36 @@ class Simulator(BasicEngine):
 
         Returns:
             Probability amplitude of the provided bit string.
+
+        Note:
+            Make sure all previous commands (especially allocations) have
+            passed through the compilation chain (call main_engine.flush() to
+            make sure).
         """
         bit_string = [bool(int(b)) for b in bit_string]
         return self._simulator.get_amplitude(bit_string,
                                              [qb.id for qb in qureg])
+
+    def set_wavefunction(self, wavefunction, qureg):
+        """
+        Set the wavefunction and the qubit ordering of the simulator.
+
+        The simulator will adopt the ordering of qureg (instead of reordering
+        the wavefunction).
+
+        Args:
+            wavefunction (list[complex]): Array of complex amplitudes
+                describing the wavefunction (must be normalized).
+            qureg (Qureg|list[Qubit]): Quantum register determining the
+                ordering. Must contain all allocated qubits.
+
+        Note:
+            Make sure all previous commands (especially allocations) have
+            passed through the compilation chain (call main_engine.flush() to
+            make sure).
+        """
+        self._simulator.set_wavefunction(wavefunction,
+                                         [qb.id for qb in qureg])
 
     def cheat(self):
         """
@@ -171,6 +207,10 @@ class Simulator(BasicEngine):
             A tuple where the first entry is a dictionary mapping qubit
             indices to bit-locations and the second entry is the corresponding
             state vector.
+
+        Note:
+            Make sure all previous commands have passed through the
+            compilation chain (call main_engine.flush() to make sure).
         """
         return self._simulator.cheat()
 

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -140,6 +140,40 @@ class Simulator(BasicEngine):
         return self._simulator.get_expectation_value(operator,
                                                      [qb.id for qb in qureg])
 
+    def apply_qubit_operator(self, qubit_operator, qureg):
+        """
+        Apply a (possibly non-unitary) qubit_operator to the current wave
+        function represented by the supplied quantum register.
+
+        Args:
+            qubit_operator (projectq.ops.QubitOperator): Operator to apply.
+            qureg (list[Qubit],Qureg): Quantum bits to which to apply the
+                operator.
+
+        Warning:
+            This function allows applying non-unitary gates and it will not
+            re-normalize the wave function! It is for numerical experiments
+            only and should not be used for other purposes.
+
+        Note:
+            Make sure all previous commands (especially allocations) have
+            passed through the compilation chain (call main_engine.flush() to
+            make sure).
+
+        Raises:
+            Exception: If `qubit_operator` acts on more qubits than present in
+                the `qureg` argument.
+        """
+        num_qubits = len(qureg)
+        for term, _ in qubit_operator.terms.items():
+            if not term == () and term[-1][0] >= num_qubits:
+                raise Exception("qubit_operator acts on more qubits than "
+                                "contained in the qureg.")
+        operator = [(list(term), coeff) for (term, coeff)
+                    in qubit_operator.terms.items()]
+        return self._simulator.apply_qubit_operator(operator,
+                                                    [qb.id for qb in qureg])
+
     def get_probability(self, bit_string, qureg):
         """
         Return the probability of the outcome `bit_string` when measuring

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -257,7 +257,6 @@ class Simulator(BasicEngine):
             Exception: If a non-single-qubit gate needs to be processed
                 (which should never happen due to is_available).
         """
-        #print(cmd)
         if cmd.gate == Measure:
             assert(get_control_count(cmd) == 0)
             ids = [qb.id for qr in cmd.qubits for qb in qr]

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -126,6 +126,40 @@ class Simulator(BasicEngine):
         return self._simulator.get_expectation_value(operator,
                                                      [qb.id for qb in qureg])
 
+    def get_probability(self, bit_string, qureg):
+        """
+        Return the probability of the outcome `bit_string` when measuring
+        the quantum register `qureg`.
+
+        Args:
+            bit_string (list[bool|int]|string[0|1]): Measurement outcome.
+            qureg (Qureg|list[Qubit]): Quantum register.
+
+        Returns:
+            Probability of measuring the provided bit string.
+        """
+        bit_string = [bool(int(b)) for b in bit_string]
+        return self._simulator.get_probability(bit_string,
+                                               [qb.id for qb in qureg])
+
+    def get_amplitude(self, bit_string, qureg):
+        """
+        Return the probability amplitude of the supplied `bit_string`.
+        The ordering is given by the quantum register `qureg`, which must
+        contain all allocated qubits.
+
+        Args:
+            bit_string (list[bool|int]|string[0|1]): Computational basis state
+            qureg (Qureg|list[Qubit]): Quantum register determining the
+                ordering. Must contain all allocated qubits.
+
+        Returns:
+            Probability amplitude of the provided bit string.
+        """
+        bit_string = [bool(int(b)) for b in bit_string]
+        return self._simulator.get_amplitude(bit_string,
+                                             [qb.id for qb in qureg])
+
     def cheat(self):
         """
         Access the ordering of the qubits and the state vector directly.

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -196,6 +196,27 @@ class Simulator(BasicEngine):
         self._simulator.set_wavefunction(wavefunction,
                                          [qb.id for qb in qureg])
 
+    def collapse_wavefunction(self, qureg, values):
+        """
+        Collapse a quantum register onto a classical basis state.
+
+        Args:
+            qureg (Qureg|list[Qubit]): Qubits to collapse.
+            values (list[bool]): Measurement outcome for each of the qubits
+                in `qureg`.
+
+        Raises:
+            RuntimeError: If an outcome has probability (approximately) 0 or
+                if unknown qubits are provided (see note).
+
+        Note:
+            Make sure all previous commands have passed through the
+            compilation chain (call main_engine.flush() to make sure).
+        """
+        return self._simulator.collapse_wavefunction([qb.id for qb in qureg],
+                                                     [bool(v) for v in
+                                                      values])
+
     def cheat(self):
         """
         Access the ordering of the qubits and the state vector directly.

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -125,7 +125,16 @@ class Simulator(BasicEngine):
             Make sure all previous commands (especially allocations) have
             passed through the compilation chain (call main_engine.flush() to
             make sure).
+
+        Raises:
+            Exception: If `qubit_operator` acts on more qubits than present in
+                the `qureg` argument.
         """
+        num_qubits = len(qureg)
+        for term, _ in qubit_operator.terms.items():
+            if not term == () and term[-1][0] >= num_qubits:
+                raise Exception("qubit_operator acts on more qubits than "
+                                "contained in the qureg.")
         operator = [(list(term), coeff) for (term, coeff)
                     in qubit_operator.terms.items()]
         return self._simulator.get_expectation_value(operator,

--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -103,7 +103,8 @@ class Simulator(BasicEngine):
             return True
         try:
             m = cmd.gate.matrix
-            if len(m) > 2:
+            # Allow up to 5-qubit gates
+            if len(m) > 2 ** 5:
                 return False
             return True
         except:
@@ -322,18 +323,19 @@ class Simulator(BasicEngine):
             qubitids = [qb.id for qb in cmd.qubits[0]]
             ctrlids = [qb.id for qb in cmd.control_qubits]
             self._simulator.emulate_time_evolution(op, t, qubitids, ctrlids)
-        elif len(cmd.gate.matrix) == 2:
+        elif len(cmd.gate.matrix) <= 2 ** 5:
             matrix = cmd.gate.matrix
+            ids = [qb.id for qr in cmd.qubits for qb in qr]
             self._simulator.apply_controlled_gate(matrix.tolist(),
-                                                  [cmd.qubits[0][0].id],
+                                                  ids,
                                                   [qb.id for qb in
                                                    cmd.control_qubits])
             if not self._gate_fusion:
                 self._simulator.run()
         else:
-            raise Exception("This simulator only supports controlled single-"
-                            "qubit gates!\nPlease add an auto-replacer engine"
-                            " to your list of compiler engines.")
+            raise Exception("This simulator only supports controlled k-qubit"
+                            " gates with k < 6!\nPlease add an auto-replacer"
+                            " engine to your list of compiler engines.")
 
     def receive(self, command_list):
         """

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -466,6 +466,18 @@ def test_simulator_set_wavefunction(sim):
     Measure | qubits
 
 
+def test_simulator_set_wavefunction_always_complex(sim):
+    """ Checks that wavefunction is always complex """
+    eng = MainEngine(sim)
+    qubit = eng.allocate_qubit()
+    eng.flush()
+    wf = [1., 0]
+    eng.backend.set_wavefunction(wf, qubit)
+    Y | qubit
+    eng.flush()
+    assert eng.backend.get_amplitude('1', qubit) == pytest.approx(1j)
+
+
 def test_simulator_collapse_wavefunction(sim):
     eng = MainEngine(sim)
     qubits = eng.allocate_qureg(4)

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -363,6 +363,20 @@ def test_simulator_time_evolution(sim):
     assert numpy.allclose(res, final_wavefunction)
 
 
+def test_simulator_set_wavefunction(sim):
+    eng = MainEngine(sim)
+    qubits = eng.allocate_qureg(2)
+    wf = [0., 0., math.sqrt(0.2), math.sqrt(0.8)]
+    with pytest.raises(RuntimeError):
+        eng.backend.set_wavefunction(wf, qubits)
+    eng.flush()
+    eng.backend.set_wavefunction(wf, qubits)
+    assert pytest.approx(eng.backend.get_probability('1', [qubits[0]])) == .8
+    assert pytest.approx(eng.backend.get_probability('01', qubits)) == .2
+    assert pytest.approx(eng.backend.get_probability('1', [qubits[1]])) == 1.
+    Measure | qubits
+
+
 def test_simulator_no_uncompute_exception(sim):
     eng = MainEngine(sim, [])
     qubit = eng.allocate_qubit()

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -377,6 +377,33 @@ def test_simulator_set_wavefunction(sim):
     Measure | qubits
 
 
+def test_simulator_collapse_wavefunction(sim):
+    eng = MainEngine(sim)
+    qubits = eng.allocate_qureg(4)
+    # unknown qubits: raises
+    with pytest.raises(RuntimeError):
+        eng.backend.collapse_wavefunction(qubits, [0] * 4)
+    eng.flush()
+    eng.backend.collapse_wavefunction(qubits, [0] * 4)
+    assert pytest.approx(eng.backend.get_probability([0] * 4, qubits)) == 1.
+    All(H) | qubits[1:]
+    eng.flush()
+    assert pytest.approx(eng.backend.get_probability([0] * 4, qubits)) == .125
+    # impossible outcome: raises
+    with pytest.raises(RuntimeError):
+        eng.backend.collapse_wavefunction(qubits, [1] + [0] * 3)
+    eng.backend.collapse_wavefunction(qubits[:-1], [0, 1, 0])
+    assert (pytest.approx(eng.backend.get_probability([0, 1, 0, 1], qubits))
+            == .5)
+    eng.backend.set_wavefunction([1.] + [0.] * 15, qubits)
+    H | qubits[0]
+    CNOT | (qubits[0], qubits[1])
+    eng.flush()
+    eng.backend.collapse_wavefunction([qubits[0]], [1])
+    assert (pytest.approx(eng.backend.get_probability([1, 1], qubits[0:2]))
+            == 1.)
+
+
 def test_simulator_no_uncompute_exception(sim):
     eng = MainEngine(sim, [])
     qubit = eng.allocate_qubit()

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -313,6 +313,19 @@ def test_simulator_expectation(sim):
     assert .4 == pytest.approx(expectation)
 
 
+def test_simulator_expectation_exception(sim):
+    eng = MainEngine(sim, [])
+    qureg = eng.allocate_qureg(3)
+    op = QubitOperator('Z2')
+    sim.get_expectation_value(op, qureg)
+    op2 = QubitOperator('Z3')
+    with pytest.raises(Exception):
+        sim.get_expectation_value(op2, qureg)
+    op3 = QubitOperator('Z1') + QubitOperator('X1 Y3')
+    with pytest.raises(Exception):
+        sim.get_expectation_value(op3, qureg)
+
+
 def test_simulator_time_evolution(sim):
     N = 9  # number of qubits
     time_to_evolve = 1.1  # time to evolve for

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -326,6 +326,43 @@ def test_simulator_expectation_exception(sim):
         sim.get_expectation_value(op3, qureg)
 
 
+def test_simulator_applyqubitoperator_exception(sim):
+    eng = MainEngine(sim, [])
+    qureg = eng.allocate_qureg(3)
+    op = QubitOperator('Z2')
+    sim.apply_qubit_operator(op, qureg)
+    op2 = QubitOperator('Z3')
+    with pytest.raises(Exception):
+        sim.apply_qubit_operator(op2, qureg)
+    op3 = QubitOperator('Z1') + QubitOperator('X1 Y3')
+    with pytest.raises(Exception):
+        sim.apply_qubit_operator(op3, qureg)
+
+
+def test_simulator_applyqubitoperator(sim):
+    eng = MainEngine(sim, [])
+    qureg = eng.allocate_qureg(3)
+    op = QubitOperator('X0 Y1 Z2')
+    sim.apply_qubit_operator(op, qureg)
+    X | qureg[0]
+    Y | qureg[1]
+    Z | qureg[2]
+    assert sim.get_amplitude('000', qureg) == pytest.approx(1.)
+
+    H | qureg[0]
+    op_H = 1. / math.sqrt(2.) * (QubitOperator('X0') + QubitOperator('Z0'))
+    sim.apply_qubit_operator(op_H, [qureg[0]])
+    assert sim.get_amplitude('000', qureg) == pytest.approx(1.)
+
+    op_Proj0 = 0.5 * (QubitOperator('') + QubitOperator('Z0'))
+    op_Proj1 = 0.5 * (QubitOperator('') - QubitOperator('Z0'))
+    H | qureg[0]
+    sim.apply_qubit_operator(op_Proj0, [qureg[0]])
+    assert sim.get_amplitude('000', qureg) == pytest.approx(1. / math.sqrt(2.))
+    sim.apply_qubit_operator(op_Proj1, [qureg[0]])
+    assert sim.get_amplitude('000', qureg) == pytest.approx(0.)
+
+
 def test_simulator_time_evolution(sim):
     N = 9  # number of qubits
     time_to_evolve = 1.1  # time to evolve for

--- a/projectq/cengines/__init__.py
+++ b/projectq/cengines/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_basics.py
+++ b/projectq/cengines/_basics.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_basics.py
+++ b/projectq/cengines/_basics.py
@@ -107,26 +107,14 @@ class BasicEngine(object):
         """
         new_id = self.main_engine.get_new_qubit_id()
         qb = Qureg([Qubit(self, new_id)])
+        cmd = Command(self, Allocate, (qb,))
         if dirty:
             from projectq.meta import DirtyQubitTag
             if self.is_meta_tag_supported(DirtyQubitTag):
-                oldnext = self.next_engine
-
-                def cmd_modifier(cmd):
-                    assert(cmd.gate == Allocate)
-                    cmd.tags += [DirtyQubitTag()]
-                    return cmd
-                self.next_engine = projectq.cengines.CommandModifier(
-                    cmd_modifier)
-                self.next_engine.next_engine = oldnext
-                self.send([Command(self, Allocate, (qb,))])
-                self.next_engine = oldnext
-                self.main_engine.active_qubits.add(qb[0])
+                cmd.tags += [DirtyQubitTag()]
                 self.main_engine.dirty_qubits.add(qb[0].id)
-                return qb
-
-        self.send([Command(self, Allocate, (qb,))])
         self.main_engine.active_qubits.add(qb[0])
+        self.send([cmd])
         return qb
 
     def allocate_qureg(self, n):

--- a/projectq/cengines/_basics.py
+++ b/projectq/cengines/_basics.py
@@ -155,21 +155,12 @@ class BasicEngine(object):
         if qubit.id == -1:
             raise ValueError("Already deallocated.")
 
-        if qubit.id not in self.main_engine.dirty_qubits:
-            self.send([Command(self, Deallocate, ([qubit],))])
-        else:
-            from projectq.meta import DirtyQubitTag
-            oldnext = self.next_engine
-
-            def cmd_modifier(cmd):
-                assert(cmd.gate == Deallocate)
-                cmd.tags += [DirtyQubitTag()]
-                return cmd
-            self.next_engine = projectq.cengines.CommandModifier(
-                cmd_modifier)
-            self.next_engine.next_engine = oldnext
-            self.send([Command(self, Deallocate, ([qubit],))])
-            self.next_engine = oldnext
+        from projectq.meta import DirtyQubitTag
+        is_dirty = qubit.id in self.main_engine.dirty_qubits
+        self.send([Command(self,
+                           Deallocate,
+                           (Qureg([qubit]),),
+                           tags=[DirtyQubitTag()] if is_dirty else [])])
 
     def is_meta_tag_supported(self, meta_tag):
         """

--- a/projectq/cengines/_basics_test.py
+++ b/projectq/cengines/_basics_test.py
@@ -77,9 +77,7 @@ def test_basic_engine_allocate_and_deallocate_qubit_and_qureg():
 
     # Allocate an actual dirty qubit
     def allow_dirty_qubits(self, meta_tag):
-        if meta_tag == DirtyQubitTag:
-            return True
-        return False
+        return meta_tag == DirtyQubitTag
 
     saving_backend.is_meta_tag_handler = types.MethodType(allow_dirty_qubits,
                                                           saving_backend)
@@ -127,6 +125,13 @@ def test_basic_engine_allocate_and_deallocate_qubit_and_qureg():
     for cmd in saving_backend.received_commands[5:]:
         assert cmd.gate == DeallocateQubitGate()
     assert saving_backend.received_commands[7].tags == [DirtyQubitTag()]
+
+
+def test_deallocate_qubit_exception():
+    eng = _basics.BasicEngine()
+    qubit = Qubit(eng, -1)
+    with pytest.raises(ValueError):
+        eng.deallocate_qubit(qubit)
 
 
 def test_basic_engine_is_meta_tag_supported():

--- a/projectq/cengines/_basics_test.py
+++ b/projectq/cengines/_basics_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_cmdmodifier.py
+++ b/projectq/cengines/_cmdmodifier.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_cmdmodifier_test.py
+++ b/projectq/cengines/_cmdmodifier_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_ibmcnotmapper.py
+++ b/projectq/cengines/_ibmcnotmapper.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_ibmcnotmapper_test.py
+++ b/projectq/cengines/_ibmcnotmapper_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -72,11 +72,14 @@ class MainEngine(BasicEngine):
         Example:
             .. code-block:: python
 
-                from projectq.cengines import TagRemover,AutoReplacer,LocalOptimizer,DecompositionRuleSet
+                from projectq.cengines import (TagRemover, AutoReplacer,
+                                               LocalOptimizer,
+                                               DecompositionRuleSet)
                 from projectq.backends import Simulator
                 from projectq import MainEngine
                 rule_set = DecompositionRuleSet()
-                engines = [AutoReplacer(rule_set), TagRemover(), LocalOptimizer(3)]
+                engines = [AutoReplacer(rule_set), TagRemover(),
+                           LocalOptimizer(3)]
                 eng = MainEngine(Simulator(), engines)
         """
         BasicEngine.__init__(self)

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -113,5 +113,5 @@ def test_main_engine_flush():
     eng.flush(deallocate_qubits=True)
     assert len(backend.received_commands) == 5
     assert backend.received_commands[3].gate == DeallocateQubitGate()
-    #keep the qubit alive until at least here
+    # keep the qubit alive until at least here
     assert len(str(qubit)) != 0

--- a/projectq/cengines/_optimize.py
+++ b/projectq/cengines/_optimize.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_optimize.py
+++ b/projectq/cengines/_optimize.py
@@ -95,28 +95,21 @@ class LocalOptimizer(BasicEngine):
         # 1-qubit gate: only gate at index i in list #idx is involved
         if N == 1:
             return [i]
-        indices = [0] * N
 
-        numidentical = 0  # number of identical commands (gate & arguments)
-        j = 0
-        while j < i:
-            # this gate would otherwise be recognized as the right one in
-            # other qubits find #times this happens before the right gate
-            # is found
-            if self._l[idx][j] == self._l[idx][i]:
-                numidentical += 1
-            j += 1
-
-        for k in range(len(IDs)):
-            j = found = 0
-            while found <= numidentical:
-                # if ==, it may be the same gate, check using numidentical
-                if self._l[IDs[k]][j] == self._l[idx][i]:
-                    found += 1
-                j += 1
-
-            # this is the index of the gate in the gate list of qubit IDs[k]
-            indices[k] = j - 1
+        # When the same gate appears multiple time, we need to make sure not to
+        # match earlier instances of the gate applied to the same qubits. So we
+        # count how many there are, and skip over them when looking in the
+        # other lists.
+        cmd = self._l[idx][i]
+        num_identical_to_skip = sum(1
+                                    for prev_cmd in self._l[idx][:i]
+                                    if prev_cmd == cmd)
+        indices = []
+        for Id in IDs:
+            identical_indices = [i
+                                 for i, c in enumerate(self._l[Id])
+                                 if c == cmd]
+            indices.append(identical_indices[num_identical_to_skip])
         return indices
 
     def _optimize(self, idx, lim=None):

--- a/projectq/cengines/_optimize_test.py
+++ b/projectq/cengines/_optimize_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_replacer/__init__.py
+++ b/projectq/cengines/_replacer/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_replacer/_decomposition_rule.py
+++ b/projectq/cengines/_replacer/_decomposition_rule.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_replacer/_decomposition_rule_set.py
+++ b/projectq/cengines/_replacer/_decomposition_rule_set.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_replacer/_decomposition_rule_test.py
+++ b/projectq/cengines/_replacer/_decomposition_rule_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_replacer/_replacer.py
+++ b/projectq/cengines/_replacer/_replacer.py
@@ -133,7 +133,9 @@ class AutoReplacer(BasicEngine):
             # the gate class of the inverse gate. If nothing is found, do the 
             # same for the first parent class, etc.
             gate_mro = type(cmd.gate).mro()[:-1]
-            inverse_mro = type(get_inverse(cmd.gate)).mro()[:-1]
+            # If gate does not have an inverse it's parent classes are 
+            # DaggeredGate, BasicGate, object. Hence don't check the last two
+            inverse_mro = type(get_inverse(cmd.gate)).mro()[:-2]
             rules = self.decompositionRuleSet.decompositions
             for level in range(max(len(gate_mro), len(inverse_mro))):
                 # Check for forward rules

--- a/projectq/cengines/_replacer/_replacer.py
+++ b/projectq/cengines/_replacer/_replacer.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_replacer/_replacer.py
+++ b/projectq/cengines/_replacer/_replacer.py
@@ -128,38 +128,36 @@ class AutoReplacer(BasicEngine):
             # check for decomposition rules
             decomp_list = []
             potential_decomps = []
-            inv_list = []
 
-            # check for forward rules
-            cls = cmd.gate.__class__.__name__
-            try:
-                potential_decomps = [
-                    d for d in self.decompositionRuleSet.decompositions[cls]
-                ]
-            except KeyError:
-                pass
-            # check for rules implementing the inverse gate
-            # and run them in reverse
-            inv_cls = get_inverse(cmd.gate).__class__.__name__
-            try:
-                potential_decomps += [
-                    d.get_inverse_decomposition()
-                    for d in self.decompositionRuleSet.decompositions[inv_cls]
-                ]
-            except KeyError:
-                pass
-            # throw out the ones which don't recognize the command
-            for d in potential_decomps:
-                if d.check(cmd):
-                    decomp_list.append(d)
-
-            # If nothing found so far, check recursively parent classes:
-            if len(decomp_list) == 0:
-                for parent_class in type(cmd.gate).mro()[1:-1]:
-                    name = parent_class.__name__
+            # First check for a decomposition rules of the gate class, then
+            # the gate class of the inverse gate. If nothing is found, do the 
+            # same for the first parent class, etc.
+            gate_mro = type(cmd.gate).mro()[:-1]
+            inverse_mro = type(get_inverse(cmd.gate)).mro()[:-1]
+            rules = self.decompositionRuleSet.decompositions
+            for level in range(max(len(gate_mro), len(inverse_mro))):
+                # Check for forward rules
+                if level < len(gate_mro):
+                    class_name = gate_mro[level].__name__
                     try:
-                        rules = self.decompositionRuleSet.decompositions[name]
-                        potential_decomps = [d for d in rules]
+                        potential_decomps = [d for d in rules[class_name]]
+                    except KeyError:
+                        pass
+                    # throw out the ones which don't recognize the command
+                    for d in potential_decomps:
+                        if d.check(cmd):
+                            decomp_list.append(d)
+                    if len(decomp_list) != 0:
+                        break
+                # Check for rules implementing the inverse gate
+                # and run them in reverse
+                if level < len(inverse_mro):
+                    inv_class_name = inverse_mro[level].__name__
+                    try:
+                        potential_decomps += [
+                            d.get_inverse_decomposition()
+                            for d in rules[inv_class_name]
+                        ]
                     except KeyError:
                         pass
                     # throw out the ones which don't recognize the command

--- a/projectq/cengines/_replacer/_replacer.py
+++ b/projectq/cengines/_replacer/_replacer.py
@@ -77,8 +77,9 @@ class AutoReplacer(BasicEngine):
     further. The loaded setup is used to find decomposition rules appropriate
     for each command (e.g., setups.default).
     """
-    def __init__(self, decompositionRuleSet, decomposition_chooser=
-                 lambda cmd, decomposition_list: decomposition_list[0]):
+    def __init__(self, decompositionRuleSet,
+                 decomposition_chooser=lambda cmd,
+                 decomposition_list: decomposition_list[0]):
         """
         Initialize an AutoReplacer.
 

--- a/projectq/cengines/_replacer/_replacer.py
+++ b/projectq/cengines/_replacer/_replacer.py
@@ -151,9 +151,25 @@ class AutoReplacer(BasicEngine):
                 if d.check(cmd):
                     decomp_list.append(d)
 
+            # If nothing found so far, check recursively parent classes:
             if len(decomp_list) == 0:
-                raise NoGateDecompositionError("\nNo replacement found for "
-                                               + str(cmd) + "!")
+                for parent_class in type(cmd.gate).mro()[1:-1]:
+                    name = parent_class.__name__
+                    try:
+                        rules = self.decompositionRuleSet.decompositions[name]
+                        potential_decomps = [d for d in rules]
+                    except KeyError:
+                        pass
+                    # throw out the ones which don't recognize the command
+                    for d in potential_decomps:
+                        if d.check(cmd):
+                            decomp_list.append(d)
+                    if len(decomp_list) != 0:
+                        break
+
+            if len(decomp_list) == 0:
+                raise NoGateDecompositionError("\nNo replacement found for " +
+                                               str(cmd) + "!")
 
             # use decomposition chooser to determine the best decomposition
             chosen_decomp = self._decomp_chooser(cmd, decomp_list)

--- a/projectq/cengines/_replacer/_replacer_test.py
+++ b/projectq/cengines/_replacer/_replacer_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_replacer/_replacer_test.py
+++ b/projectq/cengines/_replacer/_replacer_test.py
@@ -222,3 +222,5 @@ def test_auto_replacer_searches_parent_class_for_rule():
     qb = eng.allocate_qubit()
     DerivedSomeGate() | qb
     eng.flush()
+    received_gate = backend.received_commands[1].gate
+    assert received_gate == X or received_gate == H

--- a/projectq/cengines/_tagremover.py
+++ b/projectq/cengines/_tagremover.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_tagremover_test.py
+++ b/projectq/cengines/_tagremover_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_testengine.py
+++ b/projectq/cengines/_testengine.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_testengine_test.py
+++ b/projectq/cengines/_testengine_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/cengines/_testengine_test.py
+++ b/projectq/cengines/_testengine_test.py
@@ -27,9 +27,9 @@ def test_compare_engine_str():
     H | qb0
     CNOT | (qb0, qb1)
     eng.flush()
-    expected = ("Qubit 0 : Allocate | Qubit[0], H | Qubit[0], " +
-                "CX | ( Qubit[0], Qubit[1] )\nQubit 1 : Allocate | Qubit[1]," +
-                " CX | ( Qubit[0], Qubit[1] )\n")
+    expected = ("Qubit 0 : Allocate | Qureg[0], H | Qureg[0], " +
+                "CX | ( Qureg[0], Qureg[1] )\nQubit 1 : Allocate | Qureg[1]," +
+                " CX | ( Qureg[0], Qureg[1] )\n")
     assert str(compare_engine) == expected
 
 

--- a/projectq/libs/__init__.py
+++ b/projectq/libs/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/libs/math/__init__.py
+++ b/projectq/libs/math/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/libs/math/_constantmath.py
+++ b/projectq/libs/math/_constantmath.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/libs/math/_constantmath.py
+++ b/projectq/libs/math/_constantmath.py
@@ -11,7 +11,10 @@
 #   limitations under the License.
 
 import math
-from fractions import gcd
+try:
+    from math import gcd
+except ImportError:
+    from fractions import gcd
 
 from projectq.ops import R, X, Swap, Measure, CNOT, QFT
 from projectq.meta import Control, Compute, Uncompute, CustomUncompute, Dagger

--- a/projectq/libs/math/_constantmath_test.py
+++ b/projectq/libs/math/_constantmath_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/libs/math/_default_rules.py
+++ b/projectq/libs/math/_default_rules.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/libs/math/_gates.py
+++ b/projectq/libs/math/_gates.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/libs/math/_gates_test.py
+++ b/projectq/libs/math/_gates_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/__init__.py
+++ b/projectq/meta/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/__init__.py
+++ b/projectq/meta/__init__.py
@@ -33,3 +33,4 @@ from ._compute import (Compute,
 from ._control import (Control,
                        get_control_count)
 from ._dagger import Dagger
+from ._util import insert_engine, drop_engine_after

--- a/projectq/meta/_compute.py
+++ b/projectq/meta/_compute.py
@@ -194,32 +194,16 @@ class ComputeEngine(BasicEngine):
                     self.send([self._add_uncompute_tag(cmd.get_inverse())])
 
             else:
-                if len(new_local_id) == 0:
-                    # No local qubits are active currently -> do standard
-                    # uncompute
-                    self.send([self._add_uncompute_tag(cmd.get_inverse())])
-                else:
-                    # Process commands by replacing each local qubit from
-                    # compute section with new local qubit from the uncompute
-                    # section
-                    tmp_control_qubits = cmd.control_qubits
-                    changed = False
-                    for control_qubit in tmp_control_qubits:
-                        if control_qubit.id in new_local_id:
-                            control_qubit.id = new_local_id[control_qubit.id]
-                            changed = True
-                    if changed:
-                        cmd.control_qubits = tmp_control_qubits
-                    tmp_qubits = cmd.qubits
-                    changed = False
-                    for qureg in tmp_qubits:
+                # Process commands by replacing each local qubit from       
+                # compute section with new local qubit from the uncompute     
+                # section
+                if new_local_id:  # Only if we still have local qubits
+                    for qureg in cmd.all_qubits:
                         for qubit in qureg:
                             if qubit.id in new_local_id:
                                 qubit.id = new_local_id[qubit.id]
-                                changed = True
-                    if changed:
-                        cmd.qubits = tmp_qubits
-                    self.send([self._add_uncompute_tag(cmd.get_inverse())])
+
+                self.send([self._add_uncompute_tag(cmd.get_inverse())])
 
     def end_compute(self):
         """

--- a/projectq/meta/_compute.py
+++ b/projectq/meta/_compute.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_compute.py
+++ b/projectq/meta/_compute.py
@@ -18,11 +18,13 @@ annotate Compute / Action / Uncompute sections, facilitating the conditioning
 of the entire operation on the value of a qubit / register (only Action needs
 controls). This file also defines the corresponding meta tags.
 """
+
 from copy import deepcopy
 
 import projectq
 from projectq.cengines import BasicEngine
 from projectq.ops import Allocate, Deallocate
+from ._util import insert_engine, drop_engine_after
 
 
 class QubitManagementError(Exception):
@@ -145,17 +147,16 @@ class ComputeEngine(BasicEngine):
             if cmd.gate == Deallocate:
                 assert (cmd.qubits[0][0].id) in ids_local_to_compute
                 # Create new local qubit which lives within uncompute section
-                # Allocate needs to have old tags + uncompute tag
-                oldnext = self.next_engine
 
+                # Allocate needs to have old tags + uncompute tag
                 def add_uncompute(command, old_tags=deepcopy(cmd.tags)):
                     command.tags = old_tags + [UncomputeTag()]
                     return command
-                self.next_engine = projectq.cengines.CommandModifier(
-                    add_uncompute)
-                self.next_engine.next_engine = oldnext
+                tagger_eng = projectq.cengines.CommandModifier(add_uncompute)
+                insert_engine(self, tagger_eng)
                 new_local_qb = self.allocate_qubit()
-                self.next_engine = oldnext
+                drop_engine_after(self)
+
                 new_local_id[cmd.qubits[0][0].id] = deepcopy(
                     new_local_qb[0].id)
                 # Set id of new_local_qb to -1 such that it doesn't send a
@@ -351,18 +352,16 @@ class Compute(object):
                 commands (normally: MainEngine).
         """
         self.engine = engine
+        self._compute_eng = None
 
     def __enter__(self):
-        compute_eng = ComputeEngine()
-        compute_eng.main_engine = self.engine.main_engine
-        oldnext = self.engine.next_engine
-        self.engine.next_engine = compute_eng
-        compute_eng.next_engine = oldnext
-        self._compute_eng = compute_eng
+        self._compute_eng = ComputeEngine()
+        insert_engine(self.engine, self._compute_eng)
 
     def __exit__(self, type, value, traceback):
         # notify ComputeEngine that the compute section is done
         self._compute_eng.end_compute()
+        self._compute_eng = None
 
 
 class CustomUncompute(object):
@@ -407,16 +406,11 @@ class CustomUncompute(object):
         # after __enter__
         self._allocated_qubit_ids = compute_eng._allocated_qubit_ids.copy()
         self._deallocated_qubit_ids = compute_eng._deallocated_qubit_ids.copy()
-        oldnext = compute_eng.next_engine
-        self.engine.next_engine = oldnext
+        drop_engine_after(self.engine)
 
         # Now add uncompute engine
-        uncompute_eng = UncomputeEngine()
-        uncompute_eng.main_engine = self.engine.main_engine
-        oldnext = self.engine.next_engine
-        self.engine.next_engine = uncompute_eng
-        uncompute_eng.next_engine = oldnext
-        self._uncompute_eng = uncompute_eng
+        self._uncompute_eng = UncomputeEngine()
+        insert_engine(self.engine, self._uncompute_eng)
 
     def __exit__(self, type, value, traceback):
         # Check that all qubits allocated within Compute or within
@@ -431,8 +425,7 @@ class CustomUncompute(object):
                 "been allocated in the with Compute(eng) or with " +
                 "CustomUncompute(eng) context.")
         # remove uncompute engine
-        oldnext = self._uncompute_eng.next_engine
-        self.engine.next_engine = oldnext
+        drop_engine_after(self.engine)
 
 
 def Uncompute(engine):
@@ -453,5 +446,4 @@ def Uncompute(engine):
                                     "corresponding 'with Compute' statement "
                                     "found.")
     compute_eng.run_uncompute()
-    oldnext = compute_eng.next_engine
-    engine.next_engine = oldnext
+    drop_engine_after(engine)

--- a/projectq/meta/_compute.py
+++ b/projectq/meta/_compute.py
@@ -127,7 +127,7 @@ class ComputeEngine(BasicEngine):
                     for active_qubit in self.main_engine.active_qubits:
                         if active_qubit.id == qubit_id:
                             active_qubit.id = -1
-                            del active_qubit
+                            active_qubit.__del__()
                             qubit_found = True
                             break
                     if not qubit_found:
@@ -181,7 +181,7 @@ class ComputeEngine(BasicEngine):
                     for active_qubit in self.main_engine.active_qubits:
                         if active_qubit.id == qubit_id:
                             active_qubit.id = -1
-                            del active_qubit
+                            active_qubit.__del__()
                             qubit_found = True
                             break
                     if not qubit_found:

--- a/projectq/meta/_compute_test.py
+++ b/projectq/meta/_compute_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_compute_test.py
+++ b/projectq/meta/_compute_test.py
@@ -161,7 +161,7 @@ def test_automatic_deallocation_of_qubit_in_uncompute():
         ancilla = eng.allocate_qubit()
         assert ancilla[0].id != -1
         Rx(0.6) | ancilla
-    # Test that ancilla qubit has been register in MainEngine.active_qubits
+    # Test that ancilla qubit has been registered in MainEngine.active_qubits
     assert ancilla[0] in eng.active_qubits
     _compute.Uncompute(eng)
     # Test that ancilla id has been set to -1
@@ -170,6 +170,8 @@ def test_automatic_deallocation_of_qubit_in_uncompute():
     assert not ancilla[0] in eng.active_qubits
     assert backend.received_commands[1].gate == Rx(0.6)
     assert backend.received_commands[2].gate == Rx(-0.6)
+    # Test that there are no additional deallocate gates
+    assert len(backend.received_commands) == 4
 
 
 def test_compute_uncompute_no_additional_qubits():

--- a/projectq/meta/_control.py
+++ b/projectq/meta/_control.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_control.py
+++ b/projectq/meta/_control.py
@@ -22,9 +22,10 @@ Example:
 """
 
 from projectq.cengines import BasicEngine
-from projectq.ops import ClassicalInstructionGate
 from projectq.meta import ComputeTag, UncomputeTag
+from projectq.ops import ClassicalInstructionGate
 from projectq.types import BasicQubit
+from ._util import insert_engine, drop_engine_after
 
 
 class ControlEngine(BasicEngine):
@@ -101,17 +102,12 @@ class Control(object):
     def __enter__(self):
         if len(self._qubits) > 0:
             ce = ControlEngine(self._qubits)
-            ce.main_engine = self.engine.main_engine
-            oldnext = self.engine.next_engine
-            self.engine.next_engine = ce
-            ce.next_engine = oldnext
-            self._ce = ce
+            insert_engine(self.engine, ce)
 
     def __exit__(self, type, value, traceback):
         # remove control handler from engine list (i.e. skip it)
         if len(self._qubits) > 0:
-            oldnext = self._ce.next_engine
-            self.engine.next_engine = oldnext
+            drop_engine_after(self.engine)
 
 
 def get_control_count(cmd):

--- a/projectq/meta/_control_test.py
+++ b/projectq/meta/_control_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_dagger.py
+++ b/projectq/meta/_dagger.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_dagger.py
+++ b/projectq/meta/_dagger.py
@@ -22,7 +22,7 @@ Tools to easily invert a sequence of gates.
 
 from projectq.cengines import BasicEngine
 from projectq.ops import Allocate, Deallocate
-from projectq.meta import DirtyQubitTag
+from ._util import insert_engine, drop_engine_after
 
 
 class QubitManagementError(Exception):
@@ -123,18 +123,15 @@ class Dagger(object):
                 QFT | qubits
         """
         self.engine = engine
+        self._dagger_eng = None
 
     def __enter__(self):
-        dagger_eng = DaggerEngine()
-        dagger_eng.main_engine = self.engine.main_engine
-        oldnext = self.engine.next_engine
-        self.engine.next_engine = dagger_eng
-        dagger_eng.next_engine = oldnext
-        self._dagger_eng = dagger_eng
+        self._dagger_eng = DaggerEngine()
+        insert_engine(self.engine, self._dagger_eng)
 
     def __exit__(self, type, value, traceback):
         # run dagger engine
         self._dagger_eng.run()
+        self._dagger_eng = None
         # remove dagger handler from engine list (i.e. skip it)
-        oldnext = self._dagger_eng.next_engine
-        self.engine.next_engine = oldnext
+        drop_engine_after(self.engine)

--- a/projectq/meta/_dagger_test.py
+++ b/projectq/meta/_dagger_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_dirtyqubit.py
+++ b/projectq/meta/_dirtyqubit.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_dirtyqubit_test.py
+++ b/projectq/meta/_dirtyqubit_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_loop.py
+++ b/projectq/meta/_loop.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_loop_test.py
+++ b/projectq/meta/_loop_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_qubitplacement.py
+++ b/projectq/meta/_qubitplacement.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_qubitplacement_test.py
+++ b/projectq/meta/_qubitplacement_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_util.py
+++ b/projectq/meta/_util.py
@@ -31,7 +31,7 @@ def insert_engine(prev_engine, engine_to_insert):
 def drop_engine_after(prev_engine):
     """
     Removes an engine from the singly-linked list of engines.
-    
+
     Args:
         prev_engine (projectq.cengines.BasicEngine):
             The engine just before the engine to drop.

--- a/projectq/meta/_util.py
+++ b/projectq/meta/_util.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/meta/_util.py
+++ b/projectq/meta/_util.py
@@ -1,0 +1,45 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+def insert_engine(prev_engine, engine_to_insert):
+    """
+    Inserts an engine into the singly-linked list of engines.
+
+    It also sets the correct main_engine for engine_to_insert.
+
+    Args:
+        prev_engine (projectq.cengines.BasicEngine):
+            The engine just before the insertion point.
+        engine_to_insert (projectq.cengines.BasicEngine):
+            The engine to insert at the insertion point.
+    """
+    engine_to_insert.main_engine = prev_engine.main_engine
+    engine_to_insert.next_engine = prev_engine.next_engine
+    prev_engine.next_engine = engine_to_insert
+
+
+def drop_engine_after(prev_engine):
+    """
+    Removes an engine from the singly-linked list of engines.
+    
+    Args:
+        prev_engine (projectq.cengines.BasicEngine):
+            The engine just before the engine to drop.
+    Returns:
+        Engine: The dropped engine.
+    """
+    dropped_engine = prev_engine.next_engine
+    prev_engine.next_engine = dropped_engine.next_engine
+    dropped_engine.next_engine = None
+    dropped_engine.main_engine = None
+    return dropped_engine

--- a/projectq/meta/_util_test.py
+++ b/projectq/meta/_util_test.py
@@ -1,0 +1,46 @@
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+from projectq import MainEngine
+from projectq.cengines import DummyEngine
+from projectq.meta import insert_engine, drop_engine_after
+
+
+def test_insert_then_drop():
+    d1 = DummyEngine()
+    d2 = DummyEngine()
+    d3 = DummyEngine()
+    eng = MainEngine(backend=d3, engine_list=[d1])
+
+    assert d1.next_engine is d3
+    assert d2.next_engine is None
+    assert d3.next_engine is None
+    assert d1.main_engine is eng
+    assert d2.main_engine is None
+    assert d3.main_engine is eng
+
+    insert_engine(d1, d2)
+    assert d1.next_engine is d2
+    assert d2.next_engine is d3
+    assert d3.next_engine is None
+    assert d1.main_engine is eng
+    assert d2.main_engine is eng
+    assert d3.main_engine is eng
+
+    drop_engine_after(d1)
+    assert d1.next_engine is d3
+    assert d2.next_engine is None
+    assert d3.next_engine is None
+    assert d1.main_engine is eng
+    assert d2.main_engine is None
+    assert d3.main_engine is eng

--- a/projectq/meta/_util_test.py
+++ b/projectq/meta/_util_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/__init__.py
+++ b/projectq/ops/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
@@ -17,7 +19,8 @@ from ._basics import (NotMergeable,
                       BasicRotationGate,
                       ClassicalInstructionGate,
                       FastForwardingGate,
-                      BasicMathGate)
+                      BasicMathGate,
+                      BasicPhaseGate)
 from ._command import apply_command, Command
 from ._metagates import (DaggeredGate,
                          get_inverse,

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
@@ -303,6 +305,95 @@ class BasicRotationGate(BasicGate):
             difference = abs(self._angle - other._angle) % (4 * math.pi)
             # Return True if angles are close to each other modulo 4 * pi
             if difference < tolerance or difference > 4 * math.pi - tolerance:
+                return True
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+class BasicPhaseGate(BasicGate):
+    """
+    Defines a base class of a phase gate.
+
+    A phase gate has a continuous parameter (the angle), labeled 'angle' /
+    self._angle. Its inverse is the same gate with the negated argument.
+    Phase gates of the same class can be merged by adding the angles.
+    The continuous parameter is modulo 2 * pi, self._angle is in the interval
+    [0, 2 * pi).
+    """
+    def __init__(self, angle):
+        """
+        Initialize a basic rotation gate.
+
+        Args:
+            angle (float): Angle of rotation (saved modulo 2 * pi)
+        """
+        BasicGate.__init__(self)
+        self._angle = float(angle) % (2. * math.pi)
+
+    def __str__(self):
+        """
+        Return the string representation of a BasicRotationGate.
+
+        Returns the class name and the angle as
+
+        .. code-block:: python
+
+            [CLASSNAME]([ANGLE])
+        """
+        return str(self.__class__.__name__) + "(" + str(self._angle) + ")"
+
+    def tex_str(self):
+        """
+        Return the Latex string representation of a BasicRotationGate.
+
+        Returns the class name and the angle as a subscript, i.e.
+
+        .. code-block:: latex
+
+            [CLASSNAME]$_[ANGLE]$
+        """
+        return str(self.__class__.__name__) + "$_{" + str(self._angle) + "}$"
+
+    def get_inverse(self):
+        """
+        Return the inverse of this rotation gate (negate the angle, return new
+        object).
+        """
+        if self._angle == 0:
+            return self.__class__(0)
+        else:
+            return self.__class__(-self._angle + 2 * math.pi)
+
+    def get_merged(self, other):
+        """
+        Return self merged with another gate.
+
+        Default implementation handles rotation gate of the same type, where
+        angles are simply added.
+
+        Args:
+            other: Rotation gate of same type.
+
+        Raises:
+            NotMergeable: For non-rotation gates or rotation gates of
+                different type.
+
+        Returns:
+            New object representing the merged gates.
+        """
+        if isinstance(other, self.__class__):
+            return self.__class__(self._angle + other._angle)
+        raise NotMergeable("Can't merge different types of rotation gates.")
+
+    def __eq__(self, other):
+        """ Return True if same class and same rotation angle. """
+        tolerance = EQ_TOLERANCE
+        if isinstance(other, self.__class__):
+            difference = abs(self._angle - other._angle) % (2 * math.pi)
+            # Return True if angles are close to each other modulo 4 * pi
+            if difference < tolerance or difference > 2 * math.pi - tolerance:
                 return True
         return False
 

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -145,8 +145,13 @@ def test_basic_rotation_gate_str():
     assert str(basic_rotation_gate) == "BasicRotationGate(0.5)"
 
 
+def test_basic_rotation_tex_str():
+    basic_rotation_gate = _basics.BasicRotationGate(0.5)
+    assert basic_rotation_gate.tex_str() == "BasicRotationGate$_{0.5}$"
+
+
 @pytest.mark.parametrize("input_angle, inverse_angle",
-                         [(2.0, -2.0 + 4 * math.pi), (-0.5, 0.5)])
+                         [(2.0, -2.0 + 4 * math.pi), (-0.5, 0.5), (0.0, 0)])
 def test_basic_rotation_gate_get_inverse(input_angle, inverse_angle):
     basic_rotation_gate = _basics.BasicRotationGate(input_angle)
     inverse = basic_rotation_gate.get_inverse()

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
@@ -187,6 +189,64 @@ def test_basic_rotation_gate_comparison():
     basic_gate = _basics.BasicGate()
     assert not basic_gate == basic_rotation_gate6
     assert basic_rotation_gate2 != _basics.BasicRotationGate(0.5 + 2 * math.pi)
+
+
+@pytest.mark.parametrize("input_angle, modulo_angle",
+                         [(2.0, 2.0), (17., 4.4336293856408275),
+                          (-0.5 * math.pi, 1.5 * math.pi), (2 * math.pi, 0)])
+def test_basic_phase_gate_init(input_angle, modulo_angle):
+    # Test internal representation
+    gate = _basics.BasicPhaseGate(input_angle)
+    assert gate._angle == pytest.approx(modulo_angle)
+
+
+def test_basic_phase_gate_str():
+    basic_phase_gate = _basics.BasicPhaseGate(0.5)
+    assert str(basic_phase_gate) == "BasicPhaseGate(0.5)"
+
+
+def test_basic_phase_tex_str():
+    basic_phase_gate = _basics.BasicPhaseGate(0.5)
+    assert basic_phase_gate.tex_str() == "BasicPhaseGate$_{0.5}$"
+
+
+@pytest.mark.parametrize("input_angle, inverse_angle",
+                         [(2.0, -2.0 + 2 * math.pi), (-0.5, 0.5), (0.0, 0)])
+def test_basic_phase_gate_get_inverse(input_angle, inverse_angle):
+    basic_phase_gate = _basics.BasicPhaseGate(input_angle)
+    inverse = basic_phase_gate.get_inverse()
+    assert isinstance(inverse, _basics.BasicPhaseGate)
+    assert inverse._angle == pytest.approx(inverse_angle)
+
+
+def test_basic_phase_gate_get_merged():
+    basic_gate = _basics.BasicGate()
+    basic_phase_gate1 = _basics.BasicPhaseGate(0.5)
+    basic_phase_gate2 = _basics.BasicPhaseGate(1.0)
+    basic_phase_gate3 = _basics.BasicPhaseGate(1.5)
+    with pytest.raises(_basics.NotMergeable):
+        basic_phase_gate1.get_merged(basic_gate)
+    merged_gate = basic_phase_gate1.get_merged(basic_phase_gate2)
+    assert merged_gate == basic_phase_gate3
+
+
+def test_basic_phase_gate_comparison():
+    basic_phase_gate1 = _basics.BasicPhaseGate(0.5)
+    basic_phase_gate2 = _basics.BasicPhaseGate(0.5)
+    basic_phase_gate3 = _basics.BasicPhaseGate(0.5 + 2 * math.pi)
+    assert basic_phase_gate1 == basic_phase_gate2
+    assert basic_phase_gate1 == basic_phase_gate3
+    basic_phase_gate4 = _basics.BasicPhaseGate(0.50000001)
+    # Test __ne__:
+    assert basic_phase_gate4 != basic_phase_gate1
+    # Test one gate close to 2*pi the other one close to 0
+    basic_phase_gate5 = _basics.BasicPhaseGate(1.e-13)
+    basic_phase_gate6 = _basics.BasicPhaseGate(2 * math.pi - 1.e-13)
+    assert basic_phase_gate5 == basic_phase_gate6
+    # Test different types of gates
+    basic_gate = _basics.BasicGate()
+    assert not basic_gate == basic_phase_gate6
+    assert basic_phase_gate2 != _basics.BasicPhaseGate(0.5 + math.pi)
 
 
 def test_basic_math_gate():

--- a/projectq/ops/_command.py
+++ b/projectq/ops/_command.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_command.py
+++ b/projectq/ops/_command.py
@@ -311,6 +311,5 @@ class Command(object):
                 qstring += str(Qureg(qreg))
                 qstring += ", "
             qstring = qstring[:-2] + " )"
-        #qstring = convert_qubits_to_string(qubits)
         cstring = "C" * len(ctrlqubits)
         return cstring + str(self.gate) + " | " + qstring

--- a/projectq/ops/_command_test.py
+++ b/projectq/ops/_command_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_command_test.py
+++ b/projectq/ops/_command_test.py
@@ -233,6 +233,6 @@ def test_command_str():
     cmd = _command.Command(main_engine, Rx(0.5), (qubit,))
     cmd.tags = ["TestTag"]
     cmd.add_control_qubits(ctrl_qubit)
-    assert str(cmd) == "CRx(0.5) | ( Qubit[1], Qubit[0] )"
+    assert str(cmd) == "CRx(0.5) | ( Qureg[1], Qureg[0] )"
     cmd2 = _command.Command(main_engine, Rx(0.5), (qubit,))
-    assert str(cmd2) == "Rx(0.5) | Qubit[0]"
+    assert str(cmd2) == "Rx(0.5) | Qureg[0]"

--- a/projectq/ops/_gates.py
+++ b/projectq/ops/_gates.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
@@ -35,6 +37,7 @@ from projectq.ops import get_inverse
 from ._basics import (BasicGate,
                       SelfInverseGate,
                       BasicRotationGate,
+                      BasicPhaseGate,
                       ClassicalInstructionGate,
                       FastForwardingGate,
                       BasicMathGate)
@@ -145,7 +148,7 @@ class EntangleGate(BasicGate):
 Entangle = EntangleGate()
 
 
-class Ph(BasicRotationGate):
+class Ph(BasicPhaseGate):
     """ Phase gate (global phase) """
     @property
     def matrix(self):
@@ -181,7 +184,7 @@ class Rz(BasicRotationGate):
                           [0, cmath.exp(.5 * 1j * self._angle)]])
 
 
-class R(BasicRotationGate):
+class R(BasicPhaseGate):
     """ Phase-shift gate (equivalent to Rz up to a global phase) """
     @property
     def matrix(self):

--- a/projectq/ops/_gates_test.py
+++ b/projectq/ops/_gates_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
@@ -127,6 +129,31 @@ def test_rz(angle):
                                  [0, cmath.exp(.5 * 1j * angle)]])
     assert gate.matrix.shape == expected_matrix.shape
     assert np.allclose(gate.matrix, expected_matrix)
+
+
+@pytest.mark.parametrize("angle", [0, 0.2, 2.1, 4.1, 2 * math.pi])
+def test_ph(angle):
+    gate = _gates.Ph(angle)
+    gate2 = _gates.Ph(angle + 2 * math.pi)
+    expected_matrix = np.matrix([[cmath.exp(1j * angle), 0],
+                                 [0, cmath.exp(1j * angle)]])
+    assert gate.matrix.shape == expected_matrix.shape
+    assert np.allclose(gate.matrix, expected_matrix)
+    assert gate2.matrix.shape == expected_matrix.shape
+    assert np.allclose(gate2.matrix, expected_matrix)
+    assert gate == gate2
+
+
+@pytest.mark.parametrize("angle", [0, 0.2, 2.1, 4.1, 2 * math.pi])
+def test_r(angle):
+    gate = _gates.R(angle)
+    gate2 = _gates.R(angle + 2 * math.pi)
+    expected_matrix = np.matrix([[1, 0], [0, cmath.exp(1j * angle)]])
+    assert gate.matrix.shape == expected_matrix.shape
+    assert np.allclose(gate.matrix, expected_matrix)
+    assert gate2.matrix.shape == expected_matrix.shape
+    assert np.allclose(gate2.matrix, expected_matrix)
+    assert gate == gate2
 
 
 def test_flush_gate():

--- a/projectq/ops/_metagates.py
+++ b/projectq/ops/_metagates.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_metagates_test.py
+++ b/projectq/ops/_metagates_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_qftgate.py
+++ b/projectq/ops/_qftgate.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_qftgate_test.py
+++ b/projectq/ops/_qftgate_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_qubit_operator.py
+++ b/projectq/ops/_qubit_operator.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_qubit_operator.py
+++ b/projectq/ops/_qubit_operator.py
@@ -124,7 +124,7 @@ class QubitOperator(object):
                    be sorted by the qubit number. '' is the identity.
 
         Raises:
-          QubitOperatorError: Invalid operators provided to QubitOperator.
+            QubitOperatorError: Invalid operators provided to QubitOperator.
         """
         if not isinstance(coefficient, (int, float, complex)):
             raise ValueError('Coefficient must be a numeric type.')
@@ -229,7 +229,7 @@ class QubitOperator(object):
         In-place multiply (*=) terms with scalar or QubitOperator.
 
         Args:
-          multiplier(complex float, or QubitOperator): multiplier
+            multiplier(complex float, or QubitOperator): multiplier
         """
         # Handle scalars.
         if isinstance(multiplier, (int, float, complex)):
@@ -305,13 +305,13 @@ class QubitOperator(object):
         Return self * multiplier for a scalar, or a QubitOperator.
 
         Args:
-          multiplier: A scalar, or a QubitOperator.
+            multiplier: A scalar, or a QubitOperator.
 
         Returns:
-          product: A QubitOperator.
+            product: A QubitOperator.
 
         Raises:
-          TypeError: Invalid type cannot be multiply with QubitOperator.
+            TypeError: Invalid type cannot be multiply with QubitOperator.
         """
         if (isinstance(multiplier, (int, float, complex)) or
                 isinstance(multiplier, QubitOperator)):
@@ -331,13 +331,13 @@ class QubitOperator(object):
         is also queried as the default behavior.
 
         Args:
-          multiplier: A scalar to multiply by.
+            multiplier: A scalar to multiply by.
 
         Returns:
-          product: A new instance of QubitOperator.
+            product: A new instance of QubitOperator.
 
         Raises:
-          TypeError: Object of invalid type cannot multiply QubitOperator.
+            TypeError: Object of invalid type cannot multiply QubitOperator.
         """
         if not isinstance(multiplier, (int, float, complex)):
             raise TypeError(
@@ -352,14 +352,13 @@ class QubitOperator(object):
             This is always floating point division.
 
         Args:
-          divisor: A scalar to divide by.
+            divisor: A scalar to divide by.
 
         Returns:
-          A new instance of QubitOperator.
+            A new instance of QubitOperator.
 
         Raises:
-          TypeError: Cannot divide local operator by non-scalar type.
-
+            TypeError: Cannot divide local operator by non-scalar type.
         """
         if not isinstance(divisor, (int, float, complex)):
             raise TypeError('Cannot divide QubitOperator by non-scalar type.')
@@ -384,10 +383,10 @@ class QubitOperator(object):
         In-place method for += addition of QubitOperator.
 
         Args:
-          addend: A QubitOperator.
+            addend: A QubitOperator.
 
         Raises:
-          TypeError: Cannot add invalid type.
+            TypeError: Cannot add invalid type.
         """
         if isinstance(addend, QubitOperator):
             for term in addend.terms:
@@ -408,33 +407,34 @@ class QubitOperator(object):
         summand += addend
         return summand
 
-    def __sub__(self, subtrahend):
-        """
-        Return self - subtrahend for a QubitOperator.
-
-        Args:
-          addend: A QubitOperator.
-
-        Raises:
-          TypeError: Cannot add invalid type.
-        """
-        if not isinstance(subtrahend, QubitOperator):
-            raise TypeError('Cannot subtract invalid type to QubitOperator.')
-        return self + (-1. * subtrahend)
-
     def __isub__(self, subtrahend):
         """
-        In-place method for -= addition of QubitOperator.
+        In-place method for -= subtraction of QubitOperator.
 
         Args:
-          subtrahend: A QubitOperator.
+            subtrahend: A QubitOperator.
 
         Raises:
-          TypeError: Cannot add invalid type.
+            TypeError: Cannot subtract invalid type from QubitOperator.
         """
-        if not isinstance(subtrahend, QubitOperator):
-            raise TypeError('Cannot subtract invalid type to QubitOperator.')
-        return self.__iadd__(-1. * subtrahend)
+        if isinstance(subtrahend, QubitOperator):
+            for term in subtrahend.terms:
+                if term in self.terms:
+                    if abs(self.terms[term] - subtrahend.terms[term]) > 0.:
+                        self.terms[term] -= subtrahend.terms[term]
+                    else:
+                        del self.terms[term]
+                else:
+                    self.terms[term] = -subtrahend.terms[term]
+        else:
+            raise TypeError('Cannot subtract invalid type from QubitOperator.')
+        return self
+
+    def __sub__(self, subtrahend):
+        """ Return self - subtrahend for a QubitOperator. """
+        minuend = copy.deepcopy(self)
+        minuend -= subtrahend
+        return minuend
 
     def __neg__(self):
         return -1. * self

--- a/projectq/ops/_qubit_operator_test.py
+++ b/projectq/ops/_qubit_operator_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_qubit_operator_test.py
+++ b/projectq/ops/_qubit_operator_test.py
@@ -84,12 +84,12 @@ def test_init_bad_action():
 
 def test_init_bad_action_in_tuple():
     with pytest.raises(ValueError):
-        qubit_op = qo.QubitOperator(((1,'Q'),))
+        qubit_op = qo.QubitOperator(((1, 'Q'),))
 
 
 def test_init_bad_qubit_num_in_tuple():
     with pytest.raises(qo.QubitOperatorError):
-        qubit_op = qo.QubitOperator((("1",'X'),))
+        qubit_op = qo.QubitOperator((("1", 'X'),))
 
 
 def test_init_bad_tuple():
@@ -294,12 +294,16 @@ def test_rmul_bad_multiplier():
                          numpy.complex128(-1j), 2])
 def test_truediv_and_div(divisor):
     op = qo.QubitOperator(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+    op2 = copy.deepcopy(op)
     original = copy.deepcopy(op)
     res = op / divisor
+    res2 = op2.__div__(divisor)  # To test python 2 version as well
     correct = op * (1. / divisor)
     assert res.isclose(correct)
+    assert res2.isclose(correct)
     # Test if done out of place
     assert op.isclose(original)
+    assert op2.isclose(original)
 
 
 def test_truediv_bad_divisor():
@@ -312,12 +316,16 @@ def test_truediv_bad_divisor():
                          numpy.complex128(-1j), 2])
 def test_itruediv_and_idiv(divisor):
     op = qo.QubitOperator(((1, 'X'), (3, 'Y'), (8, 'Z')), 0.5)
+    op2 = copy.deepcopy(op)
     original = copy.deepcopy(op)
     correct = op * (1. / divisor)
     op /= divisor
+    op2.__idiv__(divisor)  # To test python 2 version as well
     assert op.isclose(correct)
+    assert op2.isclose(correct)
     # Test if done in-place
     assert not op.isclose(original)
+    assert not op2.isclose(original)
 
 
 def test_itruediv_bad_divisor():

--- a/projectq/ops/_shortcuts.py
+++ b/projectq/ops/_shortcuts.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_shortcuts_test.py
+++ b/projectq/ops/_shortcuts_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/ops/_time_evolution.py
+++ b/projectq/ops/_time_evolution.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at
@@ -35,7 +37,7 @@ class TimeEvolution(BasicGate):
     Example:
         .. code-block:: python
 
-            wavefuction = eng.allocate_qureg(5)
+            wavefunction = eng.allocate_qureg(5)
             hamiltonian = 0.5 * QubitOperator("X0 Z1 Y5")
             # Apply exp(-i * H * t) to the wavefunction:
             TimeEvolution(time=2.0, hamiltonian=hamiltonian) | wavefunction
@@ -161,7 +163,7 @@ class TimeEvolution(BasicGate):
 
         While in the above example the TimeEvolution gate is applied to 5
         qubits, the hamiltonian of this TimeEvolution gate acts only
-        non-trivially on the two qubits wavefuction[1] and wavefunction[3].
+        non-trivially on the two qubits wavefunction[1] and wavefunction[3].
         Therefore, the operator| will rescale the indices in the hamiltonian
         and sends the equivalent of the following new gate to the MainEngine:
 

--- a/projectq/ops/_time_evolution.py
+++ b/projectq/ops/_time_evolution.py
@@ -123,11 +123,11 @@ class TimeEvolution(BasicGate):
             factor = None
             for term in self.hamiltonian.terms:
                 if factor is None:
-                    factor = self.hamiltonian.terms[term] / float(
-                        other.hamiltonian.terms[term])
+                    factor = (self.hamiltonian.terms[term] /
+                              float(other.hamiltonian.terms[term]))
                 else:
-                    tmp = self.hamiltonian.terms[term] / float(
-                        other.hamiltonian.terms[term])
+                    tmp = (self.hamiltonian.terms[term] /
+                           float(other.hamiltonian.terms[term]))
                     if not abs(factor - tmp) <= (
                             rel_tol * max(abs(factor), abs(tmp))):
                         raise NotMergeable("Cannot merge these two gates.")

--- a/projectq/ops/_time_evolution.py
+++ b/projectq/ops/_time_evolution.py
@@ -74,7 +74,7 @@ class TimeEvolution(BasicGate):
         for term in hamiltonian.terms:
             if self.hamiltonian.terms[term].imag == 0:
                 self.hamiltonian.terms[term] = float(
-                    self.hamiltonian.terms[term])
+                    self.hamiltonian.terms[term].real)
             else:
                 raise NotHermitianOperatorError("hamiltonian must be "
                                                 "hermitian and hence only "

--- a/projectq/ops/_time_evolution_test.py
+++ b/projectq/ops/_time_evolution_test.py
@@ -69,8 +69,8 @@ def test_init_not_hermitian():
 def test_init_cast_complex_to_float():
     hamiltonian = QubitOperator("Z2", 2+0j)
     gate = te.TimeEvolution(1, hamiltonian)
-    assert isinstance(gate.hamiltonian.terms[((2,'Z'),)], float)
-    pytest.approx(gate.hamiltonian.terms[((2,'Z'),)]) == 2.0
+    assert isinstance(gate.hamiltonian.terms[((2, 'Z'),)], float)
+    pytest.approx(gate.hamiltonian.terms[((2, 'Z'),)]) == 2.0
 
 
 def test_init_negative_time():

--- a/projectq/ops/_time_evolution_test.py
+++ b/projectq/ops/_time_evolution_test.py
@@ -66,6 +66,13 @@ def test_init_not_hermitian():
         gate = te.TimeEvolution(1, hamiltonian)
 
 
+def test_init_cast_complex_to_float():
+    hamiltonian = QubitOperator("Z2", 2+0j)
+    gate = te.TimeEvolution(1, hamiltonian)
+    assert isinstance(gate.hamiltonian.terms[((2,'Z'),)], float)
+    pytest.approx(gate.hamiltonian.terms[((2,'Z'),)]) == 2.0
+
+
 def test_init_negative_time():
     hamiltonian = QubitOperator("Z2", 2)
     gate = te.TimeEvolution(-1, hamiltonian)

--- a/projectq/ops/_time_evolution_test.py
+++ b/projectq/ops/_time_evolution_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/__init__.py
+++ b/projectq/setups/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/__init__.py
+++ b/projectq/setups/decompositions/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/_gates_test.py
+++ b/projectq/setups/decompositions/_gates_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/crz2cxandrz.py
+++ b/projectq/setups/decompositions/crz2cxandrz.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/entangle.py
+++ b/projectq/setups/decompositions/entangle.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/globalphase.py
+++ b/projectq/setups/decompositions/globalphase.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/ph2r.py
+++ b/projectq/setups/decompositions/ph2r.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/qft2crandhadamard.py
+++ b/projectq/setups/decompositions/qft2crandhadamard.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/r2rzandph.py
+++ b/projectq/setups/decompositions/r2rzandph.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/swap2cnot.py
+++ b/projectq/setups/decompositions/swap2cnot.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/time_evolution.py
+++ b/projectq/setups/decompositions/time_evolution.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/time_evolution.py
+++ b/projectq/setups/decompositions/time_evolution.py
@@ -90,7 +90,7 @@ def _decompose_time_evolution_individual_terms(cmd):
     check_indices = set()
 
     # Check that hamiltonian is not identity term,
-    # Previous or operator should have apply a global phase instead:
+    # Previous __or__ operator should have apply a global phase instead:
     assert not term == ()
 
     # hamiltonian has only a single local operator

--- a/projectq/setups/decompositions/time_evolution_test.py
+++ b/projectq/setups/decompositions/time_evolution_test.py
@@ -178,14 +178,14 @@ def test_decompose_individual_terms():
         res = list_single_matrices[0]
         for i in range(1, len(list_single_matrices)):
             res = sps.kron(res, list_single_matrices[i])
-        return res
+        return res.tocsc()
 
-    id_sp = sps.identity(2, format="csr", dtype=complex)
-    x_sp = sps.csr_matrix([[0., 1.], [1., 0.]], dtype=complex)
-    y_sp = sps.csr_matrix([[0., -1.j], [1.j, 0.]], dtype=complex)
-    z_sp = sps.csr_matrix([[1., 0.], [0., -1.]], dtype=complex)
+    id_sp = sps.identity(2, format="csc", dtype=complex)
+    x_sp = sps.csc_matrix([[0., 1.], [1., 0.]], dtype=complex)
+    y_sp = sps.csc_matrix([[0., -1.j], [1.j, 0.]], dtype=complex)
+    z_sp = sps.csc_matrix([[1., 0.], [0., -1.]], dtype=complex)
 
-    matrix1 = (sps.identity(2**5, format="csr", dtype=complex) * 0.6 *
+    matrix1 = (sps.identity(2**5, format="csc", dtype=complex) * 0.6 *
                1.1 * -1.0j)
     step1 = scipy.sparse.linalg.expm(matrix1).dot(init_wavefunction)
     assert numpy.allclose(step1, final_wavefunction1)

--- a/projectq/setups/decompositions/time_evolution_test.py
+++ b/projectq/setups/decompositions/time_evolution_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/decompositions/toffoli2cnotandtgate.py
+++ b/projectq/setups/decompositions/toffoli2cnotandtgate.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/default.py
+++ b/projectq/setups/default.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/ibm.py
+++ b/projectq/setups/ibm.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/ibm_test.py
+++ b/projectq/setups/ibm_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/setups/ibm_test.py
+++ b/projectq/setups/ibm_test.py
@@ -9,24 +9,20 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+"""Tests for projectq.setup.ibm."""
 
-"""Tests for projectq.meta._qubitplacement.py"""
-
-from projectq.meta import ComputeTag
-
-from projectq.meta._qubitplacement import QubitPlacementTag
+import projectq
+from projectq import MainEngine
+from projectq.cengines import IBMCNOTMapper
 
 
-def test_qubit_placement_tag():
-    tag0 = QubitPlacementTag(0)
-    tag1 = QubitPlacementTag(0)
-    tag2 = QubitPlacementTag(2)
-    tag3 = ComputeTag()
-    assert tag0 == tag1
-    assert not tag0 == tag2
-    assert not tag0 == tag3
-    assert not tag3 == tag2
-    assert not tag0 != tag1
-    assert tag0 != tag2
-    assert tag0 != tag3
-    assert tag3 != tag2
+def test_ibm_cnot_mapper_in_cengines():
+    import projectq.setups.ibm
+    found = False
+    for engine in projectq.setups.ibm.ibm_default_engines():
+        if isinstance(engine, IBMCNOTMapper):
+            found = True
+    # To undo the changes of loading the IBM setup:
+    import projectq.setups.default
+    projectq.default_engines = projectq.setups.default.default_engines
+    assert found

--- a/projectq/tests/__init__.py
+++ b/projectq/tests/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/tests/_factoring_test.py
+++ b/projectq/tests/_factoring_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/types/__init__.py
+++ b/projectq/types/__init__.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -210,10 +210,27 @@ class Qureg(list):
         """
         Get string representation of a quantum register.
         """
-        if len(self) == 1:
-            return "Qubit[" + str(self[0]) + "]"
-        else:
-            return "Qureg" + str([q.id for q in self])
+        if len(self) == 0:
+            return "Qureg[]"
+
+        ids = [q.id for q in self[1:]]
+        ids.append(None)  # Forces a flush on last loop iteration.
+
+        out_list = []
+        start_id = self[0].id
+        count = 1
+        for qubit_id in ids:
+            if qubit_id == start_id + count:
+                count += 1
+                continue
+
+            out_list.append('{}-{}'.format(start_id, start_id + count - 1)
+                            if count > 1
+                            else '{}'.format(start_id))
+            start_id = qubit_id
+            count = 1
+
+        return "Qureg[{}]".format(', '.join(out_list))
 
     @property
     def engine(self):

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -1,3 +1,5 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
 #   You may obtain a copy of the License at

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -125,15 +125,26 @@ def test_weak_qubit_ref():
         qubit.__del__()
 
 
-@pytest.mark.parametrize("qubit_ids, expected",
-                         [([10], "Qubit[10]"), ([1, 2, 3], "Qureg[1, 2, 3]")])
-def test_qureg(qubit_ids, expected):
-    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
-    qureg = _qubit.Qureg()
-    for qubit_id in qubit_ids:
-        qubit = _qubit.Qubit(eng, qubit_id)
-        qureg.append(qubit)
-    assert str(qureg) == expected
+def test_qureg_str():
+    assert str(_qubit.Qureg([])) == 'Qureg[]'
+    eng = MainEngine(backend=DummyEngine(), engine_list=[])
+    a = eng.allocate_qureg(10)
+    b = eng.allocate_qureg(50)
+    c = eng.allocate_qubit()
+    d = eng.allocate_qubit()
+    e = eng.allocate_qubit()
+    assert str(a) == 'Qureg[0-9]'
+    assert str(b) == 'Qureg[10-59]'
+    assert str(c) == 'Qureg[60]'
+    assert str(d) == 'Qureg[61]'
+    assert str(e) == 'Qureg[62]'
+    assert str(_qubit.Qureg(c + e)) == 'Qureg[60, 62]'
+    assert str(_qubit.Qureg(a + b)) == 'Qureg[0-59]'
+    assert str(_qubit.Qureg(a + b + c)) == 'Qureg[0-60]'
+    assert str(_qubit.Qureg(a + b + d)) == 'Qureg[0-59, 61]'
+    assert str(_qubit.Qureg(a + b + e)) == 'Qureg[0-59, 62]'
+    assert str(_qubit.Qureg(b + a)) == 'Qureg[10-59, 0-9]'
+    assert str(_qubit.Qureg(e + b + a)) == 'Qureg[62, 10-59, 0-9]'
 
 
 def test_qureg_measure_if_qubit():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 future
-pytest>=3.0
-pybind11>=1.7
+pytest>=3.1
+pybind11>=1.7,<2.2.0
 requests
 scipy

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,11 @@ exec(open('projectq/_version.py').read())
 # Readme file as long_description:
 long_description = open('README.rst').read()
 
+# Read in requirements.txt
+with open ('requirements.txt', 'r') as f_requirements:
+    requirements = f_requirements.readlines()
+requirements = [r.strip() for r in requirements]
+
 
 class get_pybind_include(object):
     """Helper class to determine the pybind11 include path
@@ -159,8 +164,7 @@ setup(
                  'An open source software framework for quantum computing'),
     long_description=long_description,
     features={'cppsimulator': cppsim},
-    install_requires=['numpy', 'future', 'pytest>=3.0',
-                      'pybind11>=1.7', 'requests'],
+    install_requires=requirements,
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
     license='Apache 2',

--- a/setup.py
+++ b/setup.py
@@ -113,8 +113,8 @@ class BuildExt(build_ext):
         openmp = ''
         if has_flag(self.compiler, '-fopenmp'):
             openmp = '-fopenmp'
-        elif has_flag(self.compiler, '-openmp'):
-            openmp = '-openmp'
+        elif has_flag(self.compiler, '-qopenmp'):
+            openmp = '-qopenmp'
         if ct == 'msvc':
             openmp = ''  # supports only OpenMP 2.0
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ exec(open('projectq/_version.py').read())
 long_description = open('README.rst').read()
 
 # Read in requirements.txt
-with open ('requirements.txt', 'r') as f_requirements:
+with open('requirements.txt', 'r') as f_requirements:
     requirements = f_requirements.readlines()
 requirements = [r.strip() for r in requirements]
 


### PR DESCRIPTION
* If `AutoReplacer` doesn't find a decomposition rule for a gate class, it checks if there are decomposition rules for the parent classes which might work
* Important change for rules which only require a gate matrix and hence the rule works for all `BasicGate` instances
* Simplifies the code for Compute

(This is a clean up PR of #150 and #97)