### PR TITLE
Use vector's resize when allocating qubit

### DIFF
--- a/projectq/backends/_sim/_cppkernels/simulator.hpp
+++ b/projectq/backends/_sim/_cppkernels/simulator.hpp
@@ -55,11 +55,7 @@ public:
     void allocate_qubit(unsigned id){
         if (map_.count(id) == 0){
             map_[id] = N_++;
-            auto newvec = StateVector(1UL << N_);
-            #pragma omp parallel for schedule(static)
-            for (std::size_t i = 0; i < newvec.size(); ++i)
-                newvec[i] = (i < vec_.size())?vec_[i]:0.;
-            vec_ = std::move(newvec);
+            vec_.resize(1UL << N_, 0.);
         }
         else
             throw(std::runtime_error(


### PR DESCRIPTION
Reallocating a vector is bottlenecked on memory speed not CPU so it's actually slightly more efficient to use the built-in resize method (unless using big machines with multiple memory channels which  as I understand are not the target for ProjectQ). 

I extracted the simulator and benchmarked using my own script, so hopefully you can reproduce an ~10-20% speed up for allocations. The speed up will probably not be noticeable overall as I assume this isn't a particular bottleneck.