### PR TITLE
Change to single qubit measurement

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -88,7 +88,7 @@ The complete example looks as follows:
 
 .. literalinclude:: ../examples/teleport.py
 	:linenos:
-	:lines: 1-6,18-27,44-99
+	:lines: 1-6,18-27,44-100
 	:tab-width: 2
 
 and the corresponding circuit can be generated using
@@ -162,9 +162,9 @@ As a third example, consider Shor's algorithm for factoring, which for a given (
 	Simulating Shor's algorithm at the level of single-qubit gates and CNOTs already takes quite a bit of time for larger numbers than 15. To turn on our **emulation feature**, which does not decompose the modular arithmetic to low-level gates, but carries it out directly instead, we can change the line
 	
 	.. literalinclude:: ../examples/shor.py
-		:lineno-start: 94
-		:lines: 94-106
-		:emphasize-lines: 10
+		:lineno-start: 86
+		:lines: 86-99
+		:emphasize-lines: 8
 		:linenos:
 		:tab-width: 2
 	
@@ -173,8 +173,8 @@ As a third example, consider Shor's algorithm for factoring, which for a given (
 	The most important part of the code is
 	
 	.. literalinclude:: ../examples/shor.py
-		:lines: 59-78
-		:lineno-start: 59
+		:lines: 50-69
+		:lineno-start: 50
 		:linenos:
 		:dedent: 1
 		:tab-width: 2

--- a/examples/gate_zoo.py
+++ b/examples/gate_zoo.py
@@ -28,10 +28,10 @@ def zoo_profile():
         (Rz(0.5), 1), (Ph(0.5), 0), (S, 3), (T, 2), (H, 1),
         (Toffoli, (0, 1, 2)), (Barrier, None), (Swap, (0, 3)),
         (SqrtSwap, (0, 1)), (get_inverse(SqrtSwap), (2, 3)),
-        (SqrtX, 2), (C(get_inverse(SqrtX)), (0, 2)), (C(Ry(0.5)), (2, 3)), (CNOT, (2, 1)),
-        (Entangle, None), (te_gate, None), (QFT, None), (Tensor(H), None),
-        (BasicMathGate(add), (2, 3)),
-        (Measure, None),
+        (SqrtX, 2), (C(get_inverse(SqrtX)), (0, 2)), (C(Ry(0.5)), (2, 3)),
+        (CNOT, (2, 1)), (Entangle, None), (te_gate, None), (QFT, None),
+        (Tensor(H), None), (BasicMathGate(add), (2, 3)),
+        (All(Measure), None),
     ]
 
     # apply them

--- a/examples/grover.py
+++ b/examples/grover.py
@@ -49,7 +49,7 @@ def run_grover(eng, n, oracle):
 
         Uncompute(eng)
 
-    Measure | x
+    All(Measure) | x
     Measure | oracle_out
 
     eng.flush()

--- a/examples/ibm_entangle.ipynb
+++ b/examples/ibm_entangle.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import projectq.setups.ibm # Imports the default compiler to map to IBM QE\n",
     "from projectq.backends import IBMBackend\n",
-    "from projectq.ops import Measure, Entangle\n",
+    "from projectq.ops import All, Entangle, Measure\n",
     "from projectq import MainEngine"
    ]
   },
@@ -81,25 +81,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Authenticating...\n",
-      "IBM QE user (e-mail) > haenert@phys.ethz.ch\n",
+      "- Authenticating...\n",
+      "IBM QE user (e-mail) > dsteiger@phys.ethz.ch\n",
       "IBM QE password > ········\n",
-      "Running code...\n",
-      "Waiting for results...\n",
-      "Done.\n",
-      "00000 with p = 0.4814453125\n",
-      "10000 with p = 0.00390625\n",
-      "01000 with p = 0.0087890625\n",
-      "11000 with p = 0.0205078125\n",
-      "00100 with p = 0.02734375\n",
-      "10100 with p = 0.046875\n",
-      "01100 with p = 0.04296875\n",
-      "11100 with p = 0.3681640625*\n"
+      "- Running code: \n",
+      "include \"qelib1.inc\";\n",
+      "qreg q[3];\n",
+      "creg c[3];\n",
+      "h q[2];\n",
+      "cx q[2], q[0];\n",
+      "h q[1];\n",
+      "cx q[1], q[0];\n",
+      "h q[0];\n",
+      "measure q[0] -> c[0];\n",
+      "h q[2];\n",
+      "measure q[2] -> c[2];\n",
+      "h q[1];\n",
+      "measure q[1] -> c[1];\n",
+      "- Waiting for results...\n",
+      "- Done.\n",
+      "11100 with p = 0.4033203125*\n",
+      "01100 with p = 0.041015625\n",
+      "10000 with p = 0.0185546875\n",
+      "00000 with p = 0.3828125\n",
+      "01000 with p = 0.015625\n",
+      "11000 with p = 0.0546875\n",
+      "00100 with p = 0.0419921875\n",
+      "10100 with p = 0.0419921875\n"
      ]
     }
    ],
    "source": [
-    "Measure | qureg\n",
+    "All(Measure) | qureg\n",
     "engine.flush()"
    ]
   },
@@ -146,13 +159,11 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from projectq.backends import CommandPrinter\n",
-    "engine2 = MainEngine(CommandPrinter())"
+    "engine2 = MainEngine(CommandPrinter(), setup=projectq.setups.ibm)"
    ]
   },
   {
@@ -256,9 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from projectq.backends import Simulator\n",
@@ -275,9 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "qureg3 = engine3.allocate_qureg(5)\n",
@@ -294,12 +301,10 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "Measure | qureg3\n",
+    "All(Measure) | qureg3\n",
     "engine3.flush()"
    ]
   },
@@ -326,6 +331,13 @@
    "source": [
     "print([int(q) for q in qureg3])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -344,7 +356,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/examples/shor.py
+++ b/examples/shor.py
@@ -14,24 +14,14 @@ from builtins import input
 import projectq.libs.math
 import projectq.setups.decompositions
 from projectq.backends import Simulator, ResourceCounter
-from projectq.cengines import (MainEngine,
-                               AutoReplacer,
-                               LocalOptimizer,
-                               TagRemover,
-                               InstructionFilter,
-                               DecompositionRuleSet)
-from projectq.libs.math import (AddConstant,
-                                AddConstantModN,
+from projectq.cengines import (AutoReplacer, DecompositionRuleSet,
+                               InstructionFilter, LocalOptimizer,
+                               MainEngine, TagRemover)
+from projectq.libs.math import (AddConstant, AddConstantModN,
                                 MultiplyByConstantModN)
 from projectq.meta import Control
-from projectq.ops import (X,
-                          Measure,
-                          H,
-                          R,
-                          QFT,
-                          Swap,
-                          get_inverse,
-                          BasicMathGate)
+from projectq.ops import (All, BasicMathGate, get_inverse, H, Measure, QFT, R,
+                          Swap, X)
 
 
 def run_shor(eng, N, a, verbose=False):
@@ -81,7 +71,7 @@ def run_shor(eng, N, a, verbose=False):
             print("\033[95m{}\033[0m".format(measurements[k]), end="")
             sys.stdout.flush()
 
-    Measure | x
+    All(Measure) | x
     # turn the measured values into a number in [0,1)
     y = sum([(measurements[2 * n - 1 - i]*1. / (1 << (i + 1)))
              for i in range(2 * n)])

--- a/examples/simulator_tutorial.ipynb
+++ b/examples/simulator_tutorial.ipynb
@@ -184,7 +184,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Exception RuntimeError: 'Error: Qubit has not been measured / uncomputed! There is most likely a bug in your code.' in <bound method Qubit.__del__ of <projectq.types._qubit.Qubit object at 0x10c594310>> ignored\n"
+      "Exception RuntimeError: RuntimeError('Error: Qubit has not been measured / uncomputed! There is most likely a bug in your code.\\n raised in:\\n\\'  File \"/Users/damian/ProjectQ/ProjectQ/projectq/backends/_sim/_simulator.py\", line 385, in _handle\\'\\n\\'    self._simulator.deallocate_qubit(ID)\\'',) in <bound method Qubit.__del__ of <projectq.types._qubit.Qubit object at 0x104ec1290>> ignored\n"
      ]
     }
    ],
@@ -216,7 +216,7 @@
     "    # Do something\n",
     "    ancillas = eng.allocate_qureg(3) # allocates a quantum register with 3 qubits\n",
     "    All(H) | ancillas # applies a Hadamard gate to each of the 3 ancilla qubits\n",
-    "    Measure | ancillas # Measures all ancilla qubits such that we don't get\n",
+    "    All(Measure) | ancillas # Measures all ancilla qubits such that we don't get\n",
     "                            #an error message when they are deallocated\n",
     "    # Here the ancillas will go out of scope but because of the measurement, they are in a classical state\n",
     "test_program_2(eng)"
@@ -369,7 +369,7 @@
     "print(\"Probability to measure 10: {}\".format(prob10))\n",
     "print(\"Probability that second qubit is in state 0: {}\".format(prob_second_0))\n",
     "\n",
-    "Measure | qureg"
+    "All(Measure) | qureg"
    ]
   },
   {
@@ -412,7 +412,7 @@
     "expectation2 = eng.backend.get_expectation_value(op_sum, qureg)\n",
     "print(\"Expectation value = <Psi|-0.5 X1 + 1.0 Z0 X1|Psi> = {}\".format(expectation2))\n",
     "\n",
-    "Measure | qureg # To avoid error message of deallocating qubits in a superposition"
+    "All(Measure) | qureg # To avoid error message of deallocating qubits in a superposition"
    ]
   },
   {
@@ -586,7 +586,7 @@
     "amplitude  = eng.backend.get_amplitude('01', qubit1 + qubit2)\n",
     "print(\"Accessing same amplitude but using get_amplitude instead: {}\".format(amplitude))\n",
     "\n",
-    "Measure | qubit1 + qubit2 # In order to not deallocate a qubit in a superposition state"
+    "All(Measure) | qubit1 + qubit2 # In order to not deallocate a qubit in a superposition state"
    ]
   },
   {
@@ -666,7 +666,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "version": "2.7.15"
   }
  },
  "nbformat": 4,

--- a/examples/teleport.py
+++ b/examples/teleport.py
@@ -1,4 +1,4 @@
-from projectq.ops import H, X, Z, Rz, CNOT, Measure
+from projectq.ops import All, CNOT, H, Measure, Rz, X, Z
 from projectq import MainEngine
 from projectq.meta import Dagger, Control
 
@@ -57,7 +57,8 @@ def run_teleport(eng, state_creation_function, verbose=False):
 
     # measure two values (once in Hadamard basis) and send the bits to Bob
     H | psi
-    Measure | (psi, b1)
+    Measure | psi
+    Measure | b1
     msg_to_bob = [int(psi), int(b1)]
     if verbose:
         print("Alice is sending the message {} to Bob.".format(msg_to_bob))

--- a/projectq/backends/_ibm/_ibm_test.py
+++ b/projectq/backends/_ibm/_ibm_test.py
@@ -26,9 +26,8 @@ from projectq.cengines import (TagRemover,
                                IBMCNOTMapper,
                                DummyEngine,
                                DecompositionRuleSet)
-from projectq.ops import (Command, X, Y, Z, T, Tdag, S, Sdag, Measure,
-                          Allocate, Deallocate, NOT, Rx, Ry, Rz, Barrier,
-                          Entangle)
+from projectq.ops import (All, Allocate, Barrier, Command, Deallocate, Entangle,
+                          Measure, NOT, Rx, Ry, Rz, S, Sdag, T, Tdag, X, Y, Z)
 
 
 # Insure that no HTTP request can be made in all tests in this module
@@ -143,7 +142,7 @@ def test_ibm_backend_functional_test(monkeypatch):
     Rx(0.2) | qureg[0]
     del unused_qubit
     # measure; should be all-0 or all-1
-    Measure | qureg
+    All(Measure) | qureg
     # run the circuit
     eng.flush()
     prob_dict = eng.backend.get_probabilities([qureg[0], qureg[2], qureg[1]])

--- a/projectq/backends/_resource_test.py
+++ b/projectq/backends/_resource_test.py
@@ -19,7 +19,7 @@ Tests for projectq.backends._resource.py.
 import pytest
 
 from projectq.cengines import MainEngine, DummyEngine
-from projectq.ops import H, CNOT, X, Rz, Measure
+from projectq.ops import All, CNOT, H, Measure, Rz, X 
 
 from projectq.backends import ResourceCounter
 
@@ -55,7 +55,7 @@ def test_resource_counter():
     Rz(0.1) | qubit1
     Rz(0.3) | qubit1
 
-    Measure | (qubit1, qubit3)
+    All(Measure) | qubit1 + qubit3
 
     assert int(qubit1) == int(qubit3)
     assert int(qubit1) == 0
@@ -81,7 +81,7 @@ def test_resource_counter():
     sent_gates = [cmd.gate for cmd in backend.received_commands]
     assert sent_gates.count(H) == 1
     assert sent_gates.count(X) == 2
-    assert sent_gates.count(Measure) == 1
+    assert sent_gates.count(Measure) == 2
 
 
 def test_resource_counter_str_when_empty():

--- a/projectq/backends/_sim/_classical_simulator_test.py
+++ b/projectq/backends/_sim/_classical_simulator_test.py
@@ -15,9 +15,10 @@
 import pytest
 
 from projectq import MainEngine
-from projectq.ops import (X, NOT, C, BasicMathGate, Measure, FlushGate,
-                          Allocate, Deallocate, Command, Y)
+from projectq.ops import (All, Allocate, BasicMathGate, C, Command, Deallocate,
+                          FlushGate, Measure, NOT, X, Y)
 from projectq.cengines import AutoReplacer, DecompositionRuleSet, DummyEngine
+
 from ._classical_simulator import ClassicalSimulator
 
 
@@ -111,7 +112,7 @@ def test_simulator_arithmetic():
     assert sim.read_register(b) == 24
 
     # also test via measurement:
-    Measure | (a, b)
+    All(Measure) | a + b
     eng.flush()
 
     for i in range(len(a)):

--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -28,22 +28,9 @@ import scipy.sparse.linalg
 
 from projectq import MainEngine
 from projectq.cengines import DummyEngine
-from projectq.ops import (H,
-                          X,
-                          Y,
-                          Z,
-                          S,
-                          Rx,
-                          Ry,
-                          Rz,
-                          CNOT,
-                          Toffoli,
-                          Measure,
-                          BasicGate,
-                          BasicMathGate,
-                          QubitOperator,
-                          TimeEvolution,
-                          All)
+from projectq.ops import (All, BasicGate, BasicMathGate, CNOT, H, Measure,
+                          QubitOperator, Rx, Ry, Rz, S, TimeEvolution, Toffoli,
+                          X, Y, Z)
 from projectq.meta import Control, Dagger
 
 from projectq.backends import Simulator
@@ -173,7 +160,7 @@ def test_simulator_functional_measurement(sim):
     for qb in qubits[1:]:
         CNOT | (qubits[0], qb)
 
-    Measure | qubits
+    All(Measure) | qubits
 
     bit_value_sum = sum([int(qubit) for qubit in qubits])
     assert bit_value_sum == 0 or bit_value_sum == 5
@@ -200,7 +187,7 @@ def test_simulator_emulation(sim):
         Plus2Gate() | (qubit1 + qubit2)
     assert 1. == pytest.approx(sim.cheat()[1][6])
 
-    Measure | (qubit1 + qubit2 + qubit3)
+    All(Measure) | (qubit1 + qubit2 + qubit3)
 
 
 def test_simulator_kqubit_gate(sim):
@@ -287,7 +274,7 @@ def test_simulator_probability(sim):
             pytest.approx(0.18))
     assert (eng.backend.get_probability([1, 0], qubits[:3:2]) ==
             pytest.approx(0.28))
-    Measure | qubits
+    All(Measure) | qubits
 
 
 def test_simulator_amplitude(sim):
@@ -311,7 +298,7 @@ def test_simulator_amplitude(sim):
     bits[0] = 1
     assert (eng.backend.get_amplitude(bits, qubits) ==
             pytest.approx(math.sqrt(0.91)))
-    Measure | qubits
+    All(Measure) | qubits
     # raises if not all qubits are in the list:
     with pytest.raises(RuntimeError):
         eng.backend.get_amplitude(bits, qubits[:-1])
@@ -441,7 +428,7 @@ def test_simulator_time_evolution(sim):
         TimeEvolution(time_to_evolve, op) | qureg
     eng.flush()
     qbit_to_bit_map, final_wavefunction = copy.deepcopy(eng.backend.cheat())
-    Measure | (qureg, ctrl_qubit)
+    All(Measure) | qureg + ctrl_qubit
     # Check manually:
 
     def build_matrix(list_single_matrices):
@@ -488,7 +475,7 @@ def test_simulator_set_wavefunction(sim):
     assert pytest.approx(eng.backend.get_probability('1', [qubits[0]])) == .8
     assert pytest.approx(eng.backend.get_probability('01', qubits)) == .2
     assert pytest.approx(eng.backend.get_probability('1', [qubits[1]])) == 1.
-    Measure | qubits
+    All(Measure) | qubits
 
 
 def test_simulator_set_wavefunction_always_complex(sim):
@@ -616,4 +603,4 @@ def test_simulator_functional_entangle(sim):
     for i in range(1, 32):
         assert 0. == pytest.approx(abs(sim.cheat()[1][i]))
 
-    Measure | qubits
+    All(Measure) | qubits

--- a/projectq/libs/math/_constantmath_test.py
+++ b/projectq/libs/math/_constantmath_test.py
@@ -21,7 +21,8 @@ from projectq.cengines import (InstructionFilter,
                                AutoReplacer,
                                DecompositionRuleSet)
 from projectq.backends import Simulator
-from projectq.ops import X, BasicMathGate, ClassicalInstructionGate, Measure
+from projectq.ops import (All, BasicMathGate, ClassicalInstructionGate, Measure,
+                          X)
 
 import projectq.libs.math
 from projectq.setups.decompositions import qft2crandhadamard, swap2cnot
@@ -69,7 +70,7 @@ def test_adder():
     AddConstant(15) | qureg
     assert 1. == pytest.approx(abs(sim.cheat()[1][1]))
 
-    Measure | qureg
+    All(Measure) | qureg
 
 
 def test_modadder():
@@ -90,7 +91,7 @@ def test_modadder():
     AddConstantModN(10, 13) | qureg
     assert 1. == pytest.approx(abs(sim.cheat()[1][4]))
 
-    Measure | qureg
+    All(Measure) | qureg
 
 
 def test_modmultiplier():
@@ -111,4 +112,4 @@ def test_modmultiplier():
     MultiplyByConstantModN(4, 13) | qureg
     assert 1. == pytest.approx(abs(sim.cheat()[1][2]))
 
-    Measure | qureg
+    All(Measure) | qureg

--- a/projectq/ops/_gates.py
+++ b/projectq/ops/_gates.py
@@ -271,9 +271,10 @@ class MeasureGate(FastForwardingGate):
 
     def __or__(self, qubits):
         """ 
-        Previously (ProjectQ <= v0.3.6) All(Measure) was equal to Measure
-        But we will change it to Measure being strictly a single qubit gate in
-        the coming releases.
+        Previously (ProjectQ <= v0.3.6) MeasureGate/Measure was allowed to be
+        applied to any number of quantum registers. Now the MeasureGate/Measure
+        is strictly a single qubit gate. In the coming releases the backward
+        compatibility will be removed!
         """
         num_qubits = 0
         for qureg in self.make_tuple_of_qureg(qubits):

--- a/projectq/ops/_gates.py
+++ b/projectq/ops/_gates.py
@@ -31,6 +31,8 @@ and meta gates, i.e.,
 
 import math
 import cmath
+import warnings
+
 import numpy as np
 
 from projectq.ops import get_inverse
@@ -41,6 +43,8 @@ from ._basics import (BasicGate,
                       ClassicalInstructionGate,
                       FastForwardingGate,
                       BasicMathGate)
+from ._command import apply_command
+from projectq.types import BasicQubit
 
 
 class HGate(SelfInverseGate):
@@ -261,9 +265,27 @@ class FlushGate(FastForwardingGate):
 
 
 class MeasureGate(FastForwardingGate):
-    """ Measurement gate class """
+    """ Measurement gate class (for single qubits)."""
     def __str__(self):
         return "Measure"
+
+    def __or__(self, qubits):
+        """ 
+        Previously (ProjectQ <= v0.3.6) All(Measure) was equal to Measure
+        But we will change it to Measure being strictly a single qubit gate in
+        the coming releases.
+        """
+        num_qubits = 0
+        for qureg in self.make_tuple_of_qureg(qubits):
+            for qubit in qureg:
+                num_qubits += 1
+                cmd = self.generate_command(([qubit],))
+                apply_command(cmd)
+        if num_qubits > 1:
+            warnings.warn("Pending syntax change in future versions of " +
+                          "ProjectQ: \n Measure will be a single qubit gate " +
+                          "only. Use `All(Measure) | qureg` instead to " +
+                          "measure multiple qubits.")
 
 #: Shortcut (instance of) :class:`projectq.ops.MeasureGate`
 Measure = MeasureGate()

--- a/projectq/setups/decompositions/_gates_test.py
+++ b/projectq/setups/decompositions/_gates_test.py
@@ -24,26 +24,12 @@ from projectq.cengines import (MainEngine,
                                DummyEngine,
                                DecompositionRuleSet)
 from projectq.backends import Simulator
-from projectq.ops import (H,
-                          CRz,
-                          Rz,
-                          T,
-                          Tdag,
-                          X,
-                          Toffoli,
-                          Entangle,
-                          R,
-                          Ph,
-                          ClassicalInstructionGate,
-                          All,
-                          Measure)
+from projectq.ops import (All, ClassicalInstructionGate, CRz, Entangle, H,
+                          Measure, Ph, R, Rz, T, Tdag, Toffoli, X)
 from projectq.meta import Control
-from projectq.setups.decompositions import (entangle,
-                                            globalphase,
-                                            r2rzandph,
-                                            crz2cxandrz,
-                                            toffoli2cnotandtgate,
-                                            ph2r)
+from projectq.setups.decompositions import (crz2cxandrz, entangle,
+                                            globalphase, ph2r, r2rzandph,
+                                            toffoli2cnotandtgate)
 
 
 def low_level_gates(eng, cmd):
@@ -72,7 +58,7 @@ def test_entangle():
     assert .5 == pytest.approx(abs(sim.cheat()[1][0])**2)
     assert .5 == pytest.approx(abs(sim.cheat()[1][-1])**2)
 
-    Measure | qureg
+    All(Measure) | qureg
 
 
 def low_level_gates_noglobalphase(eng, cmd):
@@ -126,5 +112,5 @@ def test_gate_decompositions():
     for i in range(len(sim.cheat()[1])):
         assert sim.cheat()[1][i] == pytest.approx(sim2.cheat()[1][i])
 
-    Measure | qureg
-    Measure | qureg2
+    All(Measure) | qureg
+    All(Measure) | qureg2

--- a/projectq/setups/decompositions/carb1qubit2cnotrzandry_test.py
+++ b/projectq/setups/decompositions/carb1qubit2cnotrzandry_test.py
@@ -21,7 +21,7 @@ from projectq.backends import Simulator
 from projectq.cengines import (AutoReplacer, DecompositionRuleSet,
                                DummyEngine, InstructionFilter, MainEngine)
 from projectq.meta import Control
-from projectq.ops import (BasicGate, ClassicalInstructionGate, Measure,
+from projectq.ops import (All, BasicGate, ClassicalInstructionGate, Measure,
                           Ph, R, Rx, Ry, Rz, X, XGate)
 from projectq.setups.decompositions import arb1qubit2rzandry_test as arb1q_t
 
@@ -140,7 +140,7 @@ def test_decomposition(gate_matrix):
                                                 correct_ctrl_qb)
             assert correct == pytest.approx(test, rel=1e-12, abs=1e-12)
 
-        Measure | test_qb + test_ctrl_qb
-        Measure | correct_qb + correct_ctrl_qb
+        All(Measure) | test_qb + test_ctrl_qb
+        All(Measure) | correct_qb + correct_ctrl_qb
         test_eng.flush(deallocate_qubits=True)
         correct_eng.flush(deallocate_qubits=True)

--- a/projectq/setups/decompositions/cnu2toffoliandcu_test.py
+++ b/projectq/setups/decompositions/cnu2toffoliandcu_test.py
@@ -20,8 +20,8 @@ from projectq.backends import Simulator
 from projectq.cengines import (AutoReplacer, DecompositionRuleSet,
                                DummyEngine, InstructionFilter, MainEngine)
 from projectq.meta import Control
-from projectq.ops import (ClassicalInstructionGate, Measure, Ph, QFT, Rx, Ry,
-                          X, XGate)
+from projectq.ops import (All, ClassicalInstructionGate, Measure, Ph, QFT, Rx,
+                          Ry, X, XGate)
 
 from . import cnu2toffoliandcu
 
@@ -125,7 +125,7 @@ def test_decomposition():
                                                 correct_ctrl_qureg)
             assert correct == pytest.approx(test, rel=1e-12, abs=1e-12)
 
-        Measure | test_qb + test_ctrl_qureg
-        Measure | correct_qb + correct_ctrl_qureg
+        All(Measure) | test_qb + test_ctrl_qureg
+        All(Measure) | correct_qb + correct_ctrl_qureg
         test_eng.flush(deallocate_qubits=True)
         correct_eng.flush(deallocate_qubits=True)

--- a/projectq/tests/_factoring_test.py
+++ b/projectq/tests/_factoring_test.py
@@ -25,7 +25,8 @@ from projectq.cengines import (MainEngine,
                                TagRemover)
 from projectq.libs.math import MultiplyByConstantModN
 from projectq.meta import Control
-from projectq.ops import X, H, QFT, BasicMathGate, Swap, get_inverse, Measure
+from projectq.ops import (All, BasicMathGate, get_inverse, H, Measure, QFT,
+                          Swap, X)
 
 rule_set = DecompositionRuleSet(modules=(projectq.libs.math,
                                          projectq.setups.decompositions))
@@ -101,4 +102,4 @@ def test_factoring(sim):
     assert probability == pytest.approx(.5)
 
     Measure | ctrl_qubit
-    Measure | x
+    All(Measure) | x


### PR DESCRIPTION
Changes to `MeasureGate` and `Measure` gate because mappers will need single qubit measurement gates.

Previously:
* Could be applied to any number of quantum registers

Now:
* Single qubit gate

Deprecation period until next release:
* Allows to apply it to a single qureg but gives a warning