### PR TITLE
Define hash for Gates, use Gate objects as keys in ResourceCounter

### DIFF
--- a/projectq/backends/_resource.py
+++ b/projectq/backends/_resource.py
@@ -77,12 +77,12 @@ class ResourceCounter(BasicEngine):
         self.max_width = max(self.max_width, self._active_qubits)
 
         ctrl_cnt = get_control_count(cmd)
-        gate_name = ctrl_cnt * "C" + str(cmd.gate)
+        gate_description = (cmd.gate, ctrl_cnt)
 
         try:
-            self.gate_counts[gate_name] += 1
+            self.gate_counts[gate_description] += 1
         except KeyError:
-            self.gate_counts[gate_name] = 1
+            self.gate_counts[gate_description] = 1
 
     def __str__(self):
         """
@@ -95,8 +95,10 @@ class ResourceCounter(BasicEngine):
         """
         if len(self.gate_counts) > 0:
             gate_list = []
-            for gate, num in self.gate_counts.items():
-                gate_list.append(gate + " : " + str(num))
+            for gate_description, num in self.gate_counts.items():
+                gate, ctrl_cnt = gate_description
+                gate_name = ctrl_cnt * "C" + str(gate)
+                gate_list.append(gate_name + " : " + str(num))
             return ("\n".join(list(sorted(gate_list))) +
                     "\n\nMax. width (number of qubits) : " +
                     str(self.max_width) + ".")

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -260,11 +260,9 @@ class BasicRotationGate(BasicGate):
 
             [CLASSNAME]([ANGLE])
         """
-        rounded_angle = round(self.angle, EQ_PRECISION - 1)
-        if (rounded_angle < EQ_TOLERANCE or
-                rounded_angle > 4 * math.pi - EQ_TOLERANCE): 
+        rounded_angle = round(self.angle, EQ_PRECISION)
+        if rounded_angle > 4 * math.pi - EQ_TOLERANCE:
             rounded_angle = 0.
-
         return str(self.__class__.__name__) + "(" + str(rounded_angle) + ")"
 
     def tex_str(self):
@@ -277,11 +275,9 @@ class BasicRotationGate(BasicGate):
 
             [CLASSNAME]$_[ANGLE]$
         """
-        rounded_angle = round(self.angle, EQ_PRECISION - 1)
-        if (rounded_angle < EQ_TOLERANCE or
-                rounded_angle > 4 * math.pi - EQ_TOLERANCE): 
+        rounded_angle = round(self.angle, EQ_PRECISION)
+        if rounded_angle > 4 * math.pi - EQ_TOLERANCE:
             rounded_angle = 0.
-
         return str(self.__class__.__name__) + "$_{" + str(rounded_angle) + "}$"
 
     def get_inverse(self):
@@ -317,13 +313,16 @@ class BasicRotationGate(BasicGate):
 
     def __eq__(self, other):
         """ Return True if same class and same rotation angle. """
-        tolerance = EQ_TOLERANCE
         if isinstance(other, self.__class__):
-            difference = abs(self.angle - other.angle) % (4 * math.pi)
-            # Return True if angles are close to each other modulo 4 * pi
-            if difference < tolerance or difference > 4 * math.pi - tolerance:
-                return True
-        return False
+            self_rounded_angle = round(self.angle, EQ_PRECISION)
+            if self_rounded_angle > 4 * math.pi - EQ_TOLERANCE:
+                self_rounded_angle = 0.
+            other_rounded_angle = round(other.angle, EQ_PRECISION)
+            if other_rounded_angle > 4 * math.pi - EQ_TOLERANCE:
+                other_rounded_angle = 0.
+            return self_rounded_angle == other_rounded_angle
+        else:
+            return False
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -362,11 +361,9 @@ class BasicPhaseGate(BasicGate):
 
             [CLASSNAME]([ANGLE])
         """
-        rounded_angle = round(self.angle, EQ_PRECISION - 1)
-        if (rounded_angle < EQ_TOLERANCE or
-                rounded_angle > 2 * math.pi - EQ_TOLERANCE): 
+        rounded_angle = round(self.angle, EQ_PRECISION)
+        if rounded_angle > 2 * math.pi - EQ_TOLERANCE:
             rounded_angle = 0.
-
         return str(self.__class__.__name__) + "(" + str(rounded_angle) + ")"
 
     def tex_str(self):
@@ -379,11 +376,9 @@ class BasicPhaseGate(BasicGate):
 
             [CLASSNAME]$_[ANGLE]$
         """
-        rounded_angle = round(self.angle, EQ_PRECISION - 1)
-        if (rounded_angle < EQ_TOLERANCE or
-                rounded_angle > 2 * math.pi - EQ_TOLERANCE): 
+        rounded_angle = round(self.angle, EQ_PRECISION)
+        if rounded_angle > 2 * math.pi - EQ_TOLERANCE:
             rounded_angle = 0.
-
         return str(self.__class__.__name__) + "$_{" + str(rounded_angle) + "}$"
 
     def get_inverse(self):
@@ -419,13 +414,16 @@ class BasicPhaseGate(BasicGate):
 
     def __eq__(self, other):
         """ Return True if same class and same rotation angle. """
-        tolerance = EQ_TOLERANCE
         if isinstance(other, self.__class__):
-            difference = abs(self.angle - other.angle) % (2 * math.pi)
-            # Return True if angles are close to each other modulo 4 * pi
-            if difference < tolerance or difference > 2 * math.pi - tolerance:
-                return True
-        return False
+            self_rounded_angle = round(self.angle, EQ_PRECISION)
+            if self_rounded_angle > 2 * math.pi - EQ_TOLERANCE:
+                self_rounded_angle = 0.
+            other_rounded_angle = round(other.angle, EQ_PRECISION)
+            if other_rounded_angle > 2 * math.pi - EQ_TOLERANCE:
+                other_rounded_angle = 0.
+            return self_rounded_angle == other_rounded_angle
+        else:
+            return False
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -205,6 +205,12 @@ class BasicGate(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __str__(self):
+        raise NotImplementedError('This gate does not implement __str__.')
+
+    def __hash__(self):
+        return hash(str(self))
+
 
 class SelfInverseGate(BasicGate):
     """
@@ -311,6 +317,9 @@ class BasicRotationGate(BasicGate):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        return hash(str(self))
+
 
 class BasicPhaseGate(BasicGate):
     """
@@ -399,6 +408,9 @@ class BasicPhaseGate(BasicGate):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(str(self))
 
 
 # Classical instruction gates never have control qubits.

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -260,11 +260,10 @@ class BasicRotationGate(BasicGate):
 
             [CLASSNAME]([ANGLE])
         """
-        rounded_angle = self.angle
+        rounded_angle = round(self.angle, EQ_PRECISION - 1)
         if (rounded_angle < EQ_TOLERANCE or
                 rounded_angle > 4 * math.pi - EQ_TOLERANCE): 
             rounded_angle = 0.
-        rounded_angle = round(rounded_angle, EQ_PRECISION - 1)
 
         return str(self.__class__.__name__) + "(" + str(rounded_angle) + ")"
 
@@ -278,11 +277,10 @@ class BasicRotationGate(BasicGate):
 
             [CLASSNAME]$_[ANGLE]$
         """
-        rounded_angle = self.angle
+        rounded_angle = round(self.angle, EQ_PRECISION - 1)
         if (rounded_angle < EQ_TOLERANCE or
                 rounded_angle > 4 * math.pi - EQ_TOLERANCE): 
             rounded_angle = 0.
-        rounded_angle = round(rounded_angle, EQ_PRECISION - 1)
 
         return str(self.__class__.__name__) + "$_{" + str(rounded_angle) + "}$"
 
@@ -364,11 +362,10 @@ class BasicPhaseGate(BasicGate):
 
             [CLASSNAME]([ANGLE])
         """
-        rounded_angle = self.angle
+        rounded_angle = round(self.angle, EQ_PRECISION - 1)
         if (rounded_angle < EQ_TOLERANCE or
                 rounded_angle > 2 * math.pi - EQ_TOLERANCE): 
             rounded_angle = 0.
-        rounded_angle = round(rounded_angle, EQ_PRECISION - 1)
 
         return str(self.__class__.__name__) + "(" + str(rounded_angle) + ")"
 
@@ -382,11 +379,10 @@ class BasicPhaseGate(BasicGate):
 
             [CLASSNAME]$_[ANGLE]$
         """
-        rounded_angle = self.angle
+        rounded_angle = round(self.angle, EQ_PRECISION - 1)
         if (rounded_angle < EQ_TOLERANCE or
                 rounded_angle > 2 * math.pi - EQ_TOLERANCE): 
             rounded_angle = 0.
-        rounded_angle = round(rounded_angle, EQ_PRECISION - 1)
 
         return str(self.__class__.__name__) + "$_{" + str(rounded_angle) + "}$"
 

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -260,7 +260,13 @@ class BasicRotationGate(BasicGate):
 
             [CLASSNAME]([ANGLE])
         """
-        return str(self.__class__.__name__) + "(" + str(self.angle) + ")"
+        rounded_angle = self.angle
+        if (rounded_angle < EQ_TOLERANCE or
+                rounded_angle > 4 * math.pi - EQ_TOLERANCE): 
+            rounded_angle = 0.
+        rounded_angle = round(rounded_angle, EQ_PRECISION - 1)
+
+        return str(self.__class__.__name__) + "(" + str(rounded_angle) + ")"
 
     def tex_str(self):
         """
@@ -272,7 +278,13 @@ class BasicRotationGate(BasicGate):
 
             [CLASSNAME]$_[ANGLE]$
         """
-        return str(self.__class__.__name__) + "$_{" + str(self.angle) + "}$"
+        rounded_angle = self.angle
+        if (rounded_angle < EQ_TOLERANCE or
+                rounded_angle > 4 * math.pi - EQ_TOLERANCE): 
+            rounded_angle = 0.
+        rounded_angle = round(rounded_angle, EQ_PRECISION - 1)
+
+        return str(self.__class__.__name__) + "$_{" + str(rounded_angle) + "}$"
 
     def get_inverse(self):
         """
@@ -344,7 +356,7 @@ class BasicPhaseGate(BasicGate):
 
     def __str__(self):
         """
-        Return the string representation of a BasicRotationGate.
+        Return the string representation of a BasicPhaseGate.
 
         Returns the class name and the angle as
 
@@ -352,11 +364,17 @@ class BasicPhaseGate(BasicGate):
 
             [CLASSNAME]([ANGLE])
         """
-        return str(self.__class__.__name__) + "(" + str(self.angle) + ")"
+        rounded_angle = self.angle
+        if (rounded_angle < EQ_TOLERANCE or
+                rounded_angle > 2 * math.pi - EQ_TOLERANCE): 
+            rounded_angle = 0.
+        rounded_angle = round(rounded_angle, EQ_PRECISION - 1)
+
+        return str(self.__class__.__name__) + "(" + str(rounded_angle) + ")"
 
     def tex_str(self):
         """
-        Return the Latex string representation of a BasicRotationGate.
+        Return the Latex string representation of a BasicPhaseGate.
 
         Returns the class name and the angle as a subscript, i.e.
 
@@ -364,7 +382,13 @@ class BasicPhaseGate(BasicGate):
 
             [CLASSNAME]$_[ANGLE]$
         """
-        return str(self.__class__.__name__) + "$_{" + str(self.angle) + "}$"
+        rounded_angle = self.angle
+        if (rounded_angle < EQ_TOLERANCE or
+                rounded_angle > 2 * math.pi - EQ_TOLERANCE): 
+            rounded_angle = 0.
+        rounded_angle = round(rounded_angle, EQ_PRECISION - 1)
+
+        return str(self.__class__.__name__) + "$_{" + str(rounded_angle) + "}$"
 
     def get_inverse(self):
         """

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -38,8 +38,8 @@ from projectq.types import BasicQubit
 from ._command import Command, apply_command
 
 
-EQ_TOLERANCE = 1e-12
-EQ_PRECISION = int(-math.log10(EQ_TOLERANCE))
+ANGLE_PRECISION = 12
+ANGLE_TOLERANCE = 10 ** -ANGLE_PRECISION
 
 
 class NotMergeable(Exception):
@@ -248,7 +248,10 @@ class BasicRotationGate(BasicGate):
             angle (float): Angle of rotation (saved modulo 4 * pi)
         """
         BasicGate.__init__(self)
-        self.angle = float(angle) % (4. * math.pi)
+        rounded_angle = round(float(angle) % (4. * math.pi), ANGLE_PRECISION)
+        if rounded_angle > 4 * math.pi - ANGLE_TOLERANCE:
+            rounded_angle = 0.
+        self.angle = rounded_angle
 
     def __str__(self):
         """
@@ -260,10 +263,7 @@ class BasicRotationGate(BasicGate):
 
             [CLASSNAME]([ANGLE])
         """
-        rounded_angle = round(self.angle, EQ_PRECISION)
-        if rounded_angle > 4 * math.pi - EQ_TOLERANCE:
-            rounded_angle = 0.
-        return str(self.__class__.__name__) + "(" + str(rounded_angle) + ")"
+        return str(self.__class__.__name__) + "(" + str(self.angle) + ")"
 
     def tex_str(self):
         """
@@ -275,10 +275,7 @@ class BasicRotationGate(BasicGate):
 
             [CLASSNAME]$_[ANGLE]$
         """
-        rounded_angle = round(self.angle, EQ_PRECISION)
-        if rounded_angle > 4 * math.pi - EQ_TOLERANCE:
-            rounded_angle = 0.
-        return str(self.__class__.__name__) + "$_{" + str(rounded_angle) + "}$"
+        return str(self.__class__.__name__) + "$_{" + str(self.angle) + "}$"
 
     def get_inverse(self):
         """
@@ -314,13 +311,7 @@ class BasicRotationGate(BasicGate):
     def __eq__(self, other):
         """ Return True if same class and same rotation angle. """
         if isinstance(other, self.__class__):
-            self_rounded_angle = round(self.angle, EQ_PRECISION)
-            if self_rounded_angle > 4 * math.pi - EQ_TOLERANCE:
-                self_rounded_angle = 0.
-            other_rounded_angle = round(other.angle, EQ_PRECISION)
-            if other_rounded_angle > 4 * math.pi - EQ_TOLERANCE:
-                other_rounded_angle = 0.
-            return self_rounded_angle == other_rounded_angle
+            return self.angle == other.angle
         else:
             return False
 
@@ -349,7 +340,10 @@ class BasicPhaseGate(BasicGate):
             angle (float): Angle of rotation (saved modulo 2 * pi)
         """
         BasicGate.__init__(self)
-        self.angle = float(angle) % (2. * math.pi)
+        rounded_angle = round(float(angle) % (2. * math.pi), ANGLE_PRECISION)
+        if rounded_angle > 2 * math.pi - ANGLE_TOLERANCE:
+            rounded_angle = 0.
+        self.angle = rounded_angle
 
     def __str__(self):
         """
@@ -361,10 +355,7 @@ class BasicPhaseGate(BasicGate):
 
             [CLASSNAME]([ANGLE])
         """
-        rounded_angle = round(self.angle, EQ_PRECISION)
-        if rounded_angle > 2 * math.pi - EQ_TOLERANCE:
-            rounded_angle = 0.
-        return str(self.__class__.__name__) + "(" + str(rounded_angle) + ")"
+        return str(self.__class__.__name__) + "(" + str(self.angle) + ")"
 
     def tex_str(self):
         """
@@ -376,10 +367,7 @@ class BasicPhaseGate(BasicGate):
 
             [CLASSNAME]$_[ANGLE]$
         """
-        rounded_angle = round(self.angle, EQ_PRECISION)
-        if rounded_angle > 2 * math.pi - EQ_TOLERANCE:
-            rounded_angle = 0.
-        return str(self.__class__.__name__) + "$_{" + str(rounded_angle) + "}$"
+        return str(self.__class__.__name__) + "$_{" + str(self.angle) + "}$"
 
     def get_inverse(self):
         """
@@ -415,13 +403,7 @@ class BasicPhaseGate(BasicGate):
     def __eq__(self, other):
         """ Return True if same class and same rotation angle. """
         if isinstance(other, self.__class__):
-            self_rounded_angle = round(self.angle, EQ_PRECISION)
-            if self_rounded_angle > 2 * math.pi - EQ_TOLERANCE:
-                self_rounded_angle = 0.
-            other_rounded_angle = round(other.angle, EQ_PRECISION)
-            if other_rounded_angle > 2 * math.pi - EQ_TOLERANCE:
-                other_rounded_angle = 0.
-            return self_rounded_angle == other_rounded_angle
+            return self.angle == other.angle
         else:
             return False
 

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -142,16 +142,6 @@ def test_basic_rotation_gate_init(input_angle, modulo_angle):
     assert gate.angle == pytest.approx(modulo_angle)
 
 
-@pytest.mark.parametrize("input_angle, modulo_angle",
-                         [(2.0, 2.0), (17., 4.4336293856408275),
-                          (-0.5 * math.pi, 3.5 * math.pi), (4 * math.pi, 0)])
-def test_basic_rotation_gate_hash(input_angle, modulo_angle):
-    # Test hash function
-    gate1 = _basics.BasicRotationGate(input_angle)
-    gate2 = _basics.BasicRotationGate(modulo_angle)
-    assert hash(gate1) == hash(gate2)
-
-
 def test_basic_rotation_gate_str():
     basic_rotation_gate = _basics.BasicRotationGate(0.5)
     assert str(basic_rotation_gate) == "BasicRotationGate(0.5)"
@@ -211,16 +201,6 @@ def test_basic_phase_gate_init(input_angle, modulo_angle):
     # Test internal representation
     gate = _basics.BasicPhaseGate(input_angle)
     assert gate.angle == pytest.approx(modulo_angle)
-
-
-@pytest.mark.parametrize("input_angle, modulo_angle",
-                         [(2.0, 2.0), (17., 4.4336293856408275),
-                          (-0.5 * math.pi, 1.5 * math.pi), (2 * math.pi, 0)])
-def test_basic_phase_gate_hash(input_angle, modulo_angle):
-    # Test hash function
-    gate1 = _basics.BasicRotationGate(input_angle)
-    gate2 = _basics.BasicRotationGate(modulo_angle)
-    assert hash(gate1) == hash(gate2)
 
 
 def test_basic_phase_gate_str():

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -233,26 +233,26 @@ def test_basic_phase_gate_get_merged():
     assert merged_gate == basic_phase_gate3
 
 
-#def test_basic_phase_gate_comparison_and_hash():
-#    basic_phase_gate1 = _basics.BasicPhaseGate(0.5)
-#    basic_phase_gate2 = _basics.BasicPhaseGate(0.5)
-#    basic_phase_gate3 = _basics.BasicPhaseGate(0.5 + 2 * math.pi)
-#    assert basic_phase_gate1 == basic_phase_gate2
-#    assert hash(basic_phase_gate1) == hash(basic_phase_gate2)
-#    assert basic_phase_gate1 == basic_phase_gate3
-#    assert hash(basic_phase_gate1) == hash(basic_phase_gate3)
-#    basic_phase_gate4 = _basics.BasicPhaseGate(0.50000001)
-#    # Test __ne__:
-#    assert basic_phase_gate4 != basic_phase_gate1
-#    # Test one gate close to 2*pi the other one close to 0
-#    basic_phase_gate5 = _basics.BasicPhaseGate(1.e-13)
-#    basic_phase_gate6 = _basics.BasicPhaseGate(2 * math.pi - 1.e-13)
-#    assert basic_phase_gate5 == basic_phase_gate6
-#    assert hash(basic_phase_gate5) == hash(basic_phase_gate6)
-#    # Test different types of gates
-#    basic_gate = _basics.BasicGate()
-#    assert not basic_gate == basic_phase_gate6
-#    assert basic_phase_gate2 != _basics.BasicPhaseGate(0.5 + math.pi)
+def test_basic_phase_gate_comparison_and_hash():
+    basic_phase_gate1 = _basics.BasicPhaseGate(0.5)
+    basic_phase_gate2 = _basics.BasicPhaseGate(0.5)
+    basic_phase_gate3 = _basics.BasicPhaseGate(0.5 + 2 * math.pi)
+    assert basic_phase_gate1 == basic_phase_gate2
+    assert hash(basic_phase_gate1) == hash(basic_phase_gate2)
+    assert basic_phase_gate1 == basic_phase_gate3
+    assert hash(basic_phase_gate1) == hash(basic_phase_gate3)
+    basic_phase_gate4 = _basics.BasicPhaseGate(0.50000001)
+    # Test __ne__:
+    assert basic_phase_gate4 != basic_phase_gate1
+    # Test one gate close to 2*pi the other one close to 0
+    basic_phase_gate5 = _basics.BasicPhaseGate(1.e-13)
+    basic_phase_gate6 = _basics.BasicPhaseGate(2 * math.pi - 1.e-13)
+    assert basic_phase_gate5 == basic_phase_gate6
+    assert hash(basic_phase_gate5) == hash(basic_phase_gate6)
+    # Test different types of gates
+    basic_gate = _basics.BasicGate()
+    assert not basic_gate == basic_phase_gate6
+    assert basic_phase_gate2 != _basics.BasicPhaseGate(0.5 + math.pi)
 
 
 def test_basic_math_gate():

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -111,20 +111,32 @@ def test_basic_gate_or():
                                   command5])
 
 
-def test_basic_gate_compare(main_engine):
+def test_basic_gate_compare():
     gate1 = _basics.BasicGate()
     gate2 = _basics.BasicGate()
     assert gate1 == gate2
     assert not (gate1 != gate2)
 
 
-def test_comparing_different_gates(main_engine):
+def test_comparing_different_gates():
     basic_gate = _basics.BasicGate()
     basic_rotation_gate = _basics.BasicRotationGate(1.0)
     self_inverse_gate = _basics.SelfInverseGate()
     assert not basic_gate == basic_rotation_gate
     assert not basic_gate == self_inverse_gate
     assert not self_inverse_gate == basic_rotation_gate
+
+
+def test_basic_gate_str():
+    basic_gate = _basics.BasicGate()
+    with pytest.raises(NotImplementedError):
+        _ = str(basic_gate)
+
+
+def test_basic_gate_hash():
+    basic_gate = _basics.BasicGate()
+    with pytest.raises(NotImplementedError):
+        _ = hash(basic_gate)
 
 
 def test_self_inverse_gate():
@@ -150,6 +162,8 @@ def test_basic_rotation_gate_str():
 def test_basic_rotation_tex_str():
     basic_rotation_gate = _basics.BasicRotationGate(0.5)
     assert basic_rotation_gate.tex_str() == "BasicRotationGate$_{0.5}$"
+    basic_rotation_gate = _basics.BasicRotationGate(4 * math.pi - 1e-13)
+    assert basic_rotation_gate.tex_str() == "BasicRotationGate$_{0.0}$"
 
 
 @pytest.mark.parametrize("input_angle, inverse_angle",
@@ -187,6 +201,7 @@ def test_basic_rotation_gate_comparison_and_hash():
     basic_rotation_gate5 = _basics.BasicRotationGate(1.e-13)
     basic_rotation_gate6 = _basics.BasicRotationGate(4 * math.pi - 1.e-13)
     assert basic_rotation_gate5 == basic_rotation_gate6
+    assert basic_rotation_gate6 == basic_rotation_gate5
     assert hash(basic_rotation_gate5) == hash(basic_rotation_gate6)
     # Test different types of gates
     basic_gate = _basics.BasicGate()
@@ -211,6 +226,8 @@ def test_basic_phase_gate_str():
 def test_basic_phase_tex_str():
     basic_phase_gate = _basics.BasicPhaseGate(0.5)
     assert basic_phase_gate.tex_str() == "BasicPhaseGate$_{0.5}$"
+    basic_rotation_gate = _basics.BasicPhaseGate(2 * math.pi - 1e-13)
+    assert basic_rotation_gate.tex_str() == "BasicPhaseGate$_{0.0}$"
 
 
 @pytest.mark.parametrize("input_angle, inverse_angle",
@@ -248,6 +265,7 @@ def test_basic_phase_gate_comparison_and_hash():
     basic_phase_gate5 = _basics.BasicPhaseGate(1.e-13)
     basic_phase_gate6 = _basics.BasicPhaseGate(2 * math.pi - 1.e-13)
     assert basic_phase_gate5 == basic_phase_gate6
+    assert basic_phase_gate6 == basic_phase_gate5
     assert hash(basic_phase_gate5) == hash(basic_phase_gate6)
     # Test different types of gates
     basic_gate = _basics.BasicGate()

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -152,6 +152,13 @@ def test_basic_rotation_tex_str():
     assert basic_rotation_gate.tex_str() == "BasicRotationGate$_{0.5}$"
 
 
+def test_basic_rotation_gate_hash(input_angle, modulo_angle):
+    # Test hash function
+    gate1 = _basics.BasicRotationGate(input_angle)
+    gate2 = _basics.BasicRotationGate(modulo_angle)
+    assert hash(gate1) == hash(gate2)
+
+
 @pytest.mark.parametrize("input_angle, inverse_angle",
                          [(2.0, -2.0 + 4 * math.pi), (-0.5, 0.5), (0.0, 0)])
 def test_basic_rotation_gate_get_inverse(input_angle, inverse_angle):
@@ -208,6 +215,13 @@ def test_basic_phase_gate_str():
 def test_basic_phase_tex_str():
     basic_phase_gate = _basics.BasicPhaseGate(0.5)
     assert basic_phase_gate.tex_str() == "BasicPhaseGate$_{0.5}$"
+
+
+def test_basic_phase_gate_hash(input_angle, modulo_angle):
+    # Test hash function
+    gate1 = _basics.BasicRotationGate(input_angle)
+    gate2 = _basics.BasicRotationGate(modulo_angle)
+    assert hash(gate1) == hash(gate2)
 
 
 @pytest.mark.parametrize("input_angle, inverse_angle",

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -142,6 +142,16 @@ def test_basic_rotation_gate_init(input_angle, modulo_angle):
     assert gate.angle == pytest.approx(modulo_angle)
 
 
+@pytest.mark.parametrize("input_angle, modulo_angle",
+                         [(2.0, 2.0), (17., 4.4336293856408275),
+                          (-0.5 * math.pi, 3.5 * math.pi), (4 * math.pi, 0)])
+def test_basic_rotation_gate_hash(input_angle, modulo_angle):
+    # Test hash function
+    gate1 = _basics.BasicRotationGate(input_angle)
+    gate2 = _basics.BasicRotationGate(modulo_angle)
+    assert hash(gate1) == hash(gate2)
+
+
 def test_basic_rotation_gate_str():
     basic_rotation_gate = _basics.BasicRotationGate(0.5)
     assert str(basic_rotation_gate) == "BasicRotationGate(0.5)"
@@ -150,13 +160,6 @@ def test_basic_rotation_gate_str():
 def test_basic_rotation_tex_str():
     basic_rotation_gate = _basics.BasicRotationGate(0.5)
     assert basic_rotation_gate.tex_str() == "BasicRotationGate$_{0.5}$"
-
-
-def test_basic_rotation_gate_hash(input_angle, modulo_angle):
-    # Test hash function
-    gate1 = _basics.BasicRotationGate(input_angle)
-    gate2 = _basics.BasicRotationGate(modulo_angle)
-    assert hash(gate1) == hash(gate2)
 
 
 @pytest.mark.parametrize("input_angle, inverse_angle",
@@ -207,6 +210,16 @@ def test_basic_phase_gate_init(input_angle, modulo_angle):
     assert gate.angle == pytest.approx(modulo_angle)
 
 
+@pytest.mark.parametrize("input_angle, modulo_angle",
+                         [(2.0, 2.0), (17., 4.4336293856408275),
+                          (-0.5 * math.pi, 1.5 * math.pi), (2 * math.pi, 0)])
+def test_basic_phase_gate_hash(input_angle, modulo_angle):
+    # Test hash function
+    gate1 = _basics.BasicRotationGate(input_angle)
+    gate2 = _basics.BasicRotationGate(modulo_angle)
+    assert hash(gate1) == hash(gate2)
+
+
 def test_basic_phase_gate_str():
     basic_phase_gate = _basics.BasicPhaseGate(0.5)
     assert str(basic_phase_gate) == "BasicPhaseGate(0.5)"
@@ -215,13 +228,6 @@ def test_basic_phase_gate_str():
 def test_basic_phase_tex_str():
     basic_phase_gate = _basics.BasicPhaseGate(0.5)
     assert basic_phase_gate.tex_str() == "BasicPhaseGate$_{0.5}$"
-
-
-def test_basic_phase_gate_hash(input_angle, modulo_angle):
-    # Test hash function
-    gate1 = _basics.BasicRotationGate(input_angle)
-    gate2 = _basics.BasicRotationGate(modulo_angle)
-    assert hash(gate1) == hash(gate2)
 
 
 @pytest.mark.parametrize("input_angle, inverse_angle",


### PR DESCRIPTION
Addresses #189 .

I defined the hash of a gate as the hash of its string representation. Note that if a subclass of `BasicGate` (or any class) defines its own `__eq__`, then Python 3 automatically sets its `__hash__` method to `None`, so you need to redefine its `__hash__` method.