### PR TITLE
Update to newer RevKit version

### DIFF
--- a/projectq/libs/revkit/_control_function.py
+++ b/projectq/libs/revkit/_control_function.py
@@ -109,7 +109,7 @@ class ControlFunctionOracle:
                                "provided qubits")
 
         # convert reversible circuit to ProjectQ code and execute it
-        _exec(revkit.write_projectq(log=True)["contents"], qs)
+        _exec(revkit.to_projectq(mct=True), qs)
 
     def _check_function(self):
         """

--- a/projectq/libs/revkit/_permutation.py
+++ b/projectq/libs/revkit/_permutation.py
@@ -81,7 +81,7 @@ class PermutationOracle:
         self.kwargs.get("synth", revkit.tbs)()
 
         # convert reversible circuit to ProjectQ code and execute it
-        _exec(revkit.write_projectq(log=True)["contents"], qs)
+        _exec(revkit.to_projectq(mct=True), qs)
 
     def _check_permutation(self):
         """

--- a/projectq/libs/revkit/_phase.py
+++ b/projectq/libs/revkit/_phase.py
@@ -111,7 +111,7 @@ class PhaseOracle:
                                "provided qubits")
 
         # convert reversible circuit to ProjectQ code and execute it
-        _exec(revkit.write_projectq(log=True)["contents"], qs)
+        _exec(revkit.to_projectq(mct=True), qs)
 
     def _check_function(self):
         """


### PR DESCRIPTION
The updated RevKit library distinguishes between Toffoli circuits and quantum circuits. Therefore,  `write_projectq` needs to know which circuit is addressed. Also, in the updated version `to_projectq()` is a shortcut for `write_projectq(log=True)['contents'])`. 