### PR TITLE
Update to new API for getting the backend status.

### DIFF
--- a/examples/ibm.py
+++ b/examples/ibm.py
@@ -39,6 +39,6 @@ def run_entangle(eng, num_qubits=5):
 if __name__ == "__main__":
     # create main compiler engine for the IBM back-end
     eng = MainEngine(IBMBackend(use_hardware=True, num_runs=1024,
-                                verbose=False))
+                                verbose=False, device='ibmqx4'))
     # run the circuit and print the result
     print(run_entangle(eng))

--- a/examples/ibm_entangle.ipynb
+++ b/examples/ibm_entangle.ipynb
@@ -57,7 +57,7 @@
    },
    "outputs": [],
    "source": [
-    "engine = MainEngine(IBMBackend(use_hardware=True, num_runs=1024, verbose=True))\n",
+    "engine = MainEngine(IBMBackend(use_hardware=True, num_runs=1024, verbose=True, device='ibmqx4'))\n",
     "qureg = engine.allocate_qureg(3)"
    ]
   },
@@ -111,19 +111,19 @@
      "output_type": "stream",
      "text": [
       "Authenticating...\n",
-      "IBM QE user (e-mail) > dsteiger@phys.ethz.ch\n",
+      "IBM QE user (e-mail) > haenert@phys.ethz.ch\n",
       "IBM QE password > ········\n",
       "Running code...\n",
       "Waiting for results...\n",
       "Done.\n",
-      "00000 with p = 0.4677734375*\n",
+      "00000 with p = 0.4814453125\n",
       "10000 with p = 0.00390625\n",
-      "01000 with p = 0.009765625\n",
-      "11000 with p = 0.0224609375\n",
-      "00100 with p = 0.005859375\n",
-      "10100 with p = 0.0263671875\n",
-      "01100 with p = 0.0322265625\n",
-      "11100 with p = 0.431640625\n"
+      "01000 with p = 0.0087890625\n",
+      "11000 with p = 0.0205078125\n",
+      "00100 with p = 0.02734375\n",
+      "10100 with p = 0.046875\n",
+      "01100 with p = 0.04296875\n",
+      "11100 with p = 0.3681640625*\n"
      ]
     }
    ],
@@ -155,7 +155,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[0, 0, 0]\n"
+      "[1, 1, 1]\n"
      ]
     }
    ],
@@ -239,24 +239,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Allocate | Qubit[0]\n",
-      "Allocate | Qubit[1]\n",
-      "H | Qubit[1]\n",
-      "CX | ( Qubit[1], Qubit[0] )\n",
-      "Allocate | Qubit[2]\n",
-      "H | Qubit[2]\n",
-      "CX | ( Qubit[2], Qubit[0] )\n",
-      "Allocate | Qubit[3]\n",
-      "H | Qubit[3]\n",
-      "CX | ( Qubit[3], Qubit[0] )\n",
-      "Allocate | Qubit[4]\n",
-      "H | Qubit[4]\n",
-      "CX | ( Qubit[4], Qubit[0] )\n",
-      "H | Qubit[0]\n",
-      "H | Qubit[1]\n",
-      "H | Qubit[2]\n",
-      "H | Qubit[3]\n",
-      "H | Qubit[4]\n"
+      "Allocate | Qureg[0]\n",
+      "Allocate | Qureg[1]\n",
+      "H | Qureg[1]\n",
+      "CX | ( Qureg[1], Qureg[0] )\n",
+      "Allocate | Qureg[2]\n",
+      "H | Qureg[2]\n",
+      "CX | ( Qureg[2], Qureg[0] )\n",
+      "Allocate | Qureg[3]\n",
+      "H | Qureg[3]\n",
+      "CX | ( Qureg[3], Qureg[0] )\n",
+      "Allocate | Qureg[4]\n",
+      "H | Qureg[4]\n",
+      "CX | ( Qureg[4], Qureg[0] )\n",
+      "H | Qureg[0]\n",
+      "H | Qureg[1]\n",
+      "H | Qureg[2]\n",
+      "H | Qureg[3]\n",
+      "H | Qureg[4]\n"
      ]
     }
    ],
@@ -370,15 +370,6 @@
    "source": [
     "print([int(q) for q in qureg3])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -397,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/projectq/backends/_ibm/_ibm.py
+++ b/projectq/backends/_ibm/_ibm.py
@@ -41,7 +41,7 @@ class IBMBackend(BasicEngine):
     QASM, and sends the circuit through the IBM API.
     """
     def __init__(self, use_hardware=False, num_runs=1024, verbose=False,
-                 user=None, password=None):
+                 user=None, password=None, device='ibmqx2'):
         """
         Initialize the Backend object.
 
@@ -55,13 +55,15 @@ class IBMBackend(BasicEngine):
                 circuit).
             user (string): IBM Quantum Experience user name
             password (string): IBM Quantum Experience password
+            device (string): Device to use ('ibmqx2' or 'ibmqx4') if
+                use_hardware is set to True. Default is ibmqx2.
         """
         BasicEngine.__init__(self)
         self._reset()
         if use_hardware:
-            self._device = 'real'
+            self.device = device
         else:
-            self._device = 'sim_trivial_2'
+            self.device = 'sim_trivial_2'
         self._num_runs = num_runs
         self._verbose = verbose
         self._user = user
@@ -207,7 +209,7 @@ class IBMBackend(BasicEngine):
         info = json.dumps(info)
 
         try:
-            res = send(info, device=self._device,
+            res = send(info, device=self.device,
                        user=self._user, password=self._password,
                        shots=self._num_runs, verbose=self._verbose)
 

--- a/projectq/backends/_ibm/_ibm_http_client.py
+++ b/projectq/backends/_ibm/_ibm_http_client.py
@@ -47,7 +47,7 @@ def send(qasm, device='sim_trivial_2', user=None, password=None,
     """
     try:
         # check if the device is online
-        if device in ['ibmqx2', 'ibmqx3']:
+        if device in ['ibmqx2', 'ibmqx4']:
             url = 'Backends/{}/queue/status'.format(device)
             r = requests.get(urljoin(_api_url_status, url))
             online = r.json()['state']
@@ -125,7 +125,7 @@ def _run(qasm, device, user_id, access_token, shots):
     return execution_id
 
 
-def _get_result(execution_id, access_token, num_retries=100, interval=1):
+def _get_result(execution_id, access_token, num_retries=300, interval=1):
     suffix = 'Executions/{execution_id}'.format(execution_id=execution_id)
 
     for _ in range(num_retries):

--- a/projectq/backends/_ibm/_ibm_http_client.py
+++ b/projectq/backends/_ibm/_ibm_http_client.py
@@ -48,8 +48,8 @@ def send(qasm, device='sim_trivial_2', user=None, password=None,
     try:
         # check if the device is online
         if device == 'real':
-            r = requests.get(urljoin(_api_url_status, 'Status/queue'),
-                             params={"device": "chip_real"})
+            url = 'Backends/ibmqx2/queue/status'
+            r = requests.get(urljoin(_api_url_status, url))
             online = r.json()['state']
 
             if not online:

--- a/projectq/backends/_ibm/_ibm_http_client.py
+++ b/projectq/backends/_ibm/_ibm_http_client.py
@@ -47,8 +47,8 @@ def send(qasm, device='sim_trivial_2', user=None, password=None,
     """
     try:
         # check if the device is online
-        if device == 'real':
-            url = 'Backends/ibmqx2/queue/status'
+        if device in ['ibmqx2', 'ibmqx3']:
+            url = 'Backends/{}/queue/status'.format(device)
             r = requests.get(urljoin(_api_url_status, url))
             online = r.json()['state']
 
@@ -56,6 +56,8 @@ def send(qasm, device='sim_trivial_2', user=None, password=None,
                 print("The device is offline (for maintenance?). Use the "
                       "simulator instead or try again later.")
                 raise DeviceOfflineError("Device is offline.")
+            if device == 'ibmqx2':
+                device = 'real'
 
         if verbose:
             print("Authenticating...")

--- a/projectq/backends/_ibm/_ibm_http_client_test.py
+++ b/projectq/backends/_ibm/_ibm_http_client_test.py
@@ -68,8 +68,8 @@ def test_send_real_device_online_verbose(monkeypatch):
                 pass
 
         # Accessing status of device. Return online.
-        if (args[0] == urljoin(_api_url_status, "Status/queue") and
-           kwargs["params"]["device"] == "chip_real" and
+        status_url = 'Backends/ibmqx2/queue/status'
+        if (args[0] == urljoin(_api_url_status, status_url) and
            request_num[0] == 0):
             request_num[0] += 1
             return MockResponse({"state": True}, 200)
@@ -160,8 +160,8 @@ def test_send_real_device_offline(monkeypatch):
                 return self.json_data
 
         # Accessing status of device. Return online.
-        if (args[0] == urljoin(_api_url_status, "Status/queue") and
-           kwargs["params"]["device"] == "chip_real"):
+        status_url = 'Backends/ibmqx2/queue/status'
+        if args[0] == urljoin(_api_url_status, status_url):
             return MockResponse({"state": False}, 200)
     monkeypatch.setattr("requests.get", mocked_requests_get)
     shots = 1
@@ -185,8 +185,8 @@ def test_send_that_errors_are_caught(monkeypatch):
                 return self.json_data
 
         # Accessing status of device. Return online.
-        if (args[0] == urljoin(_api_url_status, "Status/queue") and
-           kwargs["params"]["device"] == "chip_real"):
+        status_url = 'Backends/ibmqx2/queue/status'
+        if args[0] == urljoin(_api_url_status, status_url):
             return MockResponse({"state": True}, 200)
 
     def mocked_requests_post(*args, **kwargs):
@@ -226,8 +226,8 @@ def test_send_that_errors_are_caught2(monkeypatch):
                 return self.json_data
 
         # Accessing status of device. Return online.
-        if (args[0] == urljoin(_api_url_status, "Status/queue") and
-           kwargs["params"]["device"] == "chip_real"):
+        status_url = 'Backends/ibmqx2/queue/status'
+        if args[0] == urljoin(_api_url_status, status_url):
             return MockResponse({"state": True}, 200)
 
     def mocked_requests_post(*args, **kwargs):
@@ -267,8 +267,8 @@ def test_send_that_errors_are_caught3(monkeypatch):
                 return self.json_data
 
         # Accessing status of device. Return online.
-        if (args[0] == urljoin(_api_url_status, "Status/queue") and
-           kwargs["params"]["device"] == "chip_real"):
+        status_url = 'Backends/ibmqx2/queue/status'
+        if args[0] == urljoin(_api_url_status, status_url):
             return MockResponse({"state": True}, 200)
 
     def mocked_requests_post(*args, **kwargs):

--- a/projectq/backends/_ibm/_ibm_http_client_test.py
+++ b/projectq/backends/_ibm/_ibm_http_client_test.py
@@ -123,8 +123,6 @@ def test_send_real_device_online_verbose(monkeypatch):
                 request_num[0] == 2):
             request_num[0] += 1
             return MockPostResponse({"id": execution_id})
-        else:
-            print(kwargs)
 
     monkeypatch.setattr("requests.get", mocked_requests_get)
     monkeypatch.setattr("requests.post", mocked_requests_post)
@@ -210,7 +208,7 @@ def test_send_that_errors_are_caught(monkeypatch):
     json_qasm = "my_json_qasm"
     name = 'projectq_test'
     _ibm_http_client.send(json_qasm,
-                          device="real",
+                          device="ibmqx2",
                           user=None, password=None,
                           shots=shots, verbose=True)
 
@@ -251,7 +249,7 @@ def test_send_that_errors_are_caught2(monkeypatch):
     json_qasm = "my_json_qasm"
     name = 'projectq_test'
     _ibm_http_client.send(json_qasm,
-                          device="real",
+                          device="ibmqx2",
                           user=None, password=None,
                           shots=shots, verbose=True)
 
@@ -292,6 +290,6 @@ def test_send_that_errors_are_caught3(monkeypatch):
     json_qasm = "my_json_qasm"
     name = 'projectq_test'
     _ibm_http_client.send(json_qasm,
-                          device="real",
+                          device="ibmqx2",
                           user=None, password=None,
                           shots=shots, verbose=True)

--- a/projectq/backends/_ibm/_ibm_http_client_test.py
+++ b/projectq/backends/_ibm/_ibm_http_client_test.py
@@ -142,7 +142,7 @@ def test_send_real_device_online_verbose(monkeypatch):
 
     # Code to test:
     res = _ibm_http_client.send(json_qasm,
-                                device="real",
+                                device="ibmqx2",
                                 user=None, password=None,
                                 shots=shots, verbose=True)
     print(res)
@@ -169,21 +169,21 @@ def test_send_real_device_offline(monkeypatch):
     name = 'projectq_test'
     with pytest.raises(_ibm_http_client.DeviceOfflineError):
         _ibm_http_client.send(json_qasm,
-                              device="real",
+                              device="ibmqx2",
                               user=None, password=None,
                               shots=shots, verbose=True)
 
 
 def test_send_that_errors_are_caught(monkeypatch):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
     def mocked_requests_get(*args, **kwargs):
-        class MockResponse:
-            def __init__(self, json_data, status_code):
-                self.json_data = json_data
-                self.status_code = status_code
-
-            def json(self):
-                return self.json_data
-
         # Accessing status of device. Return online.
         status_url = 'Backends/ibmqx2/queue/status'
         if args[0] == urljoin(_api_url_status, status_url):

--- a/projectq/cengines/_ibmcnotmapper_test.py
+++ b/projectq/cengines/_ibmcnotmapper_test.py
@@ -90,6 +90,7 @@ def test_ibmcnotmapper_valid_circuit2():
 
 def test_ibmcnotmapper_valid_circuit2_ibmqx4():
     backend = DummyEngine(save_commands=True)
+
     class FakeIBMBackend(IBMBackend):
         pass
 
@@ -117,6 +118,7 @@ def test_ibmcnotmapper_valid_circuit2_ibmqx4():
 
 def test_ibmcnotmapper_deviceexception():
     backend = DummyEngine(save_commands=True)
+
     class FakeIBMBackend(IBMBackend):
         pass
 

--- a/projectq/cengines/_ibmcnotmapper_test.py
+++ b/projectq/cengines/_ibmcnotmapper_test.py
@@ -21,6 +21,7 @@ from projectq.cengines import DummyEngine
 from projectq.ops import H, CNOT, X, Measure
 
 from projectq.cengines import _ibmcnotmapper
+from projectq.backends import IBMBackend
 
 
 def test_ibmcnotmapper_is_available(monkeypatch):
@@ -84,6 +85,55 @@ def test_ibmcnotmapper_valid_circuit2():
     CNOT | (qb1, qb2)
     CNOT | (qb0, qb4)
     CNOT | (qb2, qb1)
+    eng.flush()
+
+
+def test_ibmcnotmapper_valid_circuit2_ibmqx4():
+    backend = DummyEngine(save_commands=True)
+    class FakeIBMBackend(IBMBackend):
+        pass
+
+    fake = FakeIBMBackend(device='ibmqx4', use_hardware=True)
+    fake.receive = backend.receive
+    fake.is_available = backend.is_available
+    backend.is_last_engine = True
+
+    eng = MainEngine(backend=fake,
+                     engine_list=[_ibmcnotmapper.IBMCNOTMapper()])
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+    qb2 = eng.allocate_qubit()
+    qb3 = eng.allocate_qubit()
+    qb4 = eng.allocate_qubit()
+    CNOT | (qb3, qb1)
+    CNOT | (qb3, qb2)
+    CNOT | (qb3, qb0)
+    CNOT | (qb3, qb4)
+    CNOT | (qb1, qb2)
+    CNOT | (qb0, qb4)
+    CNOT | (qb2, qb1)
+    eng.flush()
+
+
+def test_ibmcnotmapper_deviceexception():
+    backend = DummyEngine(save_commands=True)
+    class FakeIBMBackend(IBMBackend):
+        pass
+
+    fake = FakeIBMBackend(device='ibmqx5', use_hardware=True)
+    fake.receive = backend.receive
+    fake.is_available = backend.is_available
+    backend.is_last_engine = True
+
+    eng = MainEngine(backend=fake,
+                     engine_list=[_ibmcnotmapper.IBMCNOTMapper()])
+    qb0 = eng.allocate_qubit()
+    qb1 = eng.allocate_qubit()
+    CNOT | (qb0, qb1)
+    with pytest.raises(Exception):
+        eng.flush()
+    fake.device = 'ibmqx4'
+    CNOT | (qb0, qb1)
     eng.flush()
 
 


### PR DESCRIPTION
Apparently, the old way of querying the status is no longer supported. This PR should fix this issue (see #170).
We'll have to wait until ibmqx2 is online again to test if it actually works **before** merging though.