### PR TITLE
Add simulator exception for incompatible gate size/qubit count.

### DIFF
--- a/projectq/backends/_sim/_simulator.py
+++ b/projectq/backends/_sim/_simulator.py
@@ -18,6 +18,7 @@ built first. If the c++ simulator is not exported to python, a (slow) python
 implementation is used as an alternative.
 """
 
+import math
 import random
 from projectq.cengines import BasicEngine
 from projectq.meta import get_control_count
@@ -328,6 +329,12 @@ class Simulator(BasicEngine):
         elif len(cmd.gate.matrix) <= 2 ** 5:
             matrix = cmd.gate.matrix
             ids = [qb.id for qr in cmd.qubits for qb in qr]
+            if not 2 ** len(ids) == len(cmd.gate.matrix):
+                raise Exception("Simulator: Error applying {} gate: "
+                                "{}-qubit gate applied to {} qubits.".format(
+                                    str(cmd.gate),
+                                    int(math.log(len(cmd.gate.matrix), 2)),
+                                    len(ids)))
             self._simulator.apply_controlled_gate(matrix.tolist(),
                                                   ids,
                                                   [qb.id for qb in

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -247,6 +247,26 @@ def test_simulator_kqubit_gate(sim):
         LargerGate() | (qureg + qubit)
 
 
+def test_simulator_kqubit_exception(sim):
+    m1 = Rx(0.3).matrix
+    m2 = Rx(0.8).matrix
+    m3 = Ry(0.1).matrix
+    m4 = Rz(0.9).matrix.dot(Ry(-0.1).matrix)
+    m = numpy.kron(m4, numpy.kron(m3, numpy.kron(m2, m1)))
+
+    class KQubitGate(BasicGate):
+        @property
+        def matrix(self):
+            return m
+
+    eng = MainEngine(sim, [])
+    qureg = eng.allocate_qureg(3)
+    with pytest.raises(Exception):
+        KQubitGate() | qureg
+    with pytest.raises(Exception):
+        H | qureg
+
+
 def test_simulator_probability(sim):
     eng = MainEngine(sim)
     qubits = eng.allocate_qureg(6)


### PR DESCRIPTION
Addresses #175 by raising an exception when the number of qubits does not agree with the size of the gate matrix.