### PR TITLE
Change setups

### DIFF
--- a/docs/projectq.setups.rst
+++ b/docs/projectq.setups.rst
@@ -1,18 +1,15 @@
 setups
 ======
 
-The setups package contains a collection of setups which can be loaded by the `MainEngine`. Each setup then loads its own set of decomposition rules and default compiler engines. 
+The setups package contains a collection of setups which can be loaded by the `MainEngine`. Each setup contains a `get_engine_list` function which returns a list of compiler engines:
 
 Example:
     .. code-block:: python
 
-        import projectq.setups.ibm
+        import projectq.setups.ibm as ibm_setup
         from projectq import MainEngine
-        eng = MainEngine(setup=projectq.setups.ibm)
+        eng = MainEngine(engine_list=ibm_setup.get_engine_list())
         # eng uses the default Simulator backend
-
-Note:
-	One can either provide an `engine_list` or a `setup` to the `MainEngine` but not both.
 
 The subpackage decompositions contains all the individual decomposition rules
 which can be given to, e.g., an `AutoReplacer`.
@@ -29,7 +26,8 @@ Subpackages
 Submodules
 ----------
 
-Each of the submodules contains a setup which can be loaded by the `MainEngine` :
+Each of the submodules contains a setup which can be used to specify the
+`engine_list` used by the `MainEngine` :
 
 .. autosummary::
 

--- a/examples/ibm.py
+++ b/examples/ibm.py
@@ -40,6 +40,6 @@ if __name__ == "__main__":
     # create main compiler engine for the IBM back-end
     eng = MainEngine(IBMBackend(use_hardware=True, num_runs=1024,
                                 verbose=False, device='ibmqx4'),
-                     setup=projectq.setups.ibm)
+                     engine_list=projectq.setups.ibm.get_engine_list())
     # run the circuit and print the result
     print(run_entangle(eng))

--- a/examples/ibm16.py
+++ b/examples/ibm16.py
@@ -49,6 +49,6 @@ if __name__ == "__main__":
     # create main compiler engine for the 16-qubit IBM back-end
     eng = MainEngine(IBMBackend(use_hardware=True, num_runs=1024,
                                 verbose=False, device='ibmqx5'),
-                     setup=projectq.setups.ibm16)
+                     engine_list=projectq.setups.ibm16.get_engine_list())
     # run the circuit and print the result
     print(run_test(eng))

--- a/examples/ibm_entangle.ipynb
+++ b/examples/ibm_entangle.ipynb
@@ -41,7 +41,7 @@
    "outputs": [],
    "source": [
     "engine = MainEngine(IBMBackend(use_hardware=True, num_runs=1024, verbose=True, device='ibmqx4'),\n",
-    "                    setup=projectq.setups.ibm)\n",
+    "                    engine_list=projectq.setups.ibm.get_engine_list())\n",
     "qureg = engine.allocate_qureg(3)"
    ]
   },
@@ -99,15 +99,21 @@
       "h q[1];\n",
       "measure q[1] -> c[1];\n",
       "- Waiting for results...\n",
-      "- Done.\n",
-      "11100 with p = 0.4033203125*\n",
-      "01100 with p = 0.041015625\n",
-      "10000 with p = 0.0185546875\n",
-      "00000 with p = 0.3828125\n",
-      "01000 with p = 0.015625\n",
-      "11000 with p = 0.0546875\n",
-      "00100 with p = 0.0419921875\n",
-      "10100 with p = 0.0419921875\n"
+      "- Done.\n"
+     ]
+    },
+    {
+     "ename": "Exception",
+     "evalue": "Failed to run the circuit. Aborting.\n raised in:\n'  File \"/Users/damian/ProjectQ/ProjectQ/projectq/backends/_ibm/_ibm.py\", line 269, in _run'\n'    raise Exception(\"Failed to run the circuit. Aborting.\")'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-e2da04f703e6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mAll\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mMeasure\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m|\u001b[0m \u001b[0mqureg\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mengine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflush\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/Users/damian/ProjectQ/ProjectQ/projectq/cengines/_main.pyc\u001b[0m in \u001b[0;36mflush\u001b[0;34m(self, deallocate_qubits)\u001b[0m\n\u001b[1;32m    302\u001b[0m                 \u001b[0mqb\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mactive_qubits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpop\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    303\u001b[0m                 \u001b[0mqb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__del__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 304\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreceive\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mCommand\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFlushGate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mWeakQubitRef\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/Users/damian/ProjectQ/ProjectQ/projectq/cengines/_main.pyc\u001b[0m in \u001b[0;36mreceive\u001b[0;34m(self, command_list)\u001b[0m\n\u001b[1;32m    264\u001b[0m                 then send on)\n\u001b[1;32m    265\u001b[0m         \"\"\"\n\u001b[0;32m--> 266\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcommand_list\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    267\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    268\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0msend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcommand_list\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/damian/ProjectQ/ProjectQ/projectq/cengines/_main.pyc\u001b[0m in \u001b[0;36msend\u001b[0;34m(self, command_list)\u001b[0m\n\u001b[1;32m    286\u001b[0m                                              \"\\n\" + repr(last_line[-2]))\n\u001b[1;32m    287\u001b[0m                 \u001b[0mcompact_exception\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__cause__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 288\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mcompact_exception\u001b[0m  \u001b[0;31m# use verbose=True for more info\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    289\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    290\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mflush\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdeallocate_qubits\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mException\u001b[0m: Failed to run the circuit. Aborting.\n raised in:\n'  File \"/Users/damian/ProjectQ/ProjectQ/projectq/backends/_ibm/_ibm.py\", line 269, in _run'\n'    raise Exception(\"Failed to run the circuit. Aborting.\")'"
      ]
     }
    ],
@@ -125,17 +131,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1, 1, 1]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print([int(q) for q in qureg])"
    ]
@@ -158,12 +156,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from projectq.backends import CommandPrinter\n",
-    "engine2 = MainEngine(CommandPrinter(), setup=projectq.setups.ibm)"
+    "engine2 = MainEngine(CommandPrinter(),\n",
+    "                     engine_list=projectq.setups.ibm.get_engine_list())"
    ]
   },
   {
@@ -175,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,34 +200,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Allocate | Qureg[0]\n",
-      "Allocate | Qureg[1]\n",
-      "H | Qureg[1]\n",
-      "CX | ( Qureg[1], Qureg[0] )\n",
-      "Allocate | Qureg[2]\n",
-      "H | Qureg[2]\n",
-      "CX | ( Qureg[2], Qureg[0] )\n",
-      "Allocate | Qureg[3]\n",
-      "H | Qureg[3]\n",
-      "CX | ( Qureg[3], Qureg[0] )\n",
-      "Allocate | Qureg[4]\n",
-      "H | Qureg[4]\n",
-      "CX | ( Qureg[4], Qureg[0] )\n",
-      "H | Qureg[0]\n",
-      "H | Qureg[1]\n",
-      "H | Qureg[2]\n",
-      "H | Qureg[3]\n",
-      "H | Qureg[4]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "Entangle | qureg2\n",
     "engine2.flush()"
@@ -266,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,17 +291,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1, 1, 1, 1, 1]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print([int(q) for q in qureg3])"
    ]

--- a/examples/ibm_entangle.ipynb
+++ b/examples/ibm_entangle.ipynb
@@ -99,21 +99,15 @@
       "h q[1];\n",
       "measure q[1] -> c[1];\n",
       "- Waiting for results...\n",
-      "- Done.\n"
-     ]
-    },
-    {
-     "ename": "Exception",
-     "evalue": "Failed to run the circuit. Aborting.\n raised in:\n'  File \"/Users/damian/ProjectQ/ProjectQ/projectq/backends/_ibm/_ibm.py\", line 269, in _run'\n'    raise Exception(\"Failed to run the circuit. Aborting.\")'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mException\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-4-e2da04f703e6>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mAll\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mMeasure\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m|\u001b[0m \u001b[0mqureg\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mengine\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflush\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/Users/damian/ProjectQ/ProjectQ/projectq/cengines/_main.pyc\u001b[0m in \u001b[0;36mflush\u001b[0;34m(self, deallocate_qubits)\u001b[0m\n\u001b[1;32m    302\u001b[0m                 \u001b[0mqb\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mactive_qubits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpop\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    303\u001b[0m                 \u001b[0mqb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__del__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 304\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreceive\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mCommand\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mFlushGate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mWeakQubitRef\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m-\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/Users/damian/ProjectQ/ProjectQ/projectq/cengines/_main.pyc\u001b[0m in \u001b[0;36mreceive\u001b[0;34m(self, command_list)\u001b[0m\n\u001b[1;32m    264\u001b[0m                 then send on)\n\u001b[1;32m    265\u001b[0m         \"\"\"\n\u001b[0;32m--> 266\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcommand_list\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    267\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    268\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0msend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcommand_list\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/damian/ProjectQ/ProjectQ/projectq/cengines/_main.pyc\u001b[0m in \u001b[0;36msend\u001b[0;34m(self, command_list)\u001b[0m\n\u001b[1;32m    286\u001b[0m                                              \"\\n\" + repr(last_line[-2]))\n\u001b[1;32m    287\u001b[0m                 \u001b[0mcompact_exception\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__cause__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 288\u001b[0;31m                 \u001b[0;32mraise\u001b[0m \u001b[0mcompact_exception\u001b[0m  \u001b[0;31m# use verbose=True for more info\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    289\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    290\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mflush\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdeallocate_qubits\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mException\u001b[0m: Failed to run the circuit. Aborting.\n raised in:\n'  File \"/Users/damian/ProjectQ/ProjectQ/projectq/backends/_ibm/_ibm.py\", line 269, in _run'\n'    raise Exception(\"Failed to run the circuit. Aborting.\")'"
+      "- Done.\n",
+      "11100 with p = 0.388671875*\n",
+      "01100 with p = 0.0478515625\n",
+      "10000 with p = 0.0029296875\n",
+      "00000 with p = 0.4482421875\n",
+      "01000 with p = 0.0166015625\n",
+      "11000 with p = 0.025390625\n",
+      "00100 with p = 0.0263671875\n",
+      "10100 with p = 0.0439453125\n"
      ]
     }
    ],
@@ -131,9 +125,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1, 1, 1]\n"
+     ]
+    }
+   ],
    "source": [
     "print([int(q) for q in qureg])"
    ]
@@ -156,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,9 +202,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Allocate | Qureg[0]\n",
+      "Allocate | Qureg[1]\n",
+      "H | Qureg[1]\n",
+      "CX | ( Qureg[1], Qureg[0] )\n",
+      "Allocate | Qureg[2]\n",
+      "H | Qureg[2]\n",
+      "CX | ( Qureg[2], Qureg[0] )\n",
+      "Allocate | Qureg[3]\n",
+      "H | Qureg[3]\n",
+      "CX | ( Qureg[3], Qureg[0] )\n",
+      "Allocate | Qureg[4]\n",
+      "H | Qureg[4]\n",
+      "CX | ( Qureg[4], Qureg[0] )\n",
+      "H | Qureg[0]\n",
+      "H | Qureg[1]\n",
+      "H | Qureg[2]\n",
+      "H | Qureg[3]\n",
+      "H | Qureg[4]\n"
+     ]
+    }
+   ],
    "source": [
     "Entangle | qureg2\n",
     "engine2.flush()"
@@ -240,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,7 +301,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,9 +318,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0, 0, 0, 0, 0]\n"
+     ]
+    }
+   ],
    "source": [
     "print([int(q) for q in qureg3])"
    ]

--- a/examples/quantum_random_numbers_ibm.py
+++ b/examples/quantum_random_numbers_ibm.py
@@ -4,7 +4,8 @@ from projectq import MainEngine
 from projectq.backends import IBMBackend
 
 # create a main compiler engine
-eng = MainEngine(IBMBackend(), setup=projectq.setups.ibm)
+eng = MainEngine(IBMBackend(),
+	             engine_list=projectq.setups.ibm.get_engine_list())
 
 # allocate one qubit
 q1 = eng.allocate_qubit()

--- a/projectq/cengines/_main.py
+++ b/projectq/cengines/_main.py
@@ -54,8 +54,7 @@ class MainEngine(BasicEngine):
         mapper (BasicMapperEngine): Access to the mapper if there is one.
 
     """
-    def __init__(self, backend=None, engine_list=None, setup=None,
-                 verbose=False):
+    def __init__(self, backend=None, engine_list=None, verbose=False):
         """
         Initialize the main compiler engine and all compiler engines.
 
@@ -63,15 +62,11 @@ class MainEngine(BasicEngine):
         engines and adds the back-end as the last engine.
 
         Args:
-            backend (BasicEngine): Backend to send the circuit to.
+            backend (BasicEngine): Backend to send the compiled circuit to.
             engine_list (list<BasicEngine>): List of engines / backends to use
                 as compiler engines. Note: The engine list must not contain
                 multiple mappers (instances of BasicMapperEngine).
-            setup (module): Setup module which defines a function called
-                `get_engine_list()`. `get_engine_list()` returns the list
-                of engines to be used as compiler engines.
-                The default setup is `projectq.setups.default` (if no engine
-                list and no setup is provided).
+                Default: projectq.setups.default.get_engine_list()
             verbose (bool): Either print full or compact error messages.
                             Default: False (i.e. compact error messages).
 
@@ -79,17 +74,18 @@ class MainEngine(BasicEngine):
             .. code-block:: python
 
                 from projectq import MainEngine
-                eng = MainEngine() # uses default setup and the Simulator
+                eng = MainEngine() # uses default engine_list and the Simulator
 
-        Instead of the default setup one can use, e.g., one of the IBM setups
-        which defines a custom `engine_list` useful for one of the IBM chips
+        Instead of the default `engine_list` one can use, e.g., one of the IBM
+        setups which defines a custom `engine_list` useful for one of the IBM
+        chips
 
         Example:
             .. code-block:: python
 
-                import projectq.setups.ibm
+                import projectq.setups.ibm as ibm_setup
                 from projectq import MainEngine
-                eng = MainEngine(setup=projectq.setups.ibm)
+                eng = MainEngine(engine_list=ibm_setup.get_engine_list())
                 # eng uses the default Simulator backend
 
         Alternatively, one can specify all compiler engines explicitly, e.g.,
@@ -119,17 +115,11 @@ class MainEngine(BasicEngine):
                     "Did you forget the brackets to create an instance?\n"
                     "E.g. MainEngine(backend=Simulator) instead of \n"
                     "     MainEngine(backend=Simulator())")
-        # default setup is projectq.setups.default
-        if engine_list is None and setup is None:
-            import projectq.setups.default
-            setup = projectq.setups.default
-
-        if not (engine_list is None or setup is None):  # can't provide both
-            raise ValueError("\nPlease provide either a setup or an engine "
-                             "list, but not both.")
-
+        # default engine_list is projectq.setups.default.get_engine_list()
         if engine_list is None:
-            engine_list = setup.get_engine_list()
+            import projectq.setups.default
+            engine_list = projectq.setups.default.get_engine_list()
+
         self.mapper = None
         if isinstance(engine_list, list):
             # Test that engine list elements are all BasicEngine objects

--- a/projectq/cengines/_main_test.py
+++ b/projectq/cengines/_main_test.py
@@ -49,9 +49,6 @@ def test_main_engine_init():
 
 
 def test_main_engine_init_failure():
-    with pytest.raises(ValueError):
-        eng = _main.MainEngine(engine_list=[DummyEngine()],
-                               setup=projectq.setups.default)
     with pytest.raises(_main.UnsupportedEngineError):
         eng = _main.MainEngine(backend=DummyEngine)
     with pytest.raises(_main.UnsupportedEngineError):


### PR DESCRIPTION
Remove `setup` parameter from MainEngine (has not yet been merged to Master).

This parameter has been introduced to make the compiler engine specifications more explicit instead of just `import projectq.setups.ibm`. Now it is even more explicit: One needs to set the `engine_list` parameter:
```
MainEngine(backend=..., engine_list=projectq.setups.ibm.get_engine_list())
```

Advantages is that one can give the function `get_engine_list` parameters, e.g., we can build a compiler engine setup for a linear chain and give it as a parameter the length of the chain:
```
import projectq.setups.linearchain as linearchain
MainEngine(backend=..., engine_list=linearchain.get_engine_list(num_qubits=8))
```

Downsides:
* It takes a bit more of writing but is much more flexible
* The simplicity of the `setup` parameter was nice, maybe in future we can use that parameter to set   the `engine_list` and change the default `backend` in case the user does not provide one (Previously it only set the `engine_list`)

Other options to this PR:
* add `setup_parameters` which should take a `dict` in order that we can check correct parameter names as each setup might have different ones.
I.e. 
```
MainEngine(backend=..., setup=projectq.setups.linearchain, setup_params={num_qubits: 8})
```