### PR TITLE
WIP: add the Rigetti Forest API as a backend

### DIFF
--- a/projectq/backends/_rigetti/__init__.py
+++ b/projectq/backends/_rigetti/__init__.py
@@ -12,23 +12,4 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-"""
-Contains back-ends for ProjectQ.
-
-This includes:
-
-* a debugging tool to print all received commands (CommandPrinter)
-* a circuit drawing engine (which can be used anywhere within the compilation
-  chain)
-* a simulator with emulation capabilities
-* a resource counter (counts gates and keeps track of the maximal width of the
-  circuit)
-* an interface to the IBM Quantum Experience chip (and simulator).
-* an interface to the Rigetti Forest API (and QVM)
-"""
-from ._printer import CommandPrinter
-from ._circuits import CircuitDrawer
-from ._sim import Simulator, ClassicalSimulator
-from ._resource import ResourceCounter
-from ._ibm import IBMBackend
 from ._rigetti import RigettiBackend

--- a/projectq/backends/_rigetti/_rigetti.py
+++ b/projectq/backends/_rigetti/_rigetti.py
@@ -1,0 +1,315 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+""" Back-end to run quantum program on Rigetti's Forest API."""
+
+import random
+import json
+
+from projectq.cengines import BasicEngine
+from projectq.meta import get_control_count, LogicalQubitIDTag
+from projectq.ops import (NOT,
+                          Y,
+                          Z,
+                          T,
+                          Tdag,
+                          S,
+                          Sdag,
+                          H,
+                          Rx,
+                          Ry,
+                          Rz,
+                          Measure,
+                          Allocate,
+                          Deallocate,
+                          Barrier,
+                          FlushGate)
+
+from ._rigetti_http_client import send, retrieve
+
+RIGETTI_DEVICES = ["8Q-Agave", "19Q-Acorn"]
+
+class RigettiBackend(BasicEngine):
+    """
+    The Rigetti Backend class, which stores the circuit, transforms it to JSON
+    Quil, and sends the circuit through the Rigetti Forest API.
+    """
+    def __init__(self, use_hardware=False, num_runs=1024, verbose=False,
+                 user_id=None, api_key=None, device=RIGETTI_DEVICES[0],
+                 retrieve_execution=None):
+        """
+        Initialize the Backend object.
+
+        Args:
+            use_hardware (bool): If True, the code is run on the Rigetti quantum
+                chip (instead of using the virtual machine)
+            num_runs (int): Number of runs to collect statistics.
+                (default is 1024)
+            verbose (bool): If True, statistics are printed, in addition to
+                the measurement result being registered (at the end of the
+                circuit).
+            user_id (string): Rigetti API user id
+            api_key (string): Rigetti API's API key
+            device (string): Device to use ('8Q-Agave', or '19Q-Acorn')
+                if use_hardware is set to True. Default is 8Q-Agave.
+            retrieve_execution (int): Job ID to retrieve instead of re-
+                running the circuit (e.g., if previous run timed out).
+        """
+        BasicEngine.__init__(self)
+        self._reset()
+        if use_hardware:
+            self.device = device
+        else:
+            self.device = 'simulator'
+        self._num_runs = num_runs
+        self._verbose = verbose
+        self._user_id = user
+        self._api_key = password
+        self._probabilities = dict()
+        self.quil = ""
+        self._measured_ids = []
+        self._allocated_qubits = set()
+        self._retrieve_execution = retrieve_execution
+
+    def is_available(self, cmd):
+        """
+        Return true if the command can be executed.
+
+        Rigetti's quantum chips can do X, Y, Z, T, Tdag, S, Sdag,
+        rotation gates, barriers, and CX / CNOT.
+
+        Args:
+            cmd (Command): Command for which to check availability
+        """
+        g = cmd.gate
+        if g == NOT and get_control_count(cmd) <= 1:
+            return True
+        if get_control_count(cmd) == 0:
+            if g in (T, Tdag, S, Sdag, H, Y, Z):
+                return True
+            if isinstance(g, (Rx, Ry, Rz)):
+                return True
+        if g in (Measure, Allocate, Deallocate, Barrier):
+            return True
+        return False
+
+    def _reset(self):
+        """ Reset all temporary variables (after flush gate). """
+        self._clear = True
+        self._measured_ids = []
+
+    def _store(self, cmd):
+        """
+        Temporarily store the command cmd.
+
+        Translates the command and stores it in a local variable (self._cmds).
+
+        Args:
+            cmd: Command to store
+        """
+        if self._clear:
+            self._probabilities = dict()
+            self._clear = False
+            self.qasm = ""
+            self._allocated_qubits = set()
+
+        gate = cmd.gate
+
+        if gate == Allocate:
+            self._allocated_qubits.add(cmd.qubits[0][0].id)
+            return
+
+        if gate == Deallocate:
+            return
+
+        if gate == Measure:
+            assert len(cmd.qubits) == 1 and len(cmd.qubits[0]) == 1
+            qb_id = cmd.qubits[0][0].id
+            logical_id = None
+            for t in cmd.tags:
+                if isinstance(t, LogicalQubitIDTag):
+                    logical_id = t.logical_qubit_id
+                    break
+            assert logical_id is not None
+            self._measured_ids += [logical_id]
+        elif gate == NOT and get_control_count(cmd) == 1:
+            ctrl_pos = cmd.control_qubits[0].id
+            qb_pos = cmd.qubits[0][0].id
+            self.quil += "\ncx q[{}], q[{}];".format(ctrl_pos, qb_pos)
+        elif gate == Barrier:
+            qb_pos = [qb.id for qr in cmd.qubits for qb in qr]
+            self.quil += "\nbarrier "
+            qb_str = ""
+            for pos in qb_pos:
+                qb_str += "q[{}], ".format(pos)
+            self.quil += qb_str[:-2] + ";"
+        elif isinstance(gate, (Rx, Ry, Rz)):
+            assert get_control_count(cmd) == 0
+            qb_pos = cmd.qubits[0][0].id
+            u_strs = {'Rx': 'u3({}, -pi/2, pi/2)', 'Ry': 'u3({}, 0, 0)',
+                      'Rz': 'u1({})'}
+            gate = u_strs[str(gate)[0:2]].format(gate.angle)
+            self.quil += "\n{} q[{}];".format(gate, qb_pos)
+        else:
+            assert get_control_count(cmd) == 0
+            if str(gate) in self._gate_names:
+                gate_str = self._gate_names[str(gate)]
+            else:
+                gate_str = str(gate).lower()
+
+            qb_pos = cmd.qubits[0][0].id
+            self.quil += "\n{} q[{}];".format(gate_str, qb_pos)
+
+    def _logical_to_physical(self, qb_id):
+        """
+        Return the physical location of the qubit with the given logical id.
+
+        Args:
+            qb_id (int): ID of the logical qubit whose position should be
+                returned.
+        """
+        assert self.main_engine.mapper is not None
+        mapping = self.main_engine.mapper.current_mapping
+        if qb_id not in mapping:
+            raise RuntimeError("Unknown qubit id {}. Please make sure "
+                               "eng.flush() was called and that the qubit "
+                               "was eliminated during optimization."
+                               .format(qb_id))
+        return mapping[qb_id]
+
+    def get_probabilities(self, qureg):
+        """
+        Return the list of basis states with corresponding probabilities.
+
+        The measured bits are ordered according to the supplied quantum
+        register, i.e., the left-most bit in the state-string corresponds to
+        the first qubit in the supplied quantum register.
+
+        Warning:
+            Only call this function after the circuit has been executed!
+
+        Args:
+            qureg (list<Qubit>): Quantum register determining the order of the
+                qubits.
+
+        Returns:
+            probability_dict (dict): Dictionary mapping n-bit strings to
+            probabilities.
+
+        Raises:
+            RuntimeError: If no data is available (i.e., if the circuit has
+                not been executed). Or if a qubit was supplied which was not
+                present in the circuit (might have gotten optimized away).
+        """
+        if len(self._probabilities) == 0:
+            raise RuntimeError("Please, run the circuit first!")
+
+        probability_dict = dict()
+
+        for state in self._probabilities:
+            mapped_state = ['0'] * len(qureg)
+            for i in range(len(qureg)):
+                mapped_state[i] = state[self._logical_to_physical(qureg[i].id)]
+            probability = self._probabilities[state]
+            probability_dict["".join(mapped_state)] = probability
+
+        return probability_dict
+
+    def _run(self):
+        """
+        Run the circuit.
+
+        Send the circuit via the Rigetti Forest API (JSON Quil) using the provided user
+        data / ask for user id & api key.
+        """
+        if self.quil == "":
+            return
+        # finally: add measurements (no intermediate measurements are allowed)
+        for measured_id in self._measured_ids:
+            qb_loc = self.main_engine.mapper.current_mapping[measured_id]
+            self.quil += "\nmeasure q[{}] -> c[{}];".format(qb_loc,
+                                                            qb_loc)
+
+        max_qubit_id = max(self._allocated_qubits)
+        quil = ("\ninclude \"qelib1.inc\";\nqreg q[{nq}];\ncreg c[{nq}];" +
+                self.quil).format(nq=max_qubit_id + 1)
+        info = {}
+        info['qasms'] = [{'quil': quil}]
+        info['shots'] = self._num_runs
+        info['maxCredits'] = 5
+        info['backend'] = {'name': self.device}
+        info = json.dumps(info)
+
+        try:
+            if self._retrieve_execution is None:
+                res = send(info, device=self.device,
+                           user_id=self._user_id, api_key=self._api_key,
+                           shots=self._num_runs, verbose=self._verbose)
+            else:
+                res = retrieve(device=self.device, user_id=self._user_id,
+                               api_key=self._api_key,
+                               jobid=self._retrieve_execution)
+
+            counts = res['data']['counts']
+            # Determine random outcome
+            P = random.random()
+            p_sum = 0.
+            measured = ""
+            for state in counts:
+                probability = counts[state] * 1. / self._num_runs
+                state = list(reversed(state))
+                state = "".join(state)
+                p_sum += probability
+                star = ""
+                if p_sum >= P and measured == "":
+                    measured = state
+                    star = "*"
+                self._probabilities[state] = probability
+                if self._verbose and probability > 0:
+                    print(str(state) + " with p = " + str(probability) +
+                          star)
+
+            class QB():
+                def __init__(self, ID):
+                    self.id = ID
+
+            # register measurement result
+            for ID in self._measured_ids:
+                location = self._logical_to_physical(ID)
+                result = int(measured[location])
+                self.main_engine.set_measurement_result(QB(ID), result)
+            self._reset()
+        except TypeError:
+            raise Exception("Failed to run the circuit. Aborting.")
+
+    def receive(self, command_list):
+        """
+        Receives a command list and, for each command, stores it until
+        completion.
+
+        Args:
+            command_list: List of commands to execute
+        """
+        for cmd in command_list:
+            if not cmd.gate == FlushGate():
+                self._store(cmd)
+            else:
+                self._run()
+                self._reset()
+
+    """
+    Mapping of gate names from our gate objects to the Rigetti Quil representation.
+    """
+    _gate_names = {str(Tdag): "tdg",
+                   str(Sdag): "sdg"}

--- a/projectq/backends/_rigetti/_rigetti.py
+++ b/projectq/backends/_rigetti/_rigetti.py
@@ -157,19 +157,20 @@ class RigettiBackend(BasicEngine):
         elif isinstance(gate, (Rx, Ry, Rz)):
             assert get_control_count(cmd) == 0
             qb_pos = cmd.qubits[0][0].id
-            u_strs = {'Rx': 'u3({}, -pi/2, pi/2)', 'Ry': 'u3({}, 0, 0)',
-                      'Rz': 'u1({})'}
-            gate = u_strs[str(gate)[0:2]].format(gate.angle)
-            self.quil += "\n{} {};".format(gate, qb_pos)
+            sign = ''
+            if gate.angle < 0:
+                sign = '-'
+            gate = str("{}({}pi/{})").format(str(gate)[0:2].upper(), sign, 1 / abs(gate.angle))
+            self.quil += "\n{} {}".format(gate, qb_pos)
         else:
             assert get_control_count(cmd) == 0
             if str(gate) in self._gate_names:
                 gate_str = self._gate_names[str(gate)]
             else:
-                gate_str = str(gate).lower()
+                gate_str = str(gate).upper()
 
             qb_pos = cmd.qubits[0][0].id
-            self.quil += "\n{} {}".format(gate_str.upper(), qb_pos)
+            self.quil += "\n{} {}".format(gate_str, qb_pos)
 
     def _logical_to_physical(self, qb_id):
         """

--- a/projectq/backends/_rigetti/_rigetti.py
+++ b/projectq/backends/_rigetti/_rigetti.py
@@ -259,7 +259,16 @@ class RigettiBackend(BasicEngine):
                                api_key=self._api_key,
                                jobid=self._retrieve_execution)
 
-            counts = res['data']['counts']
+            counts = {}
+            for result in res:
+                combined = ''
+                for val in result:
+                    combined += str(val)
+                if combined not in counts:
+                    counts[combined] = 1
+                else:
+                    counts[combined] += 1
+
             # Determine random outcome
             P = random.random()
             p_sum = 0.

--- a/projectq/backends/_rigetti/_rigetti_http_client.py
+++ b/projectq/backends/_rigetti/_rigetti_http_client.py
@@ -1,0 +1,168 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+# helpers to run the jsonified gate sequence on Rigetti's Forest API
+# official SDK is at https://github.com/rigetticomputing/pyquil
+import requests
+import getpass
+import json
+import sys
+import time
+from requests.compat import urljoin
+
+
+_api_url = 'https://job.rigetti.com/beta/'
+_old_api_url = 'https://api.rigetti.com/qvm'
+RIGETTI_DEVICES = ["8Q-Agave", "19Q-Acorn"]
+
+class DeviceOfflineError(Exception):
+    pass
+
+def is_online(device, user_id, api_key):
+    r = requests.get(urljoin(_api_url, "devices"), headers={
+        "X-Api-Key": api_key,
+        "X-User-Id": user_id,
+        "Accept": "application/octet-stream"
+    })
+    device_list = r.json()["devices"]
+    if device in device_list:
+        return device_list[device]["is_online"]
+    else:
+        raise Exception("Did not find record of device")
+
+def retrieve(device, user_id, api_key, jobid):
+    """
+    Retrieves a previously run job by its ID.
+
+    Args:
+        device (str): Device on which the code was run / is running.
+        user_id (str): Rigetti User ID
+        api_key (str): Rigetti API Key
+        jobid (str): Id of the job to retrieve
+    """
+    _authenticate(user_id, api_key)
+    res = _get_result(device, jobid, user_id, api_key)
+    return res
+
+
+def send(info, device=RIGETTI_DEVICES[0], user_id=None, api_key=None,
+         shots=1, verbose=False):
+    """
+    Sends Quil through the Rigetti Forest/API and runs the quantum circuit.
+
+    Args:
+        info: Contains Quil representation of the circuit to run.
+        device (str): Either '8Q-Agave' or '19Q-Acorn'
+        user_id (str): Rigetti User ID
+        api_key (str): Rigetti API Key
+        shots (int): Number of runs of the same circuit to collect statistics.
+        verbose (bool): If True, additional information is printed if available.
+            Otherwise, the backend simply registers
+            one measurement result.
+    """
+    try:
+        # check if the device is online
+        if device in RIGETTI_DEVICES:
+            online = is_online(device, user_id, api_key)
+
+            if not online:
+                print("The device is offline (for maintenance?). Use the "
+                      "simulator instead or try again later.")
+                raise DeviceOfflineError("Device is offline.")
+
+        if verbose:
+            print("- Authenticating...")
+        _authenticate(user_id, api_key)
+        if verbose:
+            print("- Running code: {}".format(
+                json.loads(info)['quils'][0]['quil']))
+        execution_id = _run(info, device, user_id, api_key, shots)
+        if verbose:
+            print("- Waiting for results...")
+        res = _get_result(device, execution_id, user_id, api_key)
+        if verbose:
+            print("- Done.")
+        return res
+    except requests.exceptions.HTTPError as err:
+        print("- There was an error running your code:")
+        print(err)
+    except requests.exceptions.RequestException as err:
+        print("- Looks like something is wrong with server:")
+        print(err)
+    except KeyError as err:
+        print("- Failed to parse response:")
+        print(err)
+
+
+def _authenticate(user_id=None, api_key=None):
+    """
+    :param user_id:
+    :param api_key:
+    :return:
+    """
+    if user_id is None:
+        try:
+            input_fun = raw_input
+        except NameError:
+            input_fun = input
+        email = input_fun('Rigetti User ID (not email) > ')
+    if api_key is None:
+        api_key = getpass.getpass(prompt='Rigetti API Key > ')
+
+def _run(quil, device, user_id, api_key, shots):
+    suffix = 'Jobs'
+
+    r = requests.post(urljoin(_api_url, suffix),
+                      data=quil,
+                      params={"access_token": access_token,
+                              "deviceRunType": device,
+                              "fromCache": "false",
+                              "shots": shots},
+                      headers={"Content-Type": "application/json"})
+    r.raise_for_status()
+
+    r_json = r.json()
+    execution_id = r_json["id"]
+    return execution_id
+
+
+def _get_result(device, execution_id, user_id, api_key, num_retries=3000,
+                interval=1):
+    suffix = 'Jobs/{execution_id}'.format(execution_id=execution_id)
+    status_url = urljoin(_api_url, 'Backends/{}/queue/status'.format(device))
+
+    print("Waiting for results. [Job ID: {}]".format(execution_id))
+
+    for retries in range(num_retries):
+        r = requests.get(urljoin(_api_url, suffix))
+        r.raise_for_status()
+
+        r_json = r.json()
+        if 'quils' in r_json:
+            quil = r_json['quils'][0]
+            if 'result' in quil:
+                return quil['result']
+        time.sleep(interval)
+        if device in RIGETTI_DEVICES and retries % 60 == 0:
+            r = requests.get(status_url)
+            r_json = r.json()
+            if 'state' in r_json and not r_json['state']:
+                raise DeviceOfflineError("Device went offline. The ID of your "
+                                         "submitted job is {}."
+                                         .format(execution_id))
+            if 'lengthQueue' in r_json:
+                print("Currently there are {} jobs queued for execution on {}."
+                      .format(r_json['lengthQueue'], device))
+    raise Exception("Timeout. The ID of your submitted job is {}."
+                    .format(execution_id))

--- a/projectq/backends/_rigetti/_rigetti_http_client.py
+++ b/projectq/backends/_rigetti/_rigetti_http_client.py
@@ -63,7 +63,7 @@ def send(info, device=RIGETTI_DEVICES[0], user_id=None, api_key=None,
 
     Args:
         info: Contains Quil representation of the circuit to run.
-        device (str): Either '8Q-Agave' or '19Q-Acorn'
+        device (str): 'QVM', '8Q-Agave', or '19Q-Acorn'
         user_id (str): Rigetti User ID
         api_key (str): Rigetti API Key
         shots (int): Number of runs of the same circuit to collect statistics.
@@ -78,7 +78,7 @@ def send(info, device=RIGETTI_DEVICES[0], user_id=None, api_key=None,
 
             if not online:
                 print("The device is offline (for maintenance?). Use the "
-                      "simulator instead or try again later.")
+                      "QVM instead or try again later.")
                 raise DeviceOfflineError("Device is offline.")
 
         if verbose:
@@ -150,14 +150,13 @@ def _run(runcodes, device, user_id, api_key, shots):
     suffix = 'job'
     r = requests.post(urljoin(_api_url, suffix),
                       json={
-                        "machine": "QVM",
+                        "machine": device,
                         "program": {
                             "type": "multishot-measure",
                             "qubits": list(range(0, max_register + 1)),
                             "trials": runcodes["shots"],
                             "compiled-quil": internal_code + "\n"
                         }
-                        # , "device": ""
                       },
                       headers={
                         "Content-Type": "application/json",

--- a/projectq/backends/_rigetti/_rigetti_http_client.py
+++ b/projectq/backends/_rigetti/_rigetti_http_client.py
@@ -153,7 +153,6 @@ def _run(runcodes, device, user_id, api_key, shots):
                         "machine": "QVM",
                         "program": {
                             "type": "multishot-measure",
-                            # "qubits": list(range(0, max_register + 1)),
                             "qubits": list(range(0, max_register + 1)),
                             "trials": runcodes["shots"],
                             "compiled-quil": internal_code + "\n"

--- a/projectq/backends/_rigetti/_rigetti_http_client_test.py
+++ b/projectq/backends/_rigetti/_rigetti_http_client_test.py
@@ -1,0 +1,464 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Tests for projectq.backends._rigetti_http_client._rigetti.py."""
+
+import json
+import pytest
+import requests
+from requests.compat import urljoin
+
+from projectq.backends._rigetti import _rigetti_http_client
+
+
+# Insure that no HTTP request can be made in all tests in this module
+@pytest.fixture(autouse=True)
+def no_requests(monkeypatch):
+    monkeypatch.delattr("requests.sessions.Session.request")
+
+
+_api_url = "https://job.rigetti.com/beta/"
+_api_url_status = "https://job.rigetti.com/beta/devices"
+
+
+def test_send_real_device_online_verbose(monkeypatch):
+    quils = {'quils': [{'quil': 'my quil'}]}
+    json_quil = json.dumps(quils)
+    name = 'projectq_test'
+    access_token = "access"
+    user_id = 2016
+    code_id = 11
+    name_item = '"name":"{name}", "jsonquil":'.format(name=name)
+    json_body = ''.join([name_item, json_quil])
+    json_data = ''.join(['{', json_body, '}'])
+    shots = 1
+    device = "8Q-Agave"
+    json_data_run = ''.join(['{"quil":', json_quil, '}'])
+    execution_id = 3
+    result_ready = [False]
+    result = "my_result"
+    request_num = [0]  # To assert correct order of calls
+
+    # Mock of Rigetti server:
+    def mocked_requests_get(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, url=""):
+                self.url = url
+
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+                self.request = MockRequest()
+                self.text = ""
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Accessing status of device. Return online.
+        status_url = '/devices'
+        if (args[0] == urljoin(_api_url_status, status_url) and
+                (request_num[0] == 0 or request_num[0] == 3)):
+            request_num[0] += 1
+            return MockResponse({"state": True}, 200)
+        # Getting result
+        elif (args[0] == urljoin(_api_url,
+              "Jobs/{execution_id}".format(execution_id=execution_id)) and
+              kwargs["params"]["access_token"] == access_token and not
+              result_ready[0] and request_num[0] == 3):
+            result_ready[0] = True
+            return MockResponse({"status": {"id": "NotDone"}}, 200)
+        elif (args[0] == urljoin(_api_url,
+              "Jobs/{execution_id}".format(execution_id=execution_id)) and
+              kwargs["params"]["access_token"] == access_token and
+              result_ready[0] and request_num[0] == 4):
+            print("state ok")
+            return MockResponse({"quils": [{"result": result}]}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, body="", url=""):
+                self.body = body
+                self.url = url
+
+        class MockPostResponse:
+            def __init__(self, json_data, text=" "):
+                self.json_data = json_data
+                self.text = text
+                self.request = MockRequest()
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Run code
+        if (args[0] == urljoin(_api_url, "Jobs") and
+                kwargs["data"] == json_quil and
+                kwargs["params"]["access_token"] == access_token and
+                kwargs["params"]["deviceRunType"] == device and
+                kwargs["params"]["fromCache"] == "false" and
+                kwargs["params"]["shots"] == shots and
+                kwargs["headers"]["Content-Type"] == "application/json" and
+                request_num[0] == 2):
+            request_num[0] += 1
+            return MockPostResponse({"id": execution_id})
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    api_key = "test"
+    user_id = "test@projectq.ch"
+    monkeypatch.setitem(__builtins__, "input", lambda x: user_id)
+    monkeypatch.setitem(__builtins__, "raw_input", lambda x: user_id)
+
+    def user_api_key_input(prompt):
+        if prompt == "Rigetti Forest API Key > ":
+            return api_key
+
+    monkeypatch.setattr("getpass.getpass", user_api_key_input)
+
+    # Code to test:
+    res = _rigetti_http_client.send(json_quil,
+                                device="8Q-Agave",
+                                user=None, password=None,
+                                shots=shots, verbose=True)
+    print(res)
+    assert res == result
+
+
+def test_send_real_device_offline(monkeypatch):
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+        # Accessing status of device. Return online.
+        status_url = 'devices'
+        if args[0] == urljoin(_api_url_status, status_url):
+            return MockResponse({"state": False}, 200)
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    shots = 1
+    json_quil = "my_json_quil"
+    name = 'projectq_test'
+    with pytest.raises(_rigetti_http_client.DeviceOfflineError):
+        _rigetti_http_client.send(json_quil,
+                              device="8Q-Agave",
+                              user=None, password=None,
+                              shots=shots, verbose=True)
+
+
+def test_send_that_errors_are_caught(monkeypatch):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+    def mocked_requests_get(*args, **kwargs):
+        # Accessing status of device. Return online.
+        status_url = 'devices'
+        if args[0] == urljoin(_api_url_status, status_url):
+            return MockResponse({"state": True}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        # Test that this error gets caught
+        raise requests.exceptions.HTTPError
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    api_key = "test"
+    user_id = "test@projectq.ch"
+    monkeypatch.setitem(__builtins__, "input", lambda x: user_id)
+    monkeypatch.setitem(__builtins__, "raw_input", lambda x: user_id)
+
+    def user_api_key_input(prompt):
+        if prompt == "Rigetti Forest API Key > ":
+            return api_key
+
+    monkeypatch.setattr("getpass.getpass", user_api_key_input)
+    shots = 1
+    json_quil = "my_json_quil"
+    name = 'projectq_test'
+    _rigetti_http_client.send(json_quil,
+                          device="8Q-Agave",
+                          user=None, password=None,
+                          shots=shots, verbose=True)
+
+
+def test_send_that_errors_are_caught2(monkeypatch):
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+        # Accessing status of device. Return online.
+        status_url = 'devices'
+        if args[0] == urljoin(_api_url_status, status_url):
+            return MockResponse({"state": True}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        # Test that this error gets caught
+        raise requests.exceptions.RequestException
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    api_key = "test"
+    user_id = "test@projectq.ch"
+    monkeypatch.setitem(__builtins__, "input", lambda x: user_id)
+    monkeypatch.setitem(__builtins__, "raw_input", lambda x: user_id)
+
+    def user_api_key_input(prompt):
+        if prompt == "Rigetti Forest API Key > ":
+            return api_key
+
+    monkeypatch.setattr("getpass.getpass", user_api_key_input)
+    shots = 1
+    json_quil = "my_json_quil"
+    name = 'projectq_test'
+    _rigetti_http_client.send(json_quil,
+                          device="8Q-Agave",
+                          user=None, password=None,
+                          shots=shots, verbose=True)
+
+
+def test_send_that_errors_are_caught3(monkeypatch):
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+        # Accessing status of device. Return online.
+        status_url = 'devices'
+        if args[0] == urljoin(_api_url_status, status_url):
+            return MockResponse({"state": True}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        # Test that this error gets caught
+        raise KeyError
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    api_key = "test"
+    user_id = "test@projectq.ch"
+    monkeypatch.setitem(__builtins__, "input", lambda x: user_id)
+    monkeypatch.setitem(__builtins__, "raw_input", lambda x: user_id)
+
+    def user_api_key_input(prompt):
+        if prompt == "Rigetti Forest API Key > ":
+            return api_key
+
+    monkeypatch.setattr("getpass.getpass", user_api_key_input)
+    shots = 1
+    json_quil = "my_json_quil"
+    name = 'projectq_test'
+    _rigetti_http_client.send(json_quil,
+                          device="8Q-Agave",
+                          user=None, password=None,
+                          shots=shots, verbose=True)
+
+
+def test_timeout_exception(monkeypatch):
+    quils = {'quils': [{'quil': 'my quil'}]}
+    json_quil = json.dumps(quils)
+    tries = [0]
+
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Accessing status of device. Return online.
+        status_url = 'devices'
+        if args[0] == urljoin(_api_url, status_url):
+            return MockResponse({"state": True}, 200)
+        job_url = 'Jobs/{}'.format("123e")
+        if args[0] == urljoin(_api_url, job_url):
+            tries[0] += 1
+            return MockResponse({"noquils": "not done"}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, url=""):
+                self.url = url
+
+        class MockPostResponse:
+            def __init__(self, json_data, text=" "):
+                self.json_data = json_data
+                self.text = text
+                self.request = MockRequest()
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        login_url = 'users/login'
+        if args[0] == urljoin(_api_url, login_url):
+            return MockPostResponse({"userId": "1", "id": "12"})
+        if args[0] == urljoin(_api_url, 'Jobs'):
+            return MockPostResponse({"id": "123e"})
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    _rigetti_http_client.time.sleep = lambda x: x
+    with pytest.raises(Exception) as excinfo:
+        _rigetti_http_client.send(json_quil,
+                              device="8Q-Agave",
+                              user="test", password="test",
+                              shots=1, verbose=False)
+    assert "123e" in str(excinfo.value)  # check that job id is in exception
+    assert tries[0] > 0
+
+
+def test_retrieve_and_device_offline_exception(monkeypatch):
+    quils = {'quils': [{'quil': 'my quil'}]}
+    json_quil = json.dumps(quils)
+    request_num = [0]
+
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Accessing status of device. Return online.
+        status_url = 'devices'
+        if args[0] == urljoin(_api_url, status_url) and request_num[0] < 2:
+            return MockResponse({"state": True, "lengthQueue": 10}, 200)
+        elif args[0] == urljoin(_api_url, status_url):
+            return MockResponse({"state": False}, 200)
+        job_url = 'Jobs/{}'.format("123e")
+        if args[0] == urljoin(_api_url, job_url):
+            request_num[0] += 1
+            return MockResponse({"noquils": "not done"}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, url=""):
+                self.url = url
+
+        class MockPostResponse:
+            def __init__(self, json_data, text=" "):
+                self.json_data = json_data
+                self.text = text
+                self.request = MockRequest()
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        login_url = 'users/login'
+        if args[0] == urljoin(_api_url, login_url):
+            return MockPostResponse({"userId": "1", "id": "12"})
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    _rigetti_http_client.time.sleep = lambda x: x
+    with pytest.raises(_rigetti_http_client.DeviceOfflineError):
+        _rigetti_http_client.retrieve(device="8Q-Agave",
+                                  user="test", password="test",
+                                  jobid="123e")
+
+
+def test_retrieve(monkeypatch):
+    quils = {'quils': [{'quil': 'my quil'}]}
+    json_quil = json.dumps(quils)
+    request_num = [0]
+
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Accessing status of device. Return online.
+        status_url = 'devices'
+        if args[0] == urljoin(_api_url, status_url):
+            return MockResponse({"state": True}, 200)
+        job_url = 'Jobs/{}'.format("123e")
+        if args[0] == urljoin(_api_url, job_url) and request_num[0] < 1:
+            request_num[0] += 1
+            return MockResponse({"noquils": "not done"}, 200)
+        elif args[0] == urljoin(_api_url, job_url):
+            return MockResponse({"quils": [{'quil': 'quil',
+                                            'result': 'correct'}]}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, url=""):
+                self.url = url
+
+        class MockPostResponse:
+            def __init__(self, json_data, text=" "):
+                self.json_data = json_data
+                self.text = text
+                self.request = MockRequest()
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    _rigetti_http_client.time.sleep = lambda x: x
+    res = _rigetti_http_client.retrieve(device="8Q-Agave",
+                                    user_id="test", api_key="test",
+                                    jobid="123e")
+    assert res == 'correct'

--- a/projectq/backends/_rigetti/_rigetti_test.py
+++ b/projectq/backends/_rigetti/_rigetti_test.py
@@ -1,0 +1,192 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Tests for projectq.backends._rigetti._rigetti.py."""
+
+import pytest
+import json
+
+import projectq.setups.decompositions
+from projectq import MainEngine
+from projectq.backends._rigetti import _rigetti
+from projectq.cengines import (TagRemover,
+                               LocalOptimizer,
+                               AutoReplacer,
+                               Rigetti5QubitMapper,
+                               SwapAndCNOTFlipper,
+                               DummyEngine,
+                               DecompositionRuleSet)
+from projectq.ops import (All, Allocate, Barrier, Command, Deallocate,
+                          Entangle, Measure, NOT, Rx, Ry, Rz, S, Sdag, T, Tdag,
+                          X, Y, Z)
+
+from projectq.setups.rigetti import agave8q_connections
+
+
+# Insure that no HTTP request can be made in all tests in this module
+@pytest.fixture(autouse=True)
+def no_requests(monkeypatch):
+    monkeypatch.delattr("requests.sessions.Session.request")
+
+
+_api_url = 'https://job.rigetti.com/beta/'
+_api_url_status = 'https://job.rigetti.com/beta/devices'
+
+
+@pytest.mark.parametrize("single_qubit_gate, is_available", [
+    (X, True), (Y, True), (Z, True), (T, True), (Tdag, True), (S, True),
+    (Sdag, True), (Allocate, True), (Deallocate, True), (Measure, True),
+    (NOT, True), (Rx(0.5), True), (Ry(0.5), True), (Rz(0.5), True),
+    (Barrier, True), (Entangle, False)])
+def test_rigetti_backend_is_available(single_qubit_gate, is_available):
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    qubit1 = eng.allocate_qubit()
+    rigetti_backend = _rigetti.RigettiBackend()
+    cmd = Command(eng, single_qubit_gate, (qubit1,))
+    assert rigetti_backend.is_available(cmd) == is_available
+
+
+@pytest.mark.parametrize("num_ctrl_qubits, is_available", [
+    (0, True), (1, True), (2, False), (3, False)])
+def test_rigetti_backend_is_available_control_not(num_ctrl_qubits, is_available):
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    qubit1 = eng.allocate_qubit()
+    qureg = eng.allocate_qureg(num_ctrl_qubits)
+    rigetti_backend = _rigetti.RigettiBackend()
+    cmd = Command(eng, NOT, (qubit1,), controls=qureg)
+    assert rigetti_backend.is_available(cmd) == is_available
+
+
+def test_rigetti_backend_init():
+    backend = _rigetti.RigettiBackend(verbose=True, use_hardware=True)
+    assert backend.quil == ""
+
+
+def test_rigetti_empty_circuit():
+    backend = _rigetti.RigettiBackend(verbose=True)
+    eng = MainEngine(backend=backend)
+    eng.flush()
+
+
+def test_rigetti_sent_error(monkeypatch):
+    # patch send
+    def mock_send(*args, **kwargs):
+        raise TypeError
+    monkeypatch.setattr(_rigetti, "send", mock_send)
+
+    backend = _rigetti.RigettiBackend(verbose=True)
+    eng = MainEngine(backend=backend,
+                     engine_list=[Rigetti5QubitMapper(),
+                                  SwapAndCNOTFlipper(set())])
+    qubit = eng.allocate_qubit()
+    X | qubit
+    with pytest.raises(Exception):
+        qubit[0].__del__()
+        eng.flush()
+    # atexit sends another FlushGate, therefore we remove the backend:
+    dummy = DummyEngine()
+    dummy.is_last_engine = True
+    eng.next_engine = dummy
+
+
+def test_rigetti_retrieve(monkeypatch):
+    # patch send
+    def mock_retrieve(*args, **kwargs):
+        return {'date': '2017-01-19T14:28:47.622Z',
+                'data': {'time': 14.429004907608032, 'counts': {'00111': 396,
+                                                                '00101': 27,
+                                                                '00000': 601},
+                         'quil': ('...')}}
+    monkeypatch.setattr(_rigetti, "retrieve", mock_retrieve)
+    backend = _rigetti.RigettiBackend(retrieve_execution="ab1s2")
+    rule_set = DecompositionRuleSet(modules=[projectq.setups.decompositions])
+    connectivity = set([(1, 2), (2, 4), (0, 2), (3, 2), (4, 3), (0, 1)])
+    engine_list = [TagRemover(),
+                   LocalOptimizer(10),
+                   AutoReplacer(rule_set),
+                   TagRemover(),
+                   Rigetti5QubitMapper(),
+                   SwapAndCNOTFlipper(connectivity),
+                   LocalOptimizer(10)]
+    eng = MainEngine(backend=backend, engine_list=engine_list)
+    unused_qubit = eng.allocate_qubit()
+    qureg = eng.allocate_qureg(3)
+    # entangle the qureg
+    Entangle | qureg
+    Tdag | qureg[0]
+    Sdag | qureg[0]
+    Barrier | qureg
+    Rx(0.2) | qureg[0]
+    del unused_qubit
+    # measure; should be all-0 or all-1
+    All(Measure) | qureg
+    # run the circuit
+    eng.flush()
+    prob_dict = eng.backend.get_probabilities([qureg[0], qureg[2], qureg[1]])
+    assert prob_dict['111'] == pytest.approx(0.38671875)
+    assert prob_dict['101'] == pytest.approx(0.0263671875)
+
+
+def test_rigetti_backend_functional_test(monkeypatch):
+    correct_info = ('{"quils": [{"quil": "\\ninclude \\"qelib1.inc\\";'
+                    '\\nqreg q[3];\\ncreg c[3];\\nh q[2];\\ncx q[2], q[0];'
+                    '\\ncx q[2], q[1];\\ntdg q[2];\\nsdg q[2];'
+                    '\\nbarrier q[2], q[0], q[1];'
+                    '\\nu3(0.2, -pi/2, pi/2) q[2];\\nmeasure q[2] -> '
+                    'c[2];\\nmeasure q[0] -> c[0];\\nmeasure q[1] -> c[1];"}]'
+                    ', "shots": 1024, "maxCredits": 5, "backend": {"name": '
+                    '"simulator"}}')
+
+    def mock_send(*args, **kwargs):
+        assert json.loads(args[0]) == json.loads(correct_info)
+        return {'date': '2017-01-19T14:28:47.622Z',
+                'data': {'time': 14.429004907608032, 'counts': {'00111': 396,
+                                                                '00101': 27,
+                                                                '00000': 601},
+                         'quil': ('...')}}
+    monkeypatch.setattr(_rigetti, "send", mock_send)
+
+    backend = _rigetti.RigettiBackend(verbose=True)
+    # no circuit has been executed -> raises exception
+    with pytest.raises(RuntimeError):
+        backend.get_probabilities([])
+    rule_set = DecompositionRuleSet(modules=[projectq.setups.decompositions])
+
+    engine_list = [TagRemover(),
+                   LocalOptimizer(10),
+                   AutoReplacer(rule_set),
+                   TagRemover(),
+                   Rigetti5QubitMapper(),
+                   SwapAndCNOTFlipper(agave8q_connections),
+                   LocalOptimizer(10)]
+    eng = MainEngine(backend=backend, engine_list=engine_list)
+    unused_qubit = eng.allocate_qubit()
+    qureg = eng.allocate_qureg(3)
+    # entangle the qureg
+    Entangle | qureg
+    Tdag | qureg[0]
+    Sdag | qureg[0]
+    Barrier | qureg
+    Rx(0.2) | qureg[0]
+    del unused_qubit
+    # measure; should be all-0 or all-1
+    All(Measure) | qureg
+    # run the circuit
+    eng.flush()
+    prob_dict = eng.backend.get_probabilities([qureg[0], qureg[2], qureg[1]])
+    assert prob_dict['111'] == pytest.approx(0.38671875)
+    assert prob_dict['101'] == pytest.approx(0.0263671875)
+
+    with pytest.raises(RuntimeError):
+        eng.backend.get_probabilities(eng.allocate_qubit())

--- a/projectq/backends/_rigetti/_rigetti_test.py
+++ b/projectq/backends/_rigetti/_rigetti_test.py
@@ -139,12 +139,11 @@ def test_rigetti_retrieve(monkeypatch):
 
 
 def test_rigetti_backend_functional_test(monkeypatch):
-    correct_info = ('{"quils": [{"quil": "\\ninclude \\"qelib1.inc\\";'
-                    '\\nqreg q[3];\\ncreg c[3];\\nh q[2];\\ncx q[2], q[0];'
-                    '\\ncx q[2], q[1];\\ntdg q[2];\\nsdg q[2];'
-                    '\\nbarrier q[2], q[0], q[1];'
-                    '\\nu3(0.2, -pi/2, pi/2) q[2];\\nmeasure q[2] -> '
-                    'c[2];\\nmeasure q[0] -> c[0];\\nmeasure q[1] -> c[1];"}]'
+    correct_info = ('{"quils": [{"quil": "H 2\\nCX 2 0'
+                    '\\nCX 2, 1\\nTDG 2\\nSDG 2'
+                    '\\nBARRIER 2 0 1'
+                    '\\nU3(0.2, -pi/2, pi/2) 2\\nMEASURE 2 '
+                    '[2]\\nMEASURE 0 [0]\\nMEASURE 1 [1]"}]'
                     ', "shots": 1024, "maxCredits": 5, "backend": {"name": '
                     '"simulator"}}')
 

--- a/projectq/setups/rigetti.py
+++ b/projectq/setups/rigetti.py
@@ -1,0 +1,47 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""
+Defines a setup useful for the Rigetti 8Q-Agave chip.
+
+It provides the `engine_list` for the `MainEngine`, and contains an
+AutoReplacer with most of the gate decompositions of ProjectQ, among others
+it includes:
+
+    * ?
+
+"""
+
+import projectq
+import projectq.setups.decompositions
+from projectq.cengines import (TagRemover,
+                               LocalOptimizer,
+                               AutoReplacer,
+                               Rigetti5QubitMapper,
+                               SwapAndCNOTFlipper,
+                               DecompositionRuleSet)
+
+
+agave8q_connections = set([(2, 1), (4, 2), (2, 0), (3, 2), (3, 4), (1, 0)])
+
+
+def get_engine_list():
+    rule_set = DecompositionRuleSet(modules=[projectq.setups.decompositions])
+    return [TagRemover(),
+            LocalOptimizer(10),
+            AutoReplacer(rule_set),
+            TagRemover(),
+            Rigetti5QubitMapper(),
+            SwapAndCNOTFlipper(agave8q_connections),
+            LocalOptimizer(10)]

--- a/projectq/setups/rigetti_test.py
+++ b/projectq/setups/rigetti_test.py
@@ -1,0 +1,29 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for projectq.setup.rigetti."""
+
+import projectq
+from projectq import MainEngine
+from projectq.cengines import Rigetti5QubitMapper, SwapAndCNOTFlipper
+
+
+def test_rigetti_cnot_mapper_in_cengines():
+    import projectq.setups.rigetti
+    found = 0
+    for engine in projectq.setups.rigetti.get_engine_list():
+        if isinstance(engine, Rigetti5QubitMapper):
+            found |= 1
+        if isinstance(engine, SwapAndCNOTFlipper):
+            found |= 2
+    assert found == 3


### PR DESCRIPTION
Hi - this is still a work in progress, but I wanted to share it with the ProjectQ team now in case you have concerns or comments

I want to make ProjectQ more portable / universal by adding the Rigetti / Forest API as a backend

Rigetti has an assembly-like language for quantum computers (Quil) similar to QASM, a QVM (quantum virtual machine), and limited access to real quantum processors... so in many ways it is similar to IBM's offering. In 2017 I created a "jsQuil" module to create and run quantum programs from a Node.js environment. This would be a similar setup and you can see how I've started to make that work here

My next steps would be to check that implementation details are correct (which gates are and aren't allowed).  Also I am a little uncertain of the equivalent of IBM5QubitMapper.