### PR TITLE
Improved error handling

### DIFF
--- a/examples/simulator_tutorial.ipynb
+++ b/examples/simulator_tutorial.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "source": [
     "# ProjectQ Simulator Tutorial"
@@ -13,10 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The aim of this tutorial is to introduce some of the basic and more advanced features of the ProjectQ simulator. Please note that all the simulator features can be found in our [code documentation](http://projectq.readthedocs.io/en/latest/projectq.backends.html#projectq.backends.Simulator).\n",
     "\n",
@@ -48,10 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Installation <a id=\"Installation\"></a>\n",
     "\n",
@@ -61,11 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import projectq\n",
@@ -74,10 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "If you now see the following message\n",
     "```\n",
@@ -88,10 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Basics <a id=\"Basics\"></a>\n",
     "\n",
@@ -101,11 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from projectq.backends import Simulator\n",
@@ -114,10 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Note that the `MainEngine` contains the simulator as the default backend, hence one can equivalently just do:"
    ]
@@ -125,11 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "eng = projectq.MainEngine()"
@@ -137,10 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "In order to simulate the probabilistic measurement process, the simulator internally requires a random number generator. When creating a simulator instance, one can provide a random seed in order to create reproducible results:"
    ]
@@ -148,11 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "eng = projectq.MainEngine(backend=Simulator(rnd_seed=10))"
@@ -160,10 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Let's write a simple test program which allocates a qubit in state |0>, performs a Hadamard gate which puts it into a superposition 1/sqrt(2) * ( |0> + |1>) and then measure the qubit:"
    ]
@@ -171,17 +132,13 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1\n"
+      "0\n"
      ]
     }
    ],
@@ -199,10 +156,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "This program randomly outputs 0 or 1. Note that the measurement does *not* return for example a probability of measuring 0 or 1 (see below how this could be achieved). The reason for this is that a program written in our high-level syntax should be independent of the backend. In other words, the code can be executed either by our simulator or by exchanging only the MainEngine's backend by a real device which cannot return a probability but only one value. See the other examples on GitHub of how to execute code on the IBM quantum chip.\n",
     "\n",
@@ -214,10 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Important debugging feature of our simulator\n",
     "\n",
@@ -227,63 +178,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Exception ignored in: <bound method Qubit.__del__ of <projectq.types._qubit.Qubit object at 0x110bcfc88>>\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/types/_qubit.py\", line 127, in __del__\n",
-      "    self.engine.deallocate_qubit(weak_copy)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 151, in deallocate_qubit\n",
-      "    tags=[DirtyQubitTag()] if is_dirty else [])])\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
-      "    self.next_engine.receive(command_list)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_tagremover.py\", line 56, in receive\n",
-      "    self.send([cmd])\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
-      "    self.next_engine.receive(command_list)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 237, in receive\n",
-      "    self._cache_cmd(cmd)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 223, in _cache_cmd\n",
-      "    self._check_and_send()\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 201, in _check_and_send\n",
-      "    self._send_qubit_pipeline(i, len(self._l[i]))\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 80, in _send_qubit_pipeline\n",
-      "    self.send([il[i]])\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
-      "    self.next_engine.receive(command_list)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_replacer/_replacer.py\", line 195, in receive\n",
-      "    self._process_command(cmd)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_replacer/_replacer.py\", line 123, in _process_command\n",
-      "    self.send([cmd])\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
-      "    self.next_engine.receive(command_list)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_tagremover.py\", line 56, in receive\n",
-      "    self.send([cmd])\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
-      "    self.next_engine.receive(command_list)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 237, in receive\n",
-      "    self._cache_cmd(cmd)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 223, in _cache_cmd\n",
-      "    self._check_and_send()\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 201, in _check_and_send\n",
-      "    self._send_qubit_pipeline(i, len(self._l[i]))\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_optimize.py\", line 80, in _send_qubit_pipeline\n",
-      "    self.send([il[i]])\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/cengines/_basics.py\", line 184, in send\n",
-      "    self.next_engine.receive(command_list)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/backends/_sim/_simulator.py\", line 317, in receive\n",
-      "    self._handle(cmd)\n",
-      "  File \"/opt/local/Library/Frameworks/Python.framework/Versions/3.5/lib/python3.5/site-packages/projectq/backends/_sim/_simulator.py\", line 275, in _handle\n",
-      "    self._simulator.deallocate_qubit(ID)\n",
-      "RuntimeError: Error: Qubit has not been measured / uncomputed! There is most likely a bug in your code.\n"
+      "Exception RuntimeError: 'Error: Qubit has not been measured / uncomputed! There is most likely a bug in your code.' in <bound method Qubit.__del__ of <projectq.types._qubit.Qubit object at 0x10c594310>> ignored\n"
      ]
     }
    ],
@@ -299,10 +200,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "It will create a long error message. At the bottom it says the reason: *Error: Qubit has not been measured / uncomputed! There is most likely a bug in your code.*\n",
     "\n",
@@ -312,11 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from projectq.ops import All\n",
@@ -332,10 +226,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Advanced features <a id=\"Advanced_features\"></a>\n",
     "\n",
@@ -349,11 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sim = Simulator(rnd_seed=5) # We can now always access the simulator via the \"sim\" variable\n",
@@ -362,10 +249,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Alternatively, one can access the simulator by accessing the backend of the compiler (MainEngine):"
    ]
@@ -373,11 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "assert id(sim) == id(eng.backend)"
@@ -385,10 +265,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Amplitude\n",
     "One can access the complex amplitude of a specific state as follows:"
@@ -397,18 +274,14 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Amplitude saved in amp_before: (1+0j)\n",
-      "Amplitude saved in amp_after: (0.7071067811865475+0j)\n"
+      "Amplitude saved in amp_after: (0.707106781187+0j)\n"
      ]
     }
    ],
@@ -446,20 +319,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "**NOTE**: One always has to call eng.flush() before accessing the amplitude as otherwise some of the gates might not have been sent and executed on the simulator. Also don't forget in such an example to measure all the qubits in the end in order to avoid the above mentioned debugging error message of deallocating qubits which are not in a classical state."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Probability\n",
     "\n",
@@ -469,21 +336,17 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Probability to measure 11: 0.0\n",
-      "Probability to measure 00: 0.4999999999999999\n",
+      "Probability to measure 00: 0.5\n",
       "Probability to measure 01: 0.0\n",
-      "Probability to measure 10: 0.4999999999999999\n",
-      "Probability that second qubit is in state 0: 0.9999999999999998\n"
+      "Probability to measure 10: 0.5\n",
+      "Probability that second qubit is in state 0: 1.0\n"
      ]
     }
    ],
@@ -513,10 +376,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Expectation value\n",
     "\n",
@@ -526,18 +386,14 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Expectation value = <Psi|Z0|Psi> = -0.9999999999999998\n",
-      "Expectation value = <Psi|-0.5 X1 + 1.0 Z0 X1|Psi> = -1.4999999999999996\n"
+      "Expectation value = <Psi|Z0|Psi> = -1.0\n",
+      "Expectation value = <Psi|-0.5 X1 + 1.0 Z0 X1|Psi> = -1.5\n"
      ]
     }
    ],
@@ -563,10 +419,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Collapse Wavefunction (Post select measurement outcome)\n",
     "\n",
@@ -576,11 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -610,10 +459,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Running the above circuit will either produce both qubits in state 0 or both qubits in state 1. Suppose I want to check the outcome if the first qubit was measured in state 0. This can be achieve by telling the simulator backend to collapse the wavefunction for the first qubit to be in state 0:"
    ]
@@ -621,11 +467,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -661,10 +503,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Set wavefunction to a specific state\n",
     "\n",
@@ -674,11 +513,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import math\n",
@@ -698,10 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "### Cheat / Accessing the wavefunction\n",
     "\n",
@@ -713,11 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -726,8 +554,8 @@
       "The full wavefunction is: [(0.9751703272018158+0j), -0.09784339500725571j, -0.19767681165408385j, (-0.019833838076209875+0j)]\n",
       "qubit1 has bit-location 0\n",
       "qubit2 has bit-location 1\n",
-      "Amplitude of state qubit1 in state 0 and qubit2 in state 1: -0.19767681165408385j\n",
-      "Accessing same amplitude but using get_amplitude instead: -0.19767681165408385j\n"
+      "Amplitude of state qubit1 in state 0 and qubit2 in state 1: -0.197676811654j\n",
+      "Accessing same amplitude but using get_amplitude instead: -0.197676811654j\n"
      ]
     }
    ],
@@ -765,10 +593,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Improving the speed of the ProjectQ simulator <a id=\"improve_speed\"></a>\n",
     "\n",
@@ -779,11 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import projectq\n",
@@ -793,10 +614,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "* As noted in the [code documentation](http://projectq.readthedocs.io/en/latest/projectq.backends.html#projectq.backends.Simulator), one can play around with the number of threads in order to increase the simulation speed. Execute the following statements in the terminal before running ProjectQ:\n",
     "```\n",
@@ -811,11 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import projectq\n",
@@ -825,32 +639,36 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "We'd like to refer interested readers to our paper on the [world's largest and fastest quantum computer simulation](https://arxiv.org/abs/1704.01127) for more details on how to optimize the speed of a quantum simulator."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.14"
   }
  },
  "nbformat": 4,

--- a/projectq/cengines/_basics.py
+++ b/projectq/cengines/_basics.py
@@ -178,7 +178,6 @@ class BasicEngine(object):
         except:
             return False
 
-    # sends the commandList to the next engine
     def send(self, command_list):
         """
         Forward the list of commands to the next engine in the pipeline.

--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -248,7 +248,7 @@ class MainEngine(BasicEngine):
         """
         Forward the list of commands to the next engine in the pipeline.
 
-        It also shortens exception traces if self.verbose is False.
+        It also shortens exception stack traces if self.verbose is False.
         """
         try:
             self.next_engine.receive(command_list)

--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -151,7 +151,7 @@ class MainEngine(BasicEngine):
                 if not hasattr(sys, "last_type"):
                     eng.flush(deallocate_qubits=True)
                 # An exception causes the termination, don't send a flush and
-                # make sure no qubits send deallocation gate anymore as this
+                # make sure no qubits send deallocation gates anymore as this
                 # might trigger additional exceptions
                 else:
                     for qubit in eng.active_qubits:

--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -259,12 +259,12 @@ class MainEngine(BasicEngine):
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 # try:
                 last_line = traceback.format_exc().splitlines()
-                compact_exception = exc_type(str(exc_value)
-                                             + '\n raised in:\n'
-                                             + repr(last_line[-3])
-                                             + "\n" + repr(last_line[-2]))
+                compact_exception = exc_type(str(exc_value) +
+                                             '\n raised in:\n' +
+                                             repr(last_line[-3]) +
+                                             "\n" + repr(last_line[-2]))
                 compact_exception.__cause__ = None
-                raise compact_exception # use verbose=True for more info
+                raise compact_exception  # use verbose=True for more info
 
     def flush(self, deallocate_qubits=False):
         """

--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -242,8 +242,16 @@ class MainEngine(BasicEngine):
             command_list (list<Command>): List of commands to receive (and
                 then send on)
         """
+        self.send(command_list)
+
+    def send(self, command_list):
+        """
+        Forward the list of commands to the next engine in the pipeline.
+
+        It also shortens exception traces if self.verbose is False.
+        """
         try:
-            self.send(command_list)
+            self.next_engine.receive(command_list)
         except:
             if self.verbose:
                 raise
@@ -257,7 +265,6 @@ class MainEngine(BasicEngine):
                                              + "\n" + repr(last_line[-2]))
                 compact_exception.__cause__ = None
                 raise compact_exception # use verbose=True for more info
-
 
     def flush(self, deallocate_qubits=False):
         """

--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -17,6 +17,8 @@ Contains the main engine of every compiler engine pipeline, called MainEngine.
 """
 
 import atexit
+import sys
+import traceback
 import weakref
 
 import projectq
@@ -51,7 +53,7 @@ class MainEngine(BasicEngine):
         backend (BasicEngine): Access the back-end.
 
     """
-    def __init__(self, backend=None, engine_list=None):
+    def __init__(self, backend=None, engine_list=None, verbose=False):
         """
         Initialize the main compiler engine and all compiler engines.
 
@@ -62,6 +64,8 @@ class MainEngine(BasicEngine):
             backend (BasicEngine): Backend to send the circuit to.
             engine_list (list<BasicEngine>): List of engines / backends to use
                 as compiler engines.
+            verbose (bool): Either print full or compact error messages.
+                            Default: False (i.e. compact error messages).
 
         Example:
             .. code-block:: python
@@ -138,10 +142,24 @@ class MainEngine(BasicEngine):
         self.active_qubits = weakref.WeakSet()
         self._measurements = dict()
         self.dirty_qubits = set()
+        self.verbose = verbose
 
-        # In order to terminate an example code without eng.flush or Measure
-        self._delfun = lambda x: x.flush(deallocate_qubits=True)
-        atexit.register(self._delfun, self)
+        # In order to terminate an example code without eng.flush
+        def atexit_function(weakref_main_eng):
+            eng = weakref_main_eng()
+            if eng is not None:
+                if not hasattr(sys, "last_type"):
+                    eng.flush(deallocate_qubits=True)
+                # An exception causes the termination, don't send a flush and
+                # make sure no qubits send deallocation gate anymore as this
+                # might trigger additional exceptions
+                else:
+                    for qubit in eng.active_qubits:
+                        qubit.id = -1
+
+        self._delfun = atexit_function
+        weakref_self = weakref.ref(self)
+        atexit.register(self._delfun, weakref_self)
 
     def __del__(self):
         """
@@ -150,7 +168,8 @@ class MainEngine(BasicEngine):
         Flushes the entire circuit down the pipeline, clearing all temporary
         buffers (in, e.g., optimizers).
         """
-        self.flush()
+        if not hasattr(sys, "last_type"):
+            self.flush(deallocate_qubits=True)
         try:
             atexit.unregister(self._delfun)  # only available in Python3
         except AttributeError:
@@ -223,7 +242,22 @@ class MainEngine(BasicEngine):
             command_list (list<Command>): List of commands to receive (and
                 then send on)
         """
-        self.send(command_list)
+        try:
+            self.send(command_list)
+        except:
+            if self.verbose:
+                raise
+            else:
+                exc_type, exc_value, exc_traceback = sys.exc_info()
+                # try:
+                last_line = traceback.format_exc().splitlines()
+                compact_exception = exc_type(str(exc_value)
+                                             + '\n raised in:\n'
+                                             + repr(last_line[-3])
+                                             + "\n" + repr(last_line[-2]))
+                compact_exception.__cause__ = None
+                raise compact_exception # use verbose=True for more info
+
 
     def flush(self, deallocate_qubits=False):
         """
@@ -239,5 +273,4 @@ class MainEngine(BasicEngine):
             while len(self.active_qubits):
                 qb = self.active_qubits.pop()
                 qb.__del__()
-            self.active_qubits = weakref.WeakSet()
         self.receive([Command(self, FlushGate(), ([WeakQubitRef(self, -1)],))])

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -74,8 +74,8 @@ def test_main_engine_init_defaults():
 
 def test_main_engine_del():
     #clear previous exceptions of other tests
-    if hasattr(sys, "last_type"):
-        del sys.last_type
+    sys.last_type = None
+    del sys.last_type
     # need engine which caches commands to test that del calls flush
     caching_engine = LocalOptimizer(m=5)
     backend = DummyEngine(save_commands=True)
@@ -127,8 +127,9 @@ def test_main_engine_flush():
 
 
 def test_main_engine_atexit_no_error():
-    if hasattr(sys, "last_type"):
-        del sys.last_type
+    #clear previous exceptions of other tests
+    sys.last_type = None
+    del sys.last_type
     backend = DummyEngine(save_commands=True)
     eng = _main.MainEngine(backend=backend, engine_list=[])
     qb = eng.allocate_qubit()

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -73,7 +73,7 @@ def test_main_engine_init_defaults():
 
 
 def test_main_engine_del():
-    #clear previous exceptions of other tests
+    # Clear previous exceptions of other tests
     sys.last_type = None
     del sys.last_type
     # need engine which caches commands to test that del calls flush
@@ -127,7 +127,7 @@ def test_main_engine_flush():
 
 
 def test_main_engine_atexit_no_error():
-    #clear previous exceptions of other tests
+    # Clear previous exceptions of other tests
     sys.last_type = None
     del sys.last_type
     backend = DummyEngine(save_commands=True)
@@ -157,6 +157,7 @@ def test_exceptions_are_forwarded():
     eng = _main.MainEngine(backend=ErrorEngine(), engine_list=[])
     with pytest.raises(TypeError):
         eng.allocate_qubit()
-    eng2 = _main.MainEngine(backend=ErrorEngine(), engine_list=[], verbose=True)
+    eng2 = _main.MainEngine(backend=ErrorEngine(), engine_list=[],
+                            verbose=True)
     with pytest.raises(TypeError):
         eng2.allocate_qubit()

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -13,11 +13,14 @@
 #   limitations under the License.
 
 """Tests for projectq.cengines._main.py."""
+import sys
 
 import pytest
+
 from projectq.cengines import DummyEngine, LocalOptimizer
 from projectq.backends import Simulator
-from projectq.ops import H, AllocateQubitGate, FlushGate, DeallocateQubitGate
+from projectq.ops import (AllocateQubitGate, DeallocateQubitGate, FlushGate,
+                          H, X)
 
 from projectq.cengines import _main
 
@@ -69,6 +72,9 @@ def test_main_engine_init_defaults():
 
 
 def test_main_engine_del():
+    #clear previous exceptions of other tests
+    if hasattr(sys, "last_type"):
+        del sys.last_type
     # need engine which caches commands to test that del calls flush
     caching_engine = LocalOptimizer(m=5)
     backend = DummyEngine(save_commands=True)
@@ -77,8 +83,8 @@ def test_main_engine_del():
     H | qubit
     assert len(backend.received_commands) == 0
     eng.__del__()
-    # Allocate, H, and Flush Gate
-    assert len(backend.received_commands) == 3
+    # Allocate, H, Deallocate, and Flush Gate
+    assert len(backend.received_commands) == 4
 
 
 def test_main_engine_set_and_get_measurement_result():

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -14,6 +14,7 @@
 
 """Tests for projectq.cengines._main.py."""
 import sys
+import weakref
 
 import pytest
 
@@ -123,3 +124,38 @@ def test_main_engine_flush():
     assert backend.received_commands[3].gate == DeallocateQubitGate()
     # keep the qubit alive until at least here
     assert len(str(qubit)) != 0
+
+
+def test_main_engine_atexit_no_error():
+    if hasattr(sys, "last_type"):
+        del sys.last_type
+    backend = DummyEngine(save_commands=True)
+    eng = _main.MainEngine(backend=backend, engine_list=[])
+    qb = eng.allocate_qubit()
+    eng._delfun(weakref.ref(eng))
+    assert len(backend.received_commands) == 3
+    assert backend.received_commands[0].gate == AllocateQubitGate()
+    assert backend.received_commands[1].gate == DeallocateQubitGate()
+    assert backend.received_commands[2].gate == FlushGate()
+
+
+def test_main_engine_atexit_with_error():
+    sys.last_type = "Something"
+    backend = DummyEngine(save_commands=True)
+    eng = _main.MainEngine(backend=backend, engine_list=[])
+    qb = eng.allocate_qubit()
+    eng._delfun(weakref.ref(eng))
+    assert len(backend.received_commands) == 1
+    assert backend.received_commands[0].gate == AllocateQubitGate()
+
+
+def test_exceptions_are_forwarded():
+    class ErrorEngine(DummyEngine):
+        def receive(self, command_list):
+            raise TypeError
+    eng = _main.MainEngine(backend=ErrorEngine(), engine_list=[])
+    with pytest.raises(TypeError):
+        eng.allocate_qubit()
+    eng2 = _main.MainEngine(backend=ErrorEngine(), engine_list=[], verbose=True)
+    with pytest.raises(TypeError):
+        eng2.allocate_qubit()

--- a/projectq/meta/_compute.py
+++ b/projectq/meta/_compute.py
@@ -399,6 +399,11 @@ class CustomUncompute(object):
         insert_engine(self.engine, self._uncompute_eng)
 
     def __exit__(self, type, value, traceback):
+        # If an error happens in this context, qubits might not have been
+        # deallocated because that code section was not yet executed,
+        # so don't check and raise an additional error.
+        if type is not None:
+            return
         # Check that all qubits allocated within Compute or within
         # CustomUncompute have been deallocated.
         all_allocated_qubits = self._allocated_qubit_ids.union(

--- a/projectq/meta/_compute_test.py
+++ b/projectq/meta/_compute_test.py
@@ -389,3 +389,13 @@ def test_qubit_management_error2():
     eng.active_qubits = weakref.WeakSet()
     with pytest.raises(_compute.QubitManagementError):
         _compute.Uncompute(eng)
+
+
+def test_only_single_error_in_costum_uncompute():
+    eng = MainEngine(backend=DummyEngine(), engine_list=[])
+    with _compute.Compute(eng):
+        qb = eng.allocate_qubit()
+    # Tests that QubitManagementError is not sent in addition
+    with pytest.raises(RuntimeError):
+        with _compute.CustomUncompute(eng):
+            raise RuntimeError

--- a/projectq/meta/_dagger.py
+++ b/projectq/meta/_dagger.py
@@ -132,6 +132,11 @@ class Dagger(object):
         insert_engine(self.engine, self._dagger_eng)
 
     def __exit__(self, type, value, traceback):
+        # If an error happens in this context, qubits might not have been
+        # deallocated because that code section was not yet executed,
+        # so don't check and raise an additional error.
+        if type is not None:
+            return
         # run dagger engine
         self._dagger_eng.run()
         self._dagger_eng = None

--- a/projectq/meta/_dagger_test.py
+++ b/projectq/meta/_dagger_test.py
@@ -60,3 +60,12 @@ def test_dagger_qubit_management_error():
     with pytest.raises(_dagger.QubitManagementError):
         with _dagger.Dagger(eng):
             ancilla = eng.allocate_qubit()
+
+
+def test_dagger_raises_only_single_error():
+    eng = MainEngine(backend=DummyEngine(), engine_list=[])
+    # Tests that QubitManagementError is not sent in addition
+    with pytest.raises(RuntimeError):
+        with _dagger.Dagger(eng):
+            ancilla = eng.allocate_qubit()
+            raise RuntimeError

--- a/projectq/setups/decompositions/arb1qubit2rzandry.py
+++ b/projectq/setups/decompositions/arb1qubit2rzandry.py
@@ -42,7 +42,7 @@ TOLERANCE = 1e-12
 
 
 def _recognize_arb1qubit(cmd):
-    """ 
+    """
     Recognize an arbitrary one qubit gate which has a matrix property.
 
     It does not allow gates which have control qubits as otherwise the


### PR DESCRIPTION
* Stop further exceptions from being thrown once the first exception causes to terminate the program. This includes the case where the first exception is by the user code and not from within ProjectQ.
* Verbose flag for `MainEngine`. By default it is `False` which has the effect that the users only see a shortened stack trace if an exception occurred within ProjectQ. But this compact stack trace should contain all the necessary debug information in most cases.
* When MainEngine goes out of scope, it not only sends a Flush gate but also deallocates all active qubits first

(Addresses first part of #192)