### PR TITLE
Change BasicGate __eq__ to test for matrix attribute

### DIFF
--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -147,15 +147,15 @@ def test_simulator_is_available(sim):
 
     new_cmd.gate = Mock1QubitGate()
     assert sim.is_available(new_cmd)
-    assert new_cmd.gate.cnt == 1
+    assert new_cmd.gate.cnt == 4
 
     new_cmd.gate = Mock6QubitGate()
     assert not sim.is_available(new_cmd)
-    assert new_cmd.gate.cnt == 1
+    assert new_cmd.gate.cnt == 4
 
     new_cmd.gate = MockNoMatrixGate()
     assert not sim.is_available(new_cmd)
-    assert new_cmd.gate.cnt == 1
+    assert new_cmd.gate.cnt == 7
 
 
 def test_simulator_cheat(sim):

--- a/projectq/cengines/_replacer/_replacer_test.py
+++ b/projectq/cengines/_replacer/_replacer_test.py
@@ -178,8 +178,6 @@ def test_auto_replacer_use_inverse_decomposition():
     qb = eng.allocate_qubit()
     MagicGate() | qb
     eng.flush()
-    for cmd in backend.received_commands:
-        print(cmd)
     assert len(backend.received_commands) == 4
     assert backend.received_commands[1].gate == H
     assert backend.received_commands[2].gate == Rx(-0.6)

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -14,9 +14,11 @@
 
 """Tests for projectq.ops._basics."""
 
-import pytest
 from copy import deepcopy
 import math
+
+import numpy as np
+import pytest
 
 from projectq.types import Qubit, Qureg
 from projectq.ops import Command
@@ -116,6 +118,13 @@ def test_basic_gate_compare():
     gate2 = _basics.BasicGate()
     assert gate1 == gate2
     assert not (gate1 != gate2)
+    gate3 = _basics.BasicGate()
+    gate3.matrix = np.matrix([[1, 0], [0, -1]])
+    assert gate1 != gate3
+    gate4 = _basics.BasicGate()
+    gate4.matrix = [[1, 0], [0, -1]]
+    with pytest.raises(TypeError):
+        gate4 == gate3
 
 
 def test_comparing_different_gates():

--- a/projectq/ops/_qftgate.py
+++ b/projectq/ops/_qftgate.py
@@ -22,5 +22,6 @@ class QFTGate(BasicGate):
     def __str__(self):
         return "QFT"
 
+
 #: Shortcut (instance of) :class:`projectq.ops.QFTGate`
 QFT = QFTGate()

--- a/projectq/ops/_qftgate_test.py
+++ b/projectq/ops/_qftgate_test.py
@@ -20,3 +20,7 @@ from projectq.ops import _qftgate
 def test_qft_gate_str():
     gate = _qftgate.QFT
     assert str(gate) == "QFT"
+
+
+def test_qft_equality():
+	assert _qftgate.QFT == _qftgate.QFTGate()

--- a/projectq/ops/_qftgate_test.py
+++ b/projectq/ops/_qftgate_test.py
@@ -23,4 +23,4 @@ def test_qft_gate_str():
 
 
 def test_qft_equality():
-	assert _qftgate.QFT == _qftgate.QFTGate()
+    assert _qftgate.QFT == _qftgate.QFTGate()

--- a/projectq/setups/decompositions/carb1qubit2cnotrzandry_test.py
+++ b/projectq/setups/decompositions/carb1qubit2cnotrzandry_test.py
@@ -58,8 +58,8 @@ def test_recognize_incorrect_gates():
         BasicGate() | qubit
         # Two qubit gate:
         two_qubit_gate = BasicGate()
-        two_qubit_gate.matrix = [[1, 0, 0, 0], [0, 1, 0, 0],
-                                 [0, 0, 1, 0], [0, 0, 0, 1]]
+        two_qubit_gate.matrix = np.matrix([[1, 0, 0, 0], [0, 1, 0, 0],
+                                           [0, 0, 1, 0], [0, 0, 0, 1]])
         two_qubit_gate | qubit
     with Control(eng, ctrl_qureg):
         # Too many Control qubits:


### PR DESCRIPTION
In order that user can do:

```
custom_gate = BasicGate()
custom_gate.matrix = numpy.matrix(...)
```
And have a correct `__eq__`