### PR TITLE
Allow newer versions of pybind11 (bug has been fixed).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 future
 pytest>=3.1
-pybind11>=1.7,<2.2.0
+pybind11>=1.7,!=2.2.0
 requests
 scipy


### PR DESCRIPTION
See #144 