### PR TITLE
Gate class counts

### DIFF
--- a/projectq/backends/_resource.py
+++ b/projectq/backends/_resource.py
@@ -39,7 +39,8 @@ class ResourceCounter(BasicEngine):
         Sets all statistics to zero.
         """
         BasicEngine.__init__(self)
-        self.gate_counts = dict()
+        self.gate_counts = {}
+        self.gate_class_counts = {}
         self._active_qubits = 0
         self.max_width = 0
 
@@ -78,11 +79,17 @@ class ResourceCounter(BasicEngine):
 
         ctrl_cnt = get_control_count(cmd)
         gate_description = (cmd.gate, ctrl_cnt)
+        gate_class_description = (cmd.gate.__class__, ctrl_cnt)
 
         try:
             self.gate_counts[gate_description] += 1
         except KeyError:
             self.gate_counts[gate_description] = 1
+
+        try:
+            self.gate_class_counts[gate_class_description] += 1
+        except KeyError:
+            self.gate_class_counts[gate_class_description] = 1
 
     def __str__(self):
         """
@@ -94,12 +101,22 @@ class ResourceCounter(BasicEngine):
                 time.
         """
         if len(self.gate_counts) > 0:
+            gate_class_list = []
+            for gate_class_description, num in self.gate_class_counts.items():
+                gate_class, ctrl_cnt = gate_class_description
+                gate_class_name = ctrl_cnt * "C" + gate_class.__name__
+                gate_class_list.append(gate_class_name + " : " + str(num))
+
             gate_list = []
             for gate_description, num in self.gate_counts.items():
                 gate, ctrl_cnt = gate_description
                 gate_name = ctrl_cnt * "C" + str(gate)
                 gate_list.append(gate_name + " : " + str(num))
-            return ("\n".join(list(sorted(gate_list))) +
+
+            return ("Gate class counts:\n    " +
+                    "\n    ".join(list(sorted(gate_class_list))) +
+                    "\n\nGate counts:\n    " +
+                    "\n    ".join(list(sorted(gate_list))) +
                     "\n\nMax. width (number of qubits) : " +
                     str(self.max_width) + ".")
         return "(No quantum resources used)"

--- a/projectq/backends/_resource_test.py
+++ b/projectq/backends/_resource_test.py
@@ -19,7 +19,7 @@ Tests for projectq.backends._resource.py.
 import pytest
 
 from projectq.cengines import MainEngine, DummyEngine
-from projectq.ops import H, CNOT, X, Measure
+from projectq.ops import H, CNOT, X, Rz, Measure
 
 from projectq.backends import ResourceCounter
 
@@ -52,6 +52,8 @@ def test_resource_counter():
 
     qubit3 = eng.allocate_qubit()
     CNOT | (qubit1, qubit3)
+    Rz(0.1) | qubit1
+    Rz(0.3) | qubit1
 
     Measure | (qubit1, qubit3)
 
@@ -61,11 +63,20 @@ def test_resource_counter():
     assert resource_counter.max_width == 2
 
     str_repr = str(resource_counter)
-    assert str_repr.count("H") == 1
-    assert str_repr.count("X") == 2
-    assert str_repr.count("CX") == 1
-    assert str_repr.count("Allocate : 3") == 1
-    assert str_repr.count("Deallocate : 1") == 1
+    assert str_repr.count(" HGate : 1") == 1
+    assert str_repr.count(" XGate : 1") == 1
+    assert str_repr.count(" CXGate : 1") == 1
+    assert str_repr.count(" Rz : 2") == 1
+    assert str_repr.count(" AllocateQubitGate : 3") == 1
+    assert str_repr.count(" DeallocateQubitGate : 1") == 1
+
+    assert str_repr.count(" H : 1") == 1
+    assert str_repr.count(" X : 1") == 1
+    assert str_repr.count(" CX : 1") == 1
+    assert str_repr.count(" Rz(0.1) : 1") == 1
+    assert str_repr.count(" Rz(0.3) : 1") == 1
+    assert str_repr.count(" Allocate : 3") == 1
+    assert str_repr.count(" Deallocate : 1") == 1
 
     sent_gates = [cmd.gate for cmd in backend.received_commands]
     assert sent_gates.count(H) == 1


### PR DESCRIPTION
Have `ResourceCounter` also keep track of gate classes. Right now the main difference is that it groups together rotation gates of the same type. The new string representation of a `ResourceCounter` begins something like
```
Gate class counts:
    AllocateQubitGate : 32
    CXGate : 1024
    DeallocateQubitGate : 32
    HGate : 2048
    Rz : 2560
    XGate : 16

Gate counts:
    Allocate : 32
    CX : 1024
    Deallocate : 32
    H : 2048
    Rz(0.09770504) : 1
    Rz(0.09817477) : 1
    Rz(0.19448398) : 2
    ...
    ...[long list of Rz's]
```
Note that the "Gate class counts" section actually appends a `C` to the gate class for each control qubit; otherwise CNOTS would be counted under `XGate`. This is just a choice I made which we can change.