### PR TITLE
Remove manually deallocated qubits from active qubits

### DIFF
--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -236,7 +236,8 @@ class MainEngine(BasicEngine):
                 id to -1).
         """
         if deallocate_qubits:
-            for qb in self.active_qubits:
+            while len(self.active_qubits):
+                qb = self.active_qubits.pop()
                 qb.__del__()
             self.active_qubits = weakref.WeakSet()
         self.receive([Command(self, FlushGate(), ([WeakQubitRef(self, -1)],))])

--- a/projectq/types/_qubit.py
+++ b/projectq/types/_qubit.py
@@ -124,6 +124,12 @@ class Qubit(BasicQubit):
         """
         if self.id == -1:
             return
+        # If a user directly calls this function, then the qubit gets id == -1
+        # but stays in active_qubits as it is not yet deleted, hence remove
+        # it manually (if the garbage collector calls this function, then the
+        # WeakRef in active qubits is already gone):
+        if self in self.engine.main_engine.active_qubits:
+            self.engine.main_engine.active_qubits.remove(self)
         weak_copy = WeakQubitRef(self.engine, self.id)
         self.id = -1
         self.engine.deallocate_qubit(weak_copy)

--- a/projectq/types/_qubit_test.py
+++ b/projectq/types/_qubit_test.py
@@ -91,6 +91,8 @@ def mock_main_engine():
     class MockMainEngine(object):
         def __init__(self):
             self.num_calls = 0
+            self.active_qubits = set()
+            self.main_engine = self
 
         def deallocate_qubit(self, qubit):
             self.num_calls += 1


### PR DESCRIPTION
Removes manually deleted qubits, i.e., user has called qb.__del__(), from active_qubits in MainEngine right away.