### PR TITLE
Make the selection of setups (and default engines) more explicit.

### DIFF
--- a/examples/compiler_tutorial.ipynb
+++ b/examples/compiler_tutorial.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "source": [
     "# ProjectQ Compiler Tutorial\n"
@@ -13,30 +11,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "The aim of this short tutorial is to give a first introduction to the ProjectQ compiler. In particular, we will show how to specify the gate set to which the compiler should translate a quantum program. A more extended tutorial will follow soon. Please check out our [ProjectQ paper](http://arxiv.org/abs/1612.08091) for an introduction to the basic concepts behind our compiler."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## The default compiler"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "To compile a quantum program, we begin by creating a compiler called `MainEngine` and specify the backend for which the compiler should translate the program. For the purpose of this tutorial, we will use a `CommandPrinter` as a backend to display the compiled algorithm. It works the same for all other backends such as, e.g., the simulator or an interface to real hardware.\n",
     "\n",
@@ -46,11 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -101,10 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "In the above example, the compiler did nothing because the default compiler (when `MainEngine` is called without a specific `engine_list` parameter) translates the individual gates to the gate set supported by the backend. In our case, the backend is a `CommandPrinter` which supports any type of gate.\n",
     "\n",
@@ -114,11 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -130,10 +108,10 @@
       "Allocate | Qureg[3]\n",
       "Cexp(-0.1j * (0.5 X0 Y1 Z2)) | ( Qureg[0], Qureg[1-3] )\n",
       "H | Qureg[3]\n",
-      "CR(1.5707963267948966) | ( Qureg[2], Qureg[3] )\n",
-      "CR(0.7853981633974483) | ( Qureg[1], Qureg[3] )\n",
+      "CR(1.5707963268) | ( Qureg[2], Qureg[3] )\n",
+      "CR(0.785398163397) | ( Qureg[1], Qureg[3] )\n",
       "H | Qureg[2]\n",
-      "CR(1.5707963267948966) | ( Qureg[1], Qureg[2] )\n",
+      "CR(1.5707963268) | ( Qureg[1], Qureg[2] )\n",
       "H | Qureg[1]\n",
       "Rx(0.1) | Qureg[0]\n",
       "CX | ( Qureg[0], Qureg[1] )\n",
@@ -150,9 +128,10 @@
    ],
    "source": [
     "from projectq.backends import Simulator\n",
+    "from projectq.setups.default import get_engine_list\n",
     "\n",
     "# Use the default compiler engines with a CommandPrinter in the end:\n",
-    "engines2 = projectq.default_engines() + [CommandPrinter()]\n",
+    "engines2 = get_engine_list() + [CommandPrinter()]\n",
     "\n",
     "eng2 = projectq.MainEngine(backend=Simulator(), engine_list=engines2)\n",
     "my_quantum_program(eng2)"
@@ -160,30 +139,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "As one can see, in this case the compiler had to do a little work because the Simulator does not support a QFT gate. Therefore, it automatically replaces the QFT gate by a sequence of lower-level gates."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Specifying a particular gate set"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "In this short example, we want to explore how to specify a particular gate set, which may be even more restrictive than what the backend naturally supports. This is useful, e.g., to obtain resource estimates for running a given program on actual quantum hardware which, in this example, can only perform CNOT and single qubit gates. All one has to do is insert an `InstructionFilter` into the `engine_list`:"
    ]
@@ -191,11 +161,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -203,7 +169,7 @@
      "text": [
       "Allocate | Qureg[3]\n",
       "Allocate | Qureg[2]\n",
-      "Rx(1.5707963267948966) | Qureg[2]\n",
+      "Rx(1.5707963268) | Qureg[2]\n",
       "Allocate | Qureg[1]\n",
       "H | Qureg[1]\n",
       "CX | ( Qureg[1], Qureg[2] )\n",
@@ -211,28 +177,28 @@
       "Rz(0.05) | Qureg[3]\n",
       "Allocate | Qureg[0]\n",
       "CX | ( Qureg[0], Qureg[3] )\n",
-      "Rz(12.516370614359172) | Qureg[3]\n",
+      "Rz(12.5163706144) | Qureg[3]\n",
       "CX | ( Qureg[0], Qureg[3] )\n",
       "CX | ( Qureg[2], Qureg[3] )\n",
       "CX | ( Qureg[1], Qureg[2] )\n",
       "H | Qureg[1]\n",
-      "R(0.39269908169872414) | Qureg[1]\n",
+      "R(0.392699081698) | Qureg[1]\n",
       "H | Qureg[3]\n",
-      "Rz(0.7853981633974483) | Qureg[3]\n",
-      "Rx(10.995574287564276) | Qureg[2]\n",
-      "R(0.7853981633974483) | Qureg[2]\n",
+      "Rz(0.785398163398) | Qureg[3]\n",
+      "Rx(10.9955742876) | Qureg[2]\n",
+      "R(0.785398163398) | Qureg[2]\n",
       "CX | ( Qureg[2], Qureg[3] )\n",
-      "Rz(11.780972450961723) | Qureg[3]\n",
+      "Rz(11.780972451) | Qureg[3]\n",
       "CX | ( Qureg[2], Qureg[3] )\n",
-      "Rz(0.39269908169872414) | Qureg[3]\n",
+      "Rz(0.392699081698) | Qureg[3]\n",
       "CX | ( Qureg[1], Qureg[3] )\n",
-      "Rz(12.173671532660448) | Qureg[3]\n",
+      "Rz(12.1736715327) | Qureg[3]\n",
       "CX | ( Qureg[1], Qureg[3] )\n",
-      "R(0.7853981633974483) | Qureg[1]\n",
+      "R(0.785398163398) | Qureg[1]\n",
       "H | Qureg[2]\n",
-      "Rz(0.7853981633974483) | Qureg[2]\n",
+      "Rz(0.785398163398) | Qureg[2]\n",
       "CX | ( Qureg[1], Qureg[2] )\n",
-      "Rz(11.780972450961723) | Qureg[2]\n",
+      "Rz(11.780972451) | Qureg[2]\n",
       "CX | ( Qureg[1], Qureg[2] )\n",
       "H | Qureg[1]\n",
       "Rx(0.1) | Qureg[0]\n",
@@ -271,7 +237,7 @@
     "supported_gate_set_filter = InstructionFilter(is_supported)\n",
     "\n",
     "# Append the instruction filter to the list of compiler engines:\n",
-    "engines3 = projectq.default_engines() + [supported_gate_set_filter]\n",
+    "engines3 = get_engine_list() + [supported_gate_set_filter]\n",
     "\n",
     "eng3 = projectq.MainEngine(backend=CommandPrinter(accept_input=False), engine_list=engines3)\n",
     "my_quantum_program(eng3)"
@@ -279,10 +245,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "As we can see, the compiler now needs to do a little more work. In some cases, the compiler does not know how to translate a command according to the specified gate set and it will throw a `NoGateDecompositionError`. This means one needs to implement a rule specifying how to decompose said command. See projectq/setups/decompositions for a few examples. This will be explained in a more extended tutorial."
    ]
@@ -291,9 +254,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": []
@@ -301,21 +262,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
   }
  },
  "nbformat": 4,

--- a/examples/ibm.py
+++ b/examples/ibm.py
@@ -39,6 +39,7 @@ def run_entangle(eng, num_qubits=5):
 if __name__ == "__main__":
     # create main compiler engine for the IBM back-end
     eng = MainEngine(IBMBackend(use_hardware=True, num_runs=1024,
-                                verbose=False, device='ibmqx4'))
+                                verbose=False, device='ibmqx4'),
+                     setup=projectq.setups.ibm)
     # run the circuit and print the result
     print(run_entangle(eng))

--- a/examples/ibm16.py
+++ b/examples/ibm16.py
@@ -48,7 +48,7 @@ def run_test(eng):
 if __name__ == "__main__":
     # create main compiler engine for the 16-qubit IBM back-end
     eng = MainEngine(IBMBackend(use_hardware=True, num_runs=1024,
-                                verbose=False, device='ibmqx5')
+                                verbose=False, device='ibmqx5'),
                      setup=projectq.setups.ibm16)
     # run the circuit and print the result
     print(run_test(eng))

--- a/examples/ibm16.py
+++ b/examples/ibm16.py
@@ -48,6 +48,7 @@ def run_test(eng):
 if __name__ == "__main__":
     # create main compiler engine for the 16-qubit IBM back-end
     eng = MainEngine(IBMBackend(use_hardware=True, num_runs=1024,
-                                verbose=False, device='ibmqx5'))
+                                verbose=False, device='ibmqx5')
+                     setup=projectq.setups.ibm16)
     # run the circuit and print the result
     print(run_test(eng))

--- a/examples/ibm_entangle.ipynb
+++ b/examples/ibm_entangle.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# ProjectQ Demo\n",
     "## Compiling code for IBM QE"
@@ -13,10 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Import the IBM setup, the gates, and the compiler engine:"
    ]
@@ -24,11 +18,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import projectq.setups.ibm # Imports the default compiler to map to IBM QE\n",
@@ -39,10 +29,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Create the compiler using the default compiler engines for the IBM backend and allocate a quantum register of 3 qubits:"
    ]
@@ -50,23 +37,17 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "engine = MainEngine(IBMBackend(use_hardware=True, num_runs=1024, verbose=True, device='ibmqx4'))\n",
+    "engine = MainEngine(IBMBackend(use_hardware=True, num_runs=1024, verbose=True, device='ibmqx4'),\n",
+    "                    setup=projectq.setups.ibm)\n",
     "qureg = engine.allocate_qureg(3)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
     "scrolled": true
    },
    "source": [
@@ -76,11 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "Entangle | qureg"
@@ -89,9 +66,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "source": [
     "Measure the quantum register and run the circuit:"
@@ -100,11 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -134,10 +105,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Output the measurement result:"
    ]
@@ -145,11 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -166,9 +130,7 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "source": [
     "## Inspecting the gates required for a 5-qubit entangle on IBM QE"
@@ -203,9 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "qureg2 = engine2.allocate_qureg(5)"
@@ -231,9 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -355,9 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -374,23 +330,23 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/quantum_random_numbers_ibm.py
+++ b/examples/quantum_random_numbers_ibm.py
@@ -4,7 +4,7 @@ from projectq import MainEngine
 from projectq.backends import IBMBackend
 
 # create a main compiler engine
-eng = MainEngine(IBMBackend())
+eng = MainEngine(IBMBackend(), setup=projectq.setups.ibm)
 
 # allocate one qubit
 q1 = eng.allocate_qubit()

--- a/examples/teleport.py
+++ b/examples/teleport.py
@@ -1,4 +1,3 @@
-import projectq.setups.default
 from projectq.ops import H, X, Z, Rz, CNOT, Measure
 from projectq import MainEngine
 from projectq.meta import Dagger, Control

--- a/examples/teleport_circuit.py
+++ b/examples/teleport_circuit.py
@@ -1,4 +1,3 @@
-import projectq.setups.default
 from projectq import MainEngine
 from projectq.backends import CircuitDrawer
 

--- a/projectq/__init__.py
+++ b/projectq/__init__.py
@@ -17,7 +17,6 @@ ProjectQ - An open source software framework for quantum computing
 
 Get started:
     Simply import the main compiler engine (from projectq import MainEngine)
-    together with your setup of choice (e.g., import projectq.setups.default)
     and start coding!
 
     For examples, see the example folder, which features implementation of

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -18,6 +18,7 @@ import weakref
 
 import pytest
 
+import projectq.setups.default
 from projectq.cengines import DummyEngine, LocalOptimizer
 from projectq.backends import Simulator
 from projectq.ops import (AllocateQubitGate, DeallocateQubitGate, FlushGate,
@@ -48,6 +49,9 @@ def test_main_engine_init():
 
 
 def test_main_engine_init_failure():
+    with pytest.raises(ValueError):
+        eng = _main.MainEngine(engine_list=[DummyEngine()],
+                               setup=projectq.setups.default)
     with pytest.raises(_main.UnsupportedEngineError):
         eng = _main.MainEngine(backend=DummyEngine)
     with pytest.raises(_main.UnsupportedEngineError):

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -67,8 +67,9 @@ def test_main_engine_init_defaults():
         eng_list.append(current_engine)
         current_engine = current_engine.next_engine
     assert isinstance(eng_list[-1].next_engine, Simulator)
-    from projectq.setups.default import default_engines
-    for engine, expected in zip(eng_list, default_engines()):
+    import projectq.setups.default
+    default_engines = projectq.setups.default.get_engine_list()
+    for engine, expected in zip(eng_list, default_engines):
         assert type(engine) == type(expected)
 
 

--- a/projectq/setups/default.py
+++ b/projectq/setups/default.py
@@ -30,12 +30,10 @@ from projectq.cengines import (TagRemover,
                                DecompositionRuleSet)
 
 
-def default_engines():
+def get_engine_list():
     rule_set = DecompositionRuleSet(modules=[projectq.setups.decompositions])
     return [TagRemover(),
             LocalOptimizer(10),
             AutoReplacer(rule_set),
             TagRemover(),
             LocalOptimizer(10)]
-
-projectq.default_engines = default_engines

--- a/projectq/setups/ibm.py
+++ b/projectq/setups/ibm.py
@@ -32,7 +32,7 @@ from projectq.cengines import (TagRemover,
                                DecompositionRuleSet)
 
 
-def ibm_default_engines():
+def get_engine_list():
     rule_set = DecompositionRuleSet(modules=[projectq.setups.decompositions])
     return [TagRemover(),
             LocalOptimizer(10),
@@ -40,6 +40,3 @@ def ibm_default_engines():
             TagRemover(),
             IBMCNOTMapper(),
             LocalOptimizer(10)]
-
-
-projectq.default_engines = ibm_default_engines

--- a/projectq/setups/ibm16.py
+++ b/projectq/setups/ibm16.py
@@ -32,7 +32,7 @@ from projectq.cengines import (TagRemover,
                                DecompositionRuleSet)
 
 
-def ibm16_default_engines():
+def get_engine_list():
     rule_set = DecompositionRuleSet(modules=[projectq.setups.decompositions])
     return [TagRemover(),
             LocalOptimizer(10),
@@ -40,6 +40,3 @@ def ibm16_default_engines():
             TagRemover(),
             ManualMapper(),
             LocalOptimizer(10)]
-
-
-projectq.default_engines = ibm16_default_engines

--- a/projectq/setups/ibm16_test.py
+++ b/projectq/setups/ibm16_test.py
@@ -20,12 +20,7 @@ from projectq.cengines import ManualMapper
 def test_manual_mapper_in_cengines():
     import projectq.setups.ibm16
     found = False
-    for engine in projectq.setups.ibm16.ibm16_default_engines():
+    for engine in projectq.setups.ibm16.get_engine_list():
         if isinstance(engine, ManualMapper):
             found = True
-
-    # To undo the changes of loading the IBM setup:
-    import projectq.setups.default
-    projectq.default_engines = projectq.setups.default.default_engines
-
     assert found

--- a/projectq/setups/ibm_test.py
+++ b/projectq/setups/ibm_test.py
@@ -21,10 +21,7 @@ from projectq.cengines import IBMCNOTMapper
 def test_ibm_cnot_mapper_in_cengines():
     import projectq.setups.ibm
     found = False
-    for engine in projectq.setups.ibm.ibm_default_engines():
+    for engine in projectq.setups.ibm.get_engine_list():
         if isinstance(engine, IBMCNOTMapper):
             found = True
-    # To undo the changes of loading the IBM setup:
-    import projectq.setups.default
-    projectq.default_engines = projectq.setups.default.default_engines
     assert found


### PR DESCRIPTION
This PR addresses the second point in #192: It makes the selection of setups more explicit by adding an additional parameter to `MainEngine`. To select, e.g., the `ibm` setup, one now does
```
from projectq import MainEngine
import projectq.setups.ibm
...
eng = MainEngine(..., setup=projectq.setups.ibm)
...
```