### PR TITLE
pytest > 3.3 does not work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy
 future
-pytest>=3.1
+pytest==3.3
 pybind11>=2.2.3
 requests
 scipy


### PR DESCRIPTION
Lock pytest to the 3.3 version.  The current HEAD of 3.10 fails with a wide variety of string parsing and other language errors.