### PR TITLE
Fix possible infinite recursion loop and drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,6 @@ matrix:
         packages: ['gcc-4.9', 'g++-4.9']
     env: CC=gcc-4.9 CXX=g++-4.9 PYTHON=2.7
   - os: linux
-    python: "3.3"
-    addons:
-      apt:
-        sources: ['ubuntu-toolchain-r-test']
-        packages: ['gcc-4.9', 'g++-4.9']
-    env: CC=gcc-4.9 CXX=g++-4.9 PYTHON=3.3
-  - os: linux
     python: "3.4"
     addons:
       apt:

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ ProjectQ - An open source software framework for quantum computing
 .. image:: https://badge.fury.io/py/projectq.svg
     :target: https://badge.fury.io/py/projectq
     
-.. image:: https://img.shields.io/badge/python-2.7%2C%203.3%2C%203.4%2C%203.5%2C%203.6-brightgreen.svg
+.. image:: https://img.shields.io/badge/python-2.7%2C%203.4%2C%203.5%2C%203.6-brightgreen.svg
 
 
 ProjectQ is an open source effort for quantum computing.

--- a/projectq/setups/decompositions/arb1qubit2rzandry.py
+++ b/projectq/setups/decompositions/arb1qubit2rzandry.py
@@ -34,7 +34,7 @@ import math
 import numpy
 
 from projectq.cengines import DecompositionRule
-from projectq.meta import Control
+from projectq.meta import Control, get_control_count
 from projectq.ops import BasicGate, Ph, Ry, Rz
 
 
@@ -42,10 +42,16 @@ TOLERANCE = 1e-12
 
 
 def _recognize_arb1qubit(cmd):
-    """ Recognize an arbitrary one qubit gate which has a matrix property."""
+    """ 
+    Recognize an arbitrary one qubit gate which has a matrix property.
+
+    It does not allow gates which have control qubits as otherwise the
+    AutoReplacer might go into an infinite loop. Use
+    carb1qubit2cnotrzandry instead.
+    """
     try:
         m = cmd.gate.matrix
-        if len(m) == 2:
+        if len(m) == 2 and get_control_count(cmd) == 0:
             return True
         else:
             return False

--- a/projectq/setups/decompositions/arb1qubit2rzandry_test.py
+++ b/projectq/setups/decompositions/arb1qubit2rzandry_test.py
@@ -25,6 +25,7 @@ from projectq.cengines import (AutoReplacer, DecompositionRuleSet,
                                DummyEngine, InstructionFilter, MainEngine)
 from projectq.ops import (BasicGate, ClassicalInstructionGate, Measure, Ph, R,
                           Rx, Ry, Rz, X)
+from projectq.meta import Control
 
 from . import arb1qubit2rzandry as arb1q
 
@@ -54,6 +55,10 @@ def test_recognize_incorrect_gates():
     two_qubit_gate.matrix = [[1, 0, 0, 0], [0, 1, 0, 0],
                              [0, 0, 1, 0], [0, 0, 0, 1]]
     two_qubit_gate | qubit
+    # Controlled single qubit gate:
+    ctrl_qubit = eng.allocate_qubit()
+    with Control(eng, ctrl_qubit):
+        Rz(0.1) | qubit
     eng.flush(deallocate_qubits=True)
     for cmd in saving_backend.received_commands:
         assert not arb1q._recognize_arb1qubit(cmd)


### PR DESCRIPTION
* Removes Python3.3 from the supported Python versions because other packages such as pytest don't work on Python3.3 anymore

* Fixes an infinite recursion loop when decomposing gates