### PR TITLE
Option to allocate qubits at 0 when drawing circuits.

### DIFF
--- a/projectq/backends/_circuits/_to_latex.py
+++ b/projectq/backends/_circuits/_to_latex.py
@@ -334,7 +334,8 @@ class _Circ2Tikz(object):
                     id_str = "^{{\\textcolor{{red}}{{{}}}}}".format(cmds[i].id)
                 xpos = self.pos[line]
                 try:
-                    if self.settings['gates']['AllocateQubitGate']['allocate_at_zero']:
+                    if (self.settings['gates']['AllocateQubitGate']
+                                     ['allocate_at_zero']):
                         xpos = 0.
                 except KeyError:
                     pass

--- a/projectq/backends/_circuits/_to_latex.py
+++ b/projectq/backends/_circuits/_to_latex.py
@@ -111,7 +111,8 @@ def get_default_settings():
                           'AllocateQubitGate': {'height': .15, 'width': .2,
                                                 'offset': .1,
                                                 'pre_offset': .1,
-                                                'draw_id': False},
+                                                'draw_id': False,
+                                                'allocate_at_zero': False},
                           'MeasureGate': {'width': 0.75, 'offset': .2,
                                           'height': .5, 'pre_offset': .2}
                           })

--- a/projectq/backends/_circuits/_to_latex.py
+++ b/projectq/backends/_circuits/_to_latex.py
@@ -336,7 +336,7 @@ class _Circ2Tikz(object):
                 try:
                     if (self.settings['gates']['AllocateQubitGate']
                                      ['allocate_at_zero']):
-                        xpos = 0.
+                        xpos = self._gate_pre_offset(gate)
                 except KeyError:
                     pass
                 self.pos[line] = max(xpos + self._gate_offset(gate) +

--- a/projectq/backends/_circuits/_to_latex.py
+++ b/projectq/backends/_circuits/_to_latex.py
@@ -336,6 +336,7 @@ class _Circ2Tikz(object):
                 try:
                     if (self.settings['gates']['AllocateQubitGate']
                                      ['allocate_at_zero']):
+                        self.pos[line] -= self._gate_pre_offset(gate)
                         xpos = self._gate_pre_offset(gate)
                 except KeyError:
                     pass

--- a/projectq/backends/_circuits/_to_latex.py
+++ b/projectq/backends/_circuits/_to_latex.py
@@ -332,11 +332,17 @@ class _Circ2Tikz(object):
                 id_str = ""
                 if self.settings['gates']['AllocateQubitGate']['draw_id']:
                     id_str = "^{{\\textcolor{{red}}{{{}}}}}".format(cmds[i].id)
-                add_str = add_str.format(self._op(line), self.pos[line], line,
+                xpos = self.pos[line]
+                try:
+                    if self.settings['gates']['AllocateQubitGate']['allocate_at_zero']:
+                        xpos = 0.
+                except KeyError:
+                    pass
+                self.pos[line] = max(xpos + self._gate_offset(gate) +
+                                     self._gate_width(gate), self.pos[line])
+                add_str = add_str.format(self._op(line), xpos, line,
                                          id_str)
                 self.op_count[line] += 1
-                self.pos[line] += (self._gate_offset(gate) +
-                                   self._gate_width(gate))
                 self.is_quantum[line] = self.settings['lines']['init_quantum']
             elif gate == Deallocate:
                 # draw 'end of line'

--- a/projectq/backends/_circuits/_to_latex_test.py
+++ b/projectq/backends/_circuits/_to_latex_test.py
@@ -204,11 +204,14 @@ def test_qubit_allocations_at_zero():
     settings = _to_latex.get_default_settings()
     settings['gates']['AllocateQubitGate']['allocate_at_zero'] = True
     code = _to_latex._body(copy.deepcopy(circuit_lines), settings)
-
     assert code.count("gate0) at (0") == 4
+
     settings['gates']['AllocateQubitGate']['allocate_at_zero'] = False
     code = _to_latex._body(copy.deepcopy(circuit_lines), settings)
+    assert code.count("gate0) at (0") == 3
 
+    del settings['gates']['AllocateQubitGate']['allocate_at_zero']
+    code = _to_latex._body(copy.deepcopy(circuit_lines), settings)
     assert code.count("gate0) at (0") == 3
 
 

--- a/projectq/backends/_circuits/_to_latex_test.py
+++ b/projectq/backends/_circuits/_to_latex_test.py
@@ -18,6 +18,7 @@ Tests for projectq.backends._circuits._to_latex.py.
 
 import pytest
 import builtins
+import copy
 
 from projectq import MainEngine
 from projectq.cengines import LastEngineException
@@ -179,6 +180,36 @@ def test_body():
     assert code.count("measure") == 1  # 1 measurement
     assert code.count("{{{}}}".format(str(Z))) == 1  # 1 Z gate
     assert code.count("{red}") == 3
+
+
+def test_qubit_allocations_at_zero():
+    drawer = _drawer.CircuitDrawer()
+    eng = MainEngine(drawer, [])
+    old_tolatex = _drawer.to_latex
+    _drawer.to_latex = lambda x: x
+
+    a = eng.allocate_qureg(4)
+
+    CNOT | (a[0],a[2])
+    CNOT | (a[0],a[3])
+    CNOT | (a[0],a[2])
+    CNOT | (a[1],a[3])
+
+    del a
+    eng.flush()
+
+    circuit_lines = drawer.get_latex()
+    _drawer.to_latex = old_tolatex
+
+    settings = _to_latex.get_default_settings()
+    settings['gates']['AllocateQubitGate']['allocate_at_zero'] = True
+    code = _to_latex._body(copy.deepcopy(circuit_lines), settings)
+
+    assert code.count("gate0) at (0") == 4
+    settings['gates']['AllocateQubitGate']['allocate_at_zero'] = False
+    code = _to_latex._body(copy.deepcopy(circuit_lines), settings)
+
+    assert code.count("gate0) at (0") == 3
 
 
 def test_qubit_lines_classicalvsquantum1():

--- a/projectq/backends/_circuits/_to_latex_test.py
+++ b/projectq/backends/_circuits/_to_latex_test.py
@@ -190,10 +190,10 @@ def test_qubit_allocations_at_zero():
 
     a = eng.allocate_qureg(4)
 
-    CNOT | (a[0],a[2])
-    CNOT | (a[0],a[3])
-    CNOT | (a[0],a[2])
-    CNOT | (a[1],a[3])
+    CNOT | (a[0], a[2])
+    CNOT | (a[0], a[3])
+    CNOT | (a[0], a[2])
+    CNOT | (a[1], a[3])
 
     del a
     eng.flush()


### PR DESCRIPTION
This PR adds an option to settings.json which forces qubit allocation to happen at x=0 when drawing circuits.