### PR TITLE
Allow arbitrary backend qubit orderings in GridMapper

### DIFF
--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -87,7 +87,9 @@ def mapper(request):
                             if qubit.id == -1:
                                 continue
                             elif qubit.id not in self.current_mapping:
-                                self.current_mapping[qubit.id] = qubit.id + 1
+                                previous_map = self.current_mapping
+                                previous_map[qubit.id] = qubit.id + 1
+                                self.current_mapping = previous_map
                     self._send_cmd_with_mapped_ids(cmd)
 
         return TrivialMapper()
@@ -682,8 +684,7 @@ def test_simulator_convert_logical_to_mapped_qubits(sim):
     eng = MainEngine(sim, [mapper])
     qubit0 = eng.allocate_qubit()
     qubit1 = eng.allocate_qubit()
-    mapper.current_mapping = dict()
-    mapper.current_mapping[qubit0[0].id] = qubit1[0].id
-    mapper.current_mapping[qubit1[0].id] = qubit0[0].id
+    mapper.current_mapping = {qubit0[0].id: qubit1[0].id,
+                              qubit1[0].id: qubit0[0].id}
     assert (sim._convert_logical_to_mapped_qureg(qubit0 + qubit1) ==
             qubit1 + qubit0)

--- a/projectq/cengines/_basicmapper.py
+++ b/projectq/cengines/_basicmapper.py
@@ -38,7 +38,15 @@ class BasicMapperEngine(BasicEngine):
 
     def __init__(self):
         BasicEngine.__init__(self)
-        self.current_mapping = None
+        self._current_mapping = None
+
+    @property
+    def current_mapping(self):
+        return deepcopy(self._current_mapping)
+
+    @current_mapping.setter
+    def current_mapping(self, current_mapping):
+        self._current_mapping = current_mapping
 
     def _send_cmd_with_mapped_ids(self, cmd):
         """

--- a/projectq/cengines/_ibm5qubitmapper.py
+++ b/projectq/cengines/_ibm5qubitmapper.py
@@ -164,7 +164,7 @@ class IBM5QubitMapper(BasicMapperEngine):
                 new_max = 0
                 if len(self.current_mapping) > 0:
                     new_max = max(self.current_mapping.values()) + 1
-                self.current_mapping[target] = new_max
+                self._current_mapping[target] = new_max
         self._cmds.append(cmd)
 
     def receive(self, command_list):

--- a/projectq/cengines/_linearmapper.py
+++ b/projectq/cengines/_linearmapper.py
@@ -497,7 +497,7 @@ class LinearMapper(BasicMapperEngine):
                     # Note: Deallocate gates get send everytime by self._run()
                     self._currently_allocated_ids.remove(cmd.qubits[0][0].id)
                     active_ids.remove(cmd.qubits[0][0].id)
-                    self.current_mapping.pop(cmd.qubits[0][0].id)
+                    self._current_mapping.pop(cmd.qubits[0][0].id)
                 else:
                     new_stored_commands.append(cmd)
             else:

--- a/projectq/cengines/_linearmapper_test.py
+++ b/projectq/cengines/_linearmapper_test.py
@@ -458,7 +458,7 @@ def test_send_possible_commands_allocate():
     assert len(backend.received_commands) == 0
     assert mapper._stored_commands == [cmd0]
     # in mapping:
-    mapper.current_mapping[0] = 3
+    mapper.current_mapping = {0: 3}
     mapper._send_possible_commands()
     assert len(mapper._stored_commands) == 0
     # Only self._run() sends Allocate gates
@@ -482,7 +482,7 @@ def test_send_possible_commands_deallocate():
     assert len(backend.received_commands) == 0
     assert mapper._stored_commands == [cmd0]
     # allocated:
-    mapper.current_mapping[0] = 3
+    mapper.current_mapping = {0: 3}
     mapper._currently_allocated_ids.add(0)
     mapper._send_possible_commands()
     # Only self._run() send Deallocate gates

--- a/projectq/cengines/_manualmapper.py
+++ b/projectq/cengines/_manualmapper.py
@@ -56,5 +56,5 @@ class ManualMapper(BasicMapperEngine):
             ids += [qb.id for qb in cmd.control_qubits]
             for ID in ids:
                 if ID not in self.current_mapping:
-                    self.current_mapping[ID] = self.map(ID)
+                    self._current_mapping[ID] = self.map(ID)
             self._send_cmd_with_mapped_ids(cmd)

--- a/projectq/cengines/_twodmapper.py
+++ b/projectq/cengines/_twodmapper.py
@@ -40,7 +40,7 @@ class GridMapper(BasicMapperEngine):
     """
     Mapper to a 2-D grid graph.
 
-    Physical qubits on the grid are numbered in row-major order. E.g. for
+    Mapped qubits on the grid are numbered in row-major order. E.g. for
     3 rows and 2 columns:
 
     0 - 1
@@ -49,14 +49,18 @@ class GridMapper(BasicMapperEngine):
     |   |
     4 - 5
 
-    The numbers are the mapped qubit ids.
+    The numbers are the mapped qubit ids. The backend might number
+    the qubits on the grid differently (e.g. not row-major), we call these
+    backend qubit ids. If the backend qubit ids are not row-major, one can
+    pass a dictionary translating from our row-major mapped ids to these
+    backend ids. 
 
     Note: The algorithm sorts twice inside each column and once inside each
           row.
 
     Attributes:
         current_mapping:  Stores the mapping: key is logical qubit id, value
-                          is mapped qubit id from 0,...,self.num_qubits
+                          are backend qubit ids.
         storage(int): Number of gate it caches before mapping.
         num_rows(int): Number of rows in the grid
         num_columns(int): Number of columns in the grid
@@ -70,7 +74,8 @@ class GridMapper(BasicMapperEngine):
                                          mappings which have been applied
 
     """
-    def __init__(self, num_rows, num_columns, storage=1000,
+    def __init__(self, num_rows, num_columns, mapped_ids_to_backend_ids=None,
+                 storage=1000, 
                  optimization_function=lambda x: return_swap_depth(x),
                  num_optimization_steps=50):
         """
@@ -79,6 +84,15 @@ class GridMapper(BasicMapperEngine):
         Args:
             num_rows(int): Number of rows in the grid
             num_columns(int): Number of columns in the grid.
+            mapped_ids_to_backend_ids(dict): Stores a mapping from mapped ids
+                                             which are 0,...,self.num_qubits-1
+                                             in row-major order on the grid to
+                                             the corresponding qubit ids of the
+                                             backend. Key: mapped id. Value:
+                                             corresponding backend id.
+                                             Default is None which means
+                                             backend ids are identical to
+                                             mapped ids.
             storage: Number of gates to temporarily store
             optimization_function: Function which takes a list of swaps and
                                    returns a cost value. Mapper chooses a
@@ -89,9 +103,24 @@ class GridMapper(BasicMapperEngine):
                                          the cost.
         """
         BasicMapperEngine.__init__(self)
+        self._current_mapping = None # Must use property access below
         self.num_rows = num_rows
         self.num_columns = num_columns
         self.num_qubits = num_rows * num_columns
+        # Internally we use the mapped ids until sending a command when it gets
+        # translated using this mapping:
+        self._mapped_ids_to_backend_ids = mapped_ids_to_backend_ids
+        if self._mapped_ids_to_backend_ids is None:
+            self._mapped_ids_to_backend_ids = dict()
+            for i in range(self.num_qubits):
+                self._mapped_ids_to_backend_ids[i] = i
+        self._backend_ids_to_mapped_ids = dict()
+        for mapped_id, backend_id in self._mapped_ids_to_backend_ids.items():
+            self._backend_ids_to_mapped_ids[backend_id] = mapped_id
+        # As we use internally the mapped ids which are in row-major order,
+        # we have an internal current mapping which maps from logical ids to
+        # these mapped ids:
+        self._current_row_major_mapping = deepcopy(self.current_mapping)
         self.storage = storage
         self.optimization_function = optimization_function
         self.num_optimization_steps = num_optimization_steps
@@ -107,6 +136,8 @@ class GridMapper(BasicMapperEngine):
         # deallocated:
         self._currently_allocated_ids = set()
         # Change between 2D and 1D mappings (2D is a snake like 1D chain)
+        # Note it translates to our mapped ids in row major order and not
+        # backend ids which might be different.
         self._map_2d_to_1d = dict()
         self._map_1d_to_2d = dict()
         for row_index in range(self.num_rows):
@@ -125,6 +156,20 @@ class GridMapper(BasicMapperEngine):
         self.num_mappings = 0
         self.depth_of_swaps = dict()
         self.num_of_swaps_per_mapping = dict()
+
+    @property
+    def current_mapping(self):
+        return deepcopy(self._current_mapping)
+
+    @current_mapping.setter
+    def current_mapping(self, current_mapping):
+        self._current_mapping = current_mapping
+        if current_mapping is None:
+            self._current_row_major_mapping = None
+        else:
+            self._current_row_major_mapping = dict()
+            for logical_id, backend_id in current_mapping.items():
+                self._current_row_major_mapping[logical_id] = self._backend_ids_to_mapped_ids[backend_id]
 
     def is_available(self, cmd):
         """
@@ -154,12 +199,12 @@ class GridMapper(BasicMapperEngine):
                  value is placement id
         """
         # Change old mapping to 1D in order to use LinearChain heuristic
-        if self.current_mapping:
+        if self._current_row_major_mapping:
             old_mapping_1d = dict()
-            for logical_id, mapped_id in self.current_mapping.items():
+            for logical_id, mapped_id in self._current_row_major_mapping.items():
                 old_mapping_1d[logical_id] = self._map_2d_to_1d[mapped_id]
         else:
-            old_mapping_1d = self.current_mapping
+            old_mapping_1d = self._current_row_major_mapping
 
         new_mapping_1d = LinearMapper.return_new_mapping(
             num_qubits=self.num_qubits,
@@ -379,10 +424,11 @@ class GridMapper(BasicMapperEngine):
         """
         Sends the stored commands possible without changing the mapping.
 
-        Note: self.current_mapping must exist already
+        Note: self._current_row_major_mapping (hence also self.current_mapping)
+              must exist already
         """
         active_ids = deepcopy(self._currently_allocated_ids)
-        for logical_id in self.current_mapping:
+        for logical_id in self._current_row_major_mapping:
             # So that loop doesn't stop before AllocateGate applied
             active_ids.add(logical_id)
 
@@ -393,7 +439,7 @@ class GridMapper(BasicMapperEngine):
                 new_stored_commands += self._stored_commands[i:]
                 break
             if isinstance(cmd.gate, AllocateQubitGate):
-                if cmd.qubits[0][0].id in self.current_mapping:
+                if cmd.qubits[0][0].id in self._current_row_major_mapping:
                     self._currently_allocated_ids.add(cmd.qubits[0][0].id)
                     # Note: Allocate gates get send everytime by self._run()
                 else:
@@ -403,7 +449,8 @@ class GridMapper(BasicMapperEngine):
                     # Note: Deallocate gates get send everytime by self._run()
                     self._currently_allocated_ids.remove(cmd.qubits[0][0].id)
                     active_ids.remove(cmd.qubits[0][0].id)
-                    self.current_mapping.pop(cmd.qubits[0][0].id)
+                    self._current_row_major_mapping.pop(cmd.qubits[0][0].id)
+                    self._current_mapping.pop(cmd.qubits[0][0].id) ###########################
                 else:
                     new_stored_commands.append(cmd)
             else:
@@ -414,7 +461,7 @@ class GridMapper(BasicMapperEngine):
                         if qubit.id not in active_ids:
                             send_gate = False
                             break
-                        mapped_ids.add(self.current_mapping[qubit.id])
+                        mapped_ids.add(self._current_row_major_mapping[qubit.id])
                 # Check that mapped ids are nearest neighbour on 2D grid
                 if len(mapped_ids) == 2:
                     qb0, qb1 = sorted(list(mapped_ids))
@@ -424,6 +471,10 @@ class GridMapper(BasicMapperEngine):
                     elif qb1 - qb0 == 1 and qb1 % self.num_columns != 0:
                         send_gate = True
                 if send_gate:
+                    # Note: This sends the cmd correctly with the backend ids
+                    #       as it looks up the mapping in self.current_mapping
+                    #       and not our internal mapping 
+                    #.      self._current_row_major_mapping
                     self._send_cmd_with_mapped_ids(cmd)
                 else:
                     for qureg in cmd.all_qubits:
@@ -444,16 +495,17 @@ class GridMapper(BasicMapperEngine):
         """
         num_of_stored_commands_before = len(self._stored_commands)
         if not self.current_mapping:
-            self.current_mapping = dict()
-        new_mapping = self._return_new_mapping()
+            self.current_mapping = dict() ###########################################
+            self._current_row_major_mapping = dict()
+        new_row_major_mapping = self._return_new_mapping()
         # Allocate all mapped qubit ids
         mapped_ids_used = set()
         for logical_id in self._currently_allocated_ids:
-            mapped_ids_used.add(self.current_mapping[logical_id])
+            mapped_ids_used.add(self._current_row_major_mapping[logical_id])
         not_allocated_ids = set(range(self.num_qubits)).difference(
             mapped_ids_used)
         for mapped_id in not_allocated_ids:
-            qb = WeakQubitRef(engine=self, idx=mapped_id)
+            qb = WeakQubitRef(engine=self, idx=self._mapped_ids_to_backend_ids[mapped_id])
             cmd = Command(engine=self, gate=AllocateQubitGate(),
                           qubits=([qb],))
             self.send([cmd])
@@ -471,8 +523,8 @@ class GridMapper(BasicMapperEngine):
                 permutations.append(self._rng.sample(matchings_numbers,
                                                      self.num_rows))
         for permutation in permutations:
-            trial_swaps = self.return_swaps(old_mapping=self.current_mapping,
-                                            new_mapping=new_mapping,
+            trial_swaps = self.return_swaps(old_mapping=self._current_row_major_mapping,
+                                            new_mapping=new_row_major_mapping,
                                             permutation=permutation)
             if swaps is None:
                 swaps = trial_swaps
@@ -482,8 +534,8 @@ class GridMapper(BasicMapperEngine):
                 lowest_cost = self.optimization_function(trial_swaps)
         # Send swap operations to arrive at new_mapping:
         for qubit_id0, qubit_id1 in swaps:
-            q0 = WeakQubitRef(engine=self, idx=qubit_id0)
-            q1 = WeakQubitRef(engine=self, idx=qubit_id1)
+            q0 = WeakQubitRef(engine=self, idx=self._mapped_ids_to_backend_ids[qubit_id0])
+            q1 = WeakQubitRef(engine=self, idx=self._mapped_ids_to_backend_ids[qubit_id1])
             cmd = Command(engine=self, gate=Swap, qubits=([q0], [q1]))
             self.send([cmd])
         # Register statistics:
@@ -498,17 +550,22 @@ class GridMapper(BasicMapperEngine):
         else:
             self.num_of_swaps_per_mapping[len(swaps)] += 1
         # Change to new map:
+        self._current_row_major_mapping = new_row_major_mapping
+        new_mapping = dict()
+        for logical_id, mapped_id in new_row_major_mapping.items():
+            new_mapping[logical_id] = self._mapped_ids_to_backend_ids[mapped_id]
         self.current_mapping = new_mapping
+
         # Send possible gates:
         self._send_possible_commands()
         # Deallocate all mapped qubit ids not used for storing information:
         mapped_ids_used = set()
         for logical_id in self._currently_allocated_ids:
-            mapped_ids_used.add(self.current_mapping[logical_id])
+            mapped_ids_used.add(self._current_row_major_mapping[logical_id])
         not_allocated_ids = set(range(self.num_qubits)).difference(
             mapped_ids_used)
         for mapped_id in not_allocated_ids:
-            qb = WeakQubitRef(engine=self, idx=mapped_id)
+            qb = WeakQubitRef(engine=self, idx=self._mapped_ids_to_backend_ids[mapped_id])
             cmd = Command(engine=self, gate=DeallocateQubitGate(),
                           qubits=([qb],))
             self.send([cmd])

--- a/projectq/cengines/_twodmapper.py
+++ b/projectq/cengines/_twodmapper.py
@@ -60,7 +60,7 @@ class GridMapper(BasicMapperEngine):
 
     Attributes:
         current_mapping:  Stores the mapping: key is logical qubit id, value
-                          are backend qubit ids.
+                          is backend qubit id.
         storage(int): Number of gate it caches before mapping.
         num_rows(int): Number of rows in the grid
         num_columns(int): Number of columns in the grid

--- a/projectq/cengines/_twodmapper.py
+++ b/projectq/cengines/_twodmapper.py
@@ -108,8 +108,8 @@ class GridMapper(BasicMapperEngine):
         self.num_rows = num_rows
         self.num_columns = num_columns
         self.num_qubits = num_rows * num_columns
-        # Internally we use the mapped ids until sending a command when it gets
-        # translated using this mapping:
+        # Internally we use the mapped ids until sending a command.
+        # Before sending we use this map to translate to backend ids:
         self._mapped_ids_to_backend_ids = mapped_ids_to_backend_ids
         if self._mapped_ids_to_backend_ids is None:
             self._mapped_ids_to_backend_ids = dict()

--- a/projectq/cengines/_twodmapper_test.py
+++ b/projectq/cengines/_twodmapper_test.py
@@ -161,7 +161,7 @@ def test_send_possible_commands_allocate():
     assert len(backend.received_commands) == 0
     assert mapper._stored_commands == [cmd0]
     # in mapping:
-    mapper.current_mapping[0] = 3
+    mapper.current_mapping = {0: 3}
     mapper._send_possible_commands()
     assert len(mapper._stored_commands) == 0
     # Only self._run() sends Allocate gates
@@ -185,7 +185,7 @@ def test_send_possible_commands_deallocate():
     assert len(backend.received_commands) == 0
     assert mapper._stored_commands == [cmd0]
     # allocated:
-    mapper.current_mapping[0] = 3
+    mapper.current_mapping = {0: 3}
     mapper._currently_allocated_ids.add(0)
     mapper._send_possible_commands()
     # Only self._run() send Deallocate gates

--- a/projectq/cengines/_twodmapper_test.py
+++ b/projectq/cengines/_twodmapper_test.py
@@ -55,6 +55,14 @@ def test_wrong_init_mapped_ids_to_backend_ids():
                          mapped_ids_to_backend_ids=test)
 
 
+def test_resetting_mapping_to_none():
+    mapper = two_d.GridMapper(num_rows=2, num_columns=3)
+    mapper.current_mapping = {0: 1}
+    assert mapper._current_row_major_mapping == {0: 1}
+    mapper.current_mapping = None
+    assert mapper._current_row_major_mapping is None
+
+
 @pytest.mark.parametrize("different_backend_ids", [False, True])
 def test_return_new_mapping(different_backend_ids):
     if different_backend_ids:

--- a/projectq/cengines/_twodmapper_test.py
+++ b/projectq/cengines/_twodmapper_test.py
@@ -20,6 +20,7 @@ import random
 
 import pytest
 
+import projectq
 from projectq.cengines import DummyEngine
 from projectq.ops import (Allocate, BasicGate, Command, Deallocate, FlushGate,
                           X)
@@ -43,8 +44,27 @@ def test_is_available():
     assert not mapper.is_available(cmd3)
 
 
-def test_return_new_mapping():
-    mapper = two_d.GridMapper(num_rows=4, num_columns=3)
+def test_wrong_init_mapped_ids_to_backend_ids():
+    with pytest.raises(RuntimeError):
+        test = {0: 1, 1: 0, 2: 2, 3: 3, 4: 4}
+        two_d.GridMapper(num_rows=2, num_columns=3,
+                         mapped_ids_to_backend_ids=test)
+    with pytest.raises(RuntimeError):
+        test = {0: 1, 1: 0, 2: 2, 3: 3, 4: 4, 5: 2}
+        two_d.GridMapper(num_rows=2, num_columns=3,
+                         mapped_ids_to_backend_ids=test)
+
+
+@pytest.mark.parametrize("different_backend_ids", [False, True])
+def test_return_new_mapping(different_backend_ids):
+    if different_backend_ids:
+        map_to_backend_ids = {0: 21, 1: 32, 2: 1, 3: 4, 4: 5, 5: 6, 6: 10,
+                              7: 7, 8: 0, 9: 56, 10: 55, 11: 9}
+    else:
+        map_to_backend_ids = None
+    mapper = two_d.GridMapper(num_rows=4, num_columns=3,
+                              mapped_ids_to_backend_ids=map_to_backend_ids)
+    eng = projectq.MainEngine(DummyEngine(), [mapper])
     linear_chain_ids = [33, 22, 11, 2, 3, 0, 6, 7, 9, 12, 4, 88]
     mapper._stored_commands = []
     for i in range(12):
@@ -63,6 +83,19 @@ def test_return_new_mapping():
                            2: 8, 11: 11, 22: 10, 33: 9}
     assert (new_mapping == possible_solution_1 or
             new_mapping == possible_solution_2)
+    eng.flush()
+    if different_backend_ids:
+        transformed_sol1 = dict()
+        for logical_id, mapped_id in possible_solution_1.items():
+            transformed_sol1[logical_id] = map_to_backend_ids[mapped_id]
+        transformed_sol2 = dict()
+        for logical_id, mapped_id in possible_solution_2.items():
+            transformed_sol2[logical_id] = map_to_backend_ids[mapped_id]
+        assert (mapper.current_mapping == transformed_sol1 or
+                mapper.current_mapping == transformed_sol2)
+    else:
+        assert (mapper.current_mapping == possible_solution_1 or
+                mapper.current_mapping == possible_solution_2)
 
 
 @pytest.mark.parametrize("num_rows, num_columns, seed, none_old, none_new",
@@ -116,13 +149,25 @@ def test_return_swaps_random(num_rows, num_columns, seed, none_old, none_new):
             assert test_chain[i] == new_chain[i]
 
 
-def test_send_possible_commands():
-    mapper = two_d.GridMapper(num_rows=2, num_columns=4)
+@pytest.mark.parametrize("different_backend_ids", [False, True])
+def test_send_possible_commands(different_backend_ids):
+    if different_backend_ids:
+        map_to_backend_ids = {0: 21, 1: 32, 2: 1, 3: 4, 4: 5, 5: 6, 6: 10,
+                              7: 7}
+    else:
+        map_to_backend_ids = None
+    mapper = two_d.GridMapper(num_rows=2, num_columns=4,
+                              mapped_ids_to_backend_ids=map_to_backend_ids)
     backend = DummyEngine(save_commands=True)
     backend.is_last_engine = True
     mapper.next_engine = backend
     # mapping is identical except 5 <-> 0
-    mapper.current_mapping = {5: 0, 1: 1, 2: 2, 3: 3, 4: 4, 0: 5, 6: 6, 7: 7}
+    if different_backend_ids:
+        mapper.current_mapping = {0: 6, 1: 32, 2: 1, 3: 4, 4: 5, 5: 21, 6: 10,
+                                  7: 7}
+    else:
+        mapper.current_mapping = {5: 0, 1: 1, 2: 2, 3: 3, 4: 4, 0: 5, 6: 6,
+                                  7: 7}
     neighbours = [(5, 1), (1, 2), (2, 3), (4, 0), (0, 6), (6, 7),
                   (5, 4), (1, 0), (2, 6), (3, 7)]
     for qb0_id, qb1_id in neighbours:
@@ -144,8 +189,14 @@ def test_send_possible_commands():
             assert len(mapper._stored_commands) == 1
 
 
-def test_send_possible_commands_allocate():
-    mapper = two_d.GridMapper(num_rows=3, num_columns=2)
+@pytest.mark.parametrize("different_backend_ids", [False, True])
+def test_send_possible_commands_allocate(different_backend_ids):
+    if different_backend_ids:
+        map_to_backend_ids = {0: 21, 1: 32, 2: 3, 3: 4, 4: 5, 5: 6}
+    else:
+        map_to_backend_ids = None
+    mapper = two_d.GridMapper(num_rows=3, num_columns=2,
+                              mapped_ids_to_backend_ids=map_to_backend_ids)
     backend = DummyEngine(save_commands=True)
     backend.is_last_engine = True
     mapper.next_engine = backend
@@ -169,8 +220,14 @@ def test_send_possible_commands_allocate():
     assert mapper._currently_allocated_ids == set([10, 0])
 
 
-def test_send_possible_commands_deallocate():
-    mapper = two_d.GridMapper(num_rows=3, num_columns=2)
+@pytest.mark.parametrize("different_backend_ids", [False, True])
+def test_send_possible_commands_deallocate(different_backend_ids):
+    if different_backend_ids:
+        map_to_backend_ids = {0: 21, 1: 32, 2: 3, 3: 4, 4: 5, 5: 6}
+    else:
+        map_to_backend_ids = None
+    mapper = two_d.GridMapper(num_rows=3, num_columns=2,
+                              mapped_ids_to_backend_ids=map_to_backend_ids)
     backend = DummyEngine(save_commands=True)
     backend.is_last_engine = True
     mapper.next_engine = backend
@@ -195,8 +252,14 @@ def test_send_possible_commands_deallocate():
     assert mapper._currently_allocated_ids == set([10])
 
 
-def test_send_possible_commands_keep_remaining_gates():
-    mapper = two_d.GridMapper(num_rows=3, num_columns=2)
+@pytest.mark.parametrize("different_backend_ids", [False, True])
+def test_send_possible_commands_keep_remaining_gates(different_backend_ids):
+    if different_backend_ids:
+        map_to_backend_ids = {0: 21, 1: 32, 2: 3, 3: 0, 4: 5, 5: 6}
+    else:
+        map_to_backend_ids = None
+    mapper = two_d.GridMapper(num_rows=3, num_columns=2,
+                              mapped_ids_to_backend_ids=map_to_backend_ids)
     backend = DummyEngine(save_commands=True)
     backend.is_last_engine = True
     mapper.next_engine = backend
@@ -215,8 +278,14 @@ def test_send_possible_commands_keep_remaining_gates():
     assert mapper._stored_commands == [cmd2]
 
 
-def test_send_possible_commands_one_inactive_qubit():
-    mapper = two_d.GridMapper(num_rows=3, num_columns=2)
+@pytest.mark.parametrize("different_backend_ids", [False, True])
+def test_send_possible_commands_one_inactive_qubit(different_backend_ids):
+    if different_backend_ids:
+        map_to_backend_ids = {0: 21, 1: 32, 2: 3, 3: 0, 4: 5, 5: 6}
+    else:
+        map_to_backend_ids = None
+    mapper = two_d.GridMapper(num_rows=3, num_columns=2,
+                              mapped_ids_to_backend_ids=map_to_backend_ids)
     backend = DummyEngine(save_commands=True)
     backend.is_last_engine = True
     mapper.next_engine = backend
@@ -231,15 +300,23 @@ def test_send_possible_commands_one_inactive_qubit():
     assert mapper._stored_commands == [cmd1]
 
 
+@pytest.mark.parametrize("different_backend_ids", [False, True])
 @pytest.mark.parametrize("num_optimization_steps", [1, 10])
-def test_run_and_receive(num_optimization_steps):
+def test_run_and_receive(num_optimization_steps, different_backend_ids):
+    if different_backend_ids:
+        map_to_backend_ids = {0: 21, 1: 32, 2: 3, 3: 0}
+    else:
+        map_to_backend_ids = None
+
     def choose_last_permutation(swaps):
         choose_last_permutation.counter -= 1
         return choose_last_permutation.counter
+
     choose_last_permutation.counter = 100
     mapper = two_d.GridMapper(
         num_rows=2,
         num_columns=2,
+        mapped_ids_to_backend_ids=map_to_backend_ids,
         optimization_function=choose_last_permutation,
         num_optimization_steps=num_optimization_steps)
     backend = DummyEngine(save_commands=True)
@@ -267,10 +344,16 @@ def test_run_and_receive(num_optimization_steps):
     assert mapper._stored_commands == []
     assert len(backend.received_commands) == 10
     assert mapper._currently_allocated_ids == set([0, 2, 3])
-    assert (mapper.current_mapping == {0: 0, 2: 2, 3: 3} or
-            mapper.current_mapping == {0: 1, 2: 3, 3: 0} or
-            mapper.current_mapping == {0: 2, 2: 0, 3: 1} or
-            mapper.current_mapping == {0: 3, 2: 1, 3: 2})
+    if different_backend_ids:
+        assert (mapper.current_mapping == {0: 21, 2: 3, 3: 0} or
+                mapper.current_mapping == {0: 32, 2: 0, 3: 21} or
+                mapper.current_mapping == {0: 3, 2: 21, 3: 32} or
+                mapper.current_mapping == {0: 0, 2: 32, 3: 3})
+    else:
+        assert (mapper.current_mapping == {0: 0, 2: 2, 3: 3} or
+                mapper.current_mapping == {0: 1, 2: 3, 3: 0} or
+                mapper.current_mapping == {0: 2, 2: 0, 3: 1} or
+                mapper.current_mapping == {0: 3, 2: 1, 3: 2})
     cmd9 = Command(None, X, qubits=([qb0],), controls=[qb2])
     mapper.storage = 1
     mapper.receive([cmd9])


### PR DESCRIPTION
Potentially breaking changes (does not affect master branch):
* self.current_mapping is now a property (all ProjectQ mappers are adapted)