### PR TITLE
Update CNOT direction of IBM mapper.

### DIFF
--- a/examples/ibm.py
+++ b/examples/ibm.py
@@ -1,6 +1,6 @@
 import projectq.setups.ibm
 from projectq.backends import IBMBackend
-from projectq.ops import Measure, Entangle
+from projectq.ops import Measure, Entangle, All
 from projectq import MainEngine
 
 
@@ -22,7 +22,7 @@ def run_entangle(eng, num_qubits=5):
     Entangle | qureg
 
     # measure; should be all-0 or all-1
-    Measure | qureg
+    All(Measure) | qureg
 
     # run the circuit
     eng.flush()

--- a/projectq/cengines/_ibmcnotmapper.py
+++ b/projectq/cengines/_ibmcnotmapper.py
@@ -227,7 +227,7 @@ class IBMCNOTMapper(BasicEngine):
             interactions = [(1, 0), (2, 0), (3, 0), (4, 0),
                             (4, 2), (3, 1)]
         elif device == 'ibmqx4':
-            interactions = [(0, 1), (0, 2), (0, 3), (4, 0),
+            interactions = [(0, 1), (2, 0), (0, 3), (4, 0),
                             (4, 2), (1, 3)]
         else:
             raise Exception("Unknown backend type. Must be either ibmqx2 or "


### PR DESCRIPTION
This updates the CNOT direction in the IBMCNOTMapper and thus fixes compilation for the 5-qubit IBM Q backend.