### PR TITLE
Implement MatrixGate and simplify __eq__ in BasicGate to improve performance

### DIFF
--- a/projectq/backends/_sim/_simulator_test.py
+++ b/projectq/backends/_sim/_simulator_test.py
@@ -29,7 +29,7 @@ import scipy.sparse.linalg
 from projectq import MainEngine
 from projectq.cengines import (BasicEngine, BasicMapperEngine, DummyEngine,
                                LocalOptimizer, NotYetMeasuredError)
-from projectq.ops import (All, Allocate, BasicGate, BasicMathGate, CNOT,
+from projectq.ops import (All, Allocate, BasicGate, MatrixGate, BasicMathGate, CNOT,
                           Command, H, Measure, QubitOperator, Rx, Ry, Rz, S,
                           TimeEvolution, Toffoli, X, Y, Z)
 from projectq.meta import Control, Dagger, LogicalQubitIDTag
@@ -97,37 +97,32 @@ def mapper(request):
         return None
 
 
-class Mock1QubitGate(BasicGate):
-        def __init__(self):
-            BasicGate.__init__(self)
-            self.cnt = 0
+class Mock1QubitGate(MatrixGate):
+    def __init__(self):
+        MatrixGate.__init__(self)
+        self.cnt = 0
 
-        @property
-        def matrix(self):
-            self.cnt += 1
-            return [[0, 1], [1, 0]]
+    @property
+    def matrix(self):
+        self.cnt += 1
+        return [[0, 1], [1, 0]]
 
 
-class Mock6QubitGate(BasicGate):
-        def __init__(self):
-            BasicGate.__init__(self)
-            self.cnt = 0
+class Mock6QubitGate(MatrixGate):
+    def __init__(self):
+        MatrixGate.__init__(self)
+        self.cnt = 0
 
-        @property
-        def matrix(self):
-            self.cnt += 1
-            return numpy.eye(2 ** 6)
+    @property
+    def matrix(self):
+        self.cnt += 1
+        return numpy.eye(2 ** 6)
 
 
 class MockNoMatrixGate(BasicGate):
-        def __init__(self):
-            BasicGate.__init__(self)
-            self.cnt = 0
-
-        @property
-        def matrix(self):
-            self.cnt += 1
-            raise AttributeError
+    def __init__(self):
+        BasicGate.__init__(self)
+        self.cnt = 0
 
 
 def test_simulator_is_available(sim):
@@ -147,15 +142,15 @@ def test_simulator_is_available(sim):
 
     new_cmd.gate = Mock1QubitGate()
     assert sim.is_available(new_cmd)
-    assert new_cmd.gate.cnt == 4
+    assert new_cmd.gate.cnt == 1
 
     new_cmd.gate = Mock6QubitGate()
     assert not sim.is_available(new_cmd)
-    assert new_cmd.gate.cnt == 4
+    assert new_cmd.gate.cnt == 1
 
     new_cmd.gate = MockNoMatrixGate()
     assert not sim.is_available(new_cmd)
-    assert new_cmd.gate.cnt == 7
+    assert new_cmd.gate.cnt == 0
 
 
 def test_simulator_cheat(sim):

--- a/projectq/ops/__init__.py
+++ b/projectq/ops/__init__.py
@@ -15,6 +15,7 @@
 from ._basics import (NotMergeable,
                       NotInvertible,
                       BasicGate,
+                      MatrixGate,
                       SelfInverseGate,
                       BasicRotationGate,
                       ClassicalInstructionGate,

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -266,10 +266,7 @@ class MatrixGate(BasicGate):
         raise NotImplementedError('This gate does not implement __str__.')
 
     def get_inverse(self):
-        if self.matrix is not None:
-            return MatrixGate(np.linalg.inv(self.matrix))
-        else:
-            return MatrixGate()
+        return MatrixGate(np.linalg.inv(self.matrix))
 
 class SelfInverseGate(BasicGate):
     """

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -235,7 +235,7 @@ class MatrixGate(BasicGate):
     """
     def __init__(self, matrix=None):
         BasicGate.__init__(self)
-        self._matrix = np.matrix(matrix)
+        self._matrix = np.matrix(matrix) if matrix is not None else None
 
     @property
     def matrix(self):

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -205,7 +205,7 @@ class BasicGate(object):
 
     @property
     def matrix(self):
-        return None
+        raise AttributeError("BasicGate has no matrix property. Use MatrixGate instead.")
 
     @matrix.setter
     def matrix(self):
@@ -233,9 +233,9 @@ class MatrixGate(BasicGate):
 
     A matrix gate is defined via its matrix.
     """
-    def __init__(self):
+    def __init__(self, matrix=None):
         BasicGate.__init__(self)
-        self._matrix = None
+        self._matrix = np.matrix(matrix)
 
     @property
     def matrix(self):
@@ -266,7 +266,10 @@ class MatrixGate(BasicGate):
         raise NotImplementedError('This gate does not implement __str__.')
 
     def get_inverse(self):
-        raise NotInvertible("MatrixGate: No get_inverse() implemented.") #todo: implement!
+        if self.matrix is not None:
+            return MatrixGate(np.linalg.inv(self.matrix))
+        else:
+            return MatrixGate()
 
 class SelfInverseGate(BasicGate):
     """

--- a/projectq/ops/_basics.py
+++ b/projectq/ops/_basics.py
@@ -203,40 +203,20 @@ class BasicGate(object):
         cmd = self.generate_command(qubits)
         apply_command(cmd)
 
+    @property
+    def matrix(self):
+        return None
+
+    @matrix.setter
+    def matrix(self):
+        raise AttributeError("You cannot set the matrix property gates derived"
+                             "from BasicGate. Please use MatrixGate instead if"
+                             "you need that functionality.")
+
     def __eq__(self, other):
         """ Return True if equal (i.e., instance of same class).
-
-            Unless both have a matrix attribute in which case we also check
-            that the matrices are identical as people might want to do the
-            following:
-
-            Example:
-                .. code-block:: python
-
-                gate = BasicGate()
-                gate.matrix = numpy.matrix([[1,0],[0, -1]])
         """
-        if hasattr(self, 'matrix'):
-            if not hasattr(other, 'matrix'):
-                return False
-        if hasattr(other, 'matrix'):
-            if not hasattr(self, 'matrix'):
-                return False
-        if hasattr(self, 'matrix') and hasattr(other, 'matrix'):
-            if (not isinstance(self.matrix, np.matrix) or
-                    not isinstance(other.matrix, np.matrix)):
-                raise TypeError("One of the gates doesn't have the correct "
-                                "type (numpy.matrix) for the matrix "
-                                "attribute.")
-            if (self.matrix.shape == other.matrix.shape and
-                np.allclose(self.matrix, other.matrix,
-                            rtol=RTOL, atol=ATOL,
-                            equal_nan=False)):
-                return True
-            else:
-                return False
-        else:
-            return isinstance(other, self.__class__)
+        return isinstance(other, self.__class__)
 
     def __ne__(self, other):
         return not self.__eq__(other)
@@ -247,6 +227,46 @@ class BasicGate(object):
     def __hash__(self):
         return hash(str(self))
 
+class MatrixGate(BasicGate):
+    """
+    Defines a base class of a matrix gate.
+
+    A matrix gate is defined via its matrix.
+    """
+    def __init__(self):
+        BasicGate.__init__(self)
+        self._matrix = None
+
+    @property
+    def matrix(self):
+        return self._matrix
+
+    @matrix.setter
+    def matrix(self, matrix):
+        self._matrix = np.matrix(matrix)
+
+    def __eq__(self, other):
+        """ Return True if equal (i.e., instance of same class).
+        """
+        if not isinstance(other, self.__class__):
+            return False
+        if (not isinstance(self.matrix, np.matrix) or
+                not isinstance(other.matrix, np.matrix)):
+            raise TypeError("One of the gates doesn't have the correct "
+                            "type (numpy.matrix) for the matrix "
+                            "attribute.")
+        if (self.matrix.shape == other.matrix.shape and
+            np.allclose(self.matrix, other.matrix,
+                        rtol=RTOL, atol=ATOL,
+                        equal_nan=False)):
+            return True
+        return False
+
+    def __str__(self):
+        raise NotImplementedError('This gate does not implement __str__.')
+
+    def get_inverse(self):
+        raise NotInvertible("MatrixGate: No get_inverse() implemented.") #todo: implement!
 
 class SelfInverseGate(BasicGate):
     """

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -294,3 +294,30 @@ def test_basic_math_gate():
     # Test a=2, b=3, and c=5 should give a=2, b=3, c=11
     math_fun = gate.get_math_function(("qreg1", "qreg2", "qreg3"))
     assert math_fun([2, 3, 5]) == [2, 3, 11]
+
+def test_matrix_gate():
+    gate1 = _basics.MatrixGate()
+    gate2 = _basics.MatrixGate()
+    with pytest.raises(TypeError):
+        assert gate1 == gate2
+    gate3 = _basics.MatrixGate([[0, 1], [1, 0]])
+    gate4 = _basics.MatrixGate([[0, 1], [1, 0]])
+    gate5 = _basics.MatrixGate([[1, 0], [0, -1]])
+    assert gate3 == gate4
+    assert gate4 != gate5
+    with pytest.raises(TypeError):
+        assert gate1 != gate3
+    with pytest.raises(TypeError):
+        assert gate3 != gate1
+    gate6 = _basics.BasicGate()
+    assert gate6 != gate1
+    assert gate6 != gate3
+    assert gate1 != gate6
+    assert gate3 != gate6
+    gate7 = gate5.get_inverse()
+    gate8 = _basics.MatrixGate([[1, 0], [0, (1+1j)/math.sqrt(2)]])
+    assert gate7 == gate5
+    assert gate7 != gate8
+    gate9 = _basics.MatrixGate([[1, 0], [0, (1-1j)/math.sqrt(2)]])
+    gate10 = gate9.get_inverse()
+    assert gate10 == gate8

--- a/projectq/ops/_basics_test.py
+++ b/projectq/ops/_basics_test.py
@@ -118,13 +118,12 @@ def test_basic_gate_compare():
     gate2 = _basics.BasicGate()
     assert gate1 == gate2
     assert not (gate1 != gate2)
-    gate3 = _basics.BasicGate()
+    gate3 = _basics.MatrixGate()
     gate3.matrix = np.matrix([[1, 0], [0, -1]])
     assert gate1 != gate3
-    gate4 = _basics.BasicGate()
+    gate4 = _basics.MatrixGate()
     gate4.matrix = [[1, 0], [0, -1]]
-    with pytest.raises(TypeError):
-        gate4 == gate3
+    assert gate4 == gate3
 
 
 def test_comparing_different_gates():

--- a/projectq/ops/_gates.py
+++ b/projectq/ops/_gates.py
@@ -37,6 +37,7 @@ import numpy as np
 
 from projectq.ops import get_inverse
 from ._basics import (BasicGate,
+                      MatrixGate,
                       SelfInverseGate,
                       BasicRotationGate,
                       BasicPhaseGate,

--- a/projectq/ops/_metagates.py
+++ b/projectq/ops/_metagates.py
@@ -28,7 +28,7 @@ As well as the meta functions
 * C (Creates an n-ary controlled version of an arbitrary gate)
 """
 
-from ._basics import BasicGate, NotInvertible
+from ._basics import BasicGate, MatrixGate, NotInvertible
 from ._command import Command, apply_command
 
 
@@ -39,7 +39,7 @@ class ControlQubitError(Exception):
     pass
 
 
-class DaggeredGate(BasicGate):
+class DaggeredGate(MatrixGate): #todo: do we want this?
     """
     Wrapper class allowing to execute the inverse of a gate, even when it does
     not define one.

--- a/projectq/setups/decompositions/arb1qubit2rzandry_test.py
+++ b/projectq/setups/decompositions/arb1qubit2rzandry_test.py
@@ -23,7 +23,7 @@ import pytest
 from projectq.backends import Simulator
 from projectq.cengines import (AutoReplacer, DecompositionRuleSet,
                                DummyEngine, InstructionFilter, MainEngine)
-from projectq.ops import (BasicGate, ClassicalInstructionGate, Measure, Ph, R,
+from projectq.ops import (BasicGate, MatrixGate, ClassicalInstructionGate, Measure, Ph, R,
                           Rx, Ry, Rz, X)
 from projectq.meta import Control
 
@@ -51,7 +51,7 @@ def test_recognize_incorrect_gates():
     # Does not have matrix attribute:
     BasicGate() | qubit
     # Two qubit gate:
-    two_qubit_gate = BasicGate()
+    two_qubit_gate = MatrixGate()
     two_qubit_gate.matrix = [[1, 0, 0, 0], [0, 1, 0, 0],
                              [0, 0, 1, 0], [0, 0, 0, 1]]
     two_qubit_gate | qubit
@@ -121,7 +121,7 @@ def create_test_matrices():
 def test_decomposition(gate_matrix):
     for basis_state in ([1, 0], [0, 1]):
         # Create single qubit gate with gate_matrix
-        test_gate = BasicGate()
+        test_gate = MatrixGate()
         test_gate.matrix = np.matrix(gate_matrix)
 
         correct_dummy_eng = DummyEngine(save_commands=True)
@@ -165,7 +165,7 @@ def test_decomposition(gate_matrix):
                                          [[0, 2], [4, 0]],
                                          [[1, 2], [4, 0]]])
 def test_decomposition_errors(gate_matrix):
-    test_gate = BasicGate()
+    test_gate = MatrixGate()
     test_gate.matrix = np.matrix(gate_matrix)
     rule_set = DecompositionRuleSet(modules=[arb1q])
     eng = MainEngine(backend=DummyEngine(),

--- a/projectq/setups/decompositions/carb1qubit2cnotrzandry_test.py
+++ b/projectq/setups/decompositions/carb1qubit2cnotrzandry_test.py
@@ -21,7 +21,7 @@ from projectq.backends import Simulator
 from projectq.cengines import (AutoReplacer, DecompositionRuleSet,
                                DummyEngine, InstructionFilter, MainEngine)
 from projectq.meta import Control
-from projectq.ops import (All, BasicGate, ClassicalInstructionGate, Measure,
+from projectq.ops import (All, BasicGate, MatrixGate, ClassicalInstructionGate, Measure,
                           Ph, R, Rx, Ry, Rz, X, XGate)
 from projectq.setups.decompositions import arb1qubit2rzandry_test as arb1q_t
 
@@ -57,7 +57,7 @@ def test_recognize_incorrect_gates():
         # Does not have matrix attribute:
         BasicGate() | qubit
         # Two qubit gate:
-        two_qubit_gate = BasicGate()
+        two_qubit_gate = MatrixGate()
         two_qubit_gate.matrix = np.matrix([[1, 0, 0, 0], [0, 1, 0, 0],
                                            [0, 0, 1, 0], [0, 0, 0, 1]])
         two_qubit_gate | qubit
@@ -94,7 +94,7 @@ def test_recognize_v(gate_matrix):
 @pytest.mark.parametrize("gate_matrix", arb1q_t.create_test_matrices())
 def test_decomposition(gate_matrix):
     # Create single qubit gate with gate_matrix
-    test_gate = BasicGate()
+    test_gate = MatrixGate()
     test_gate.matrix = np.matrix(gate_matrix)
 
     for basis_state in ([1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0],


### PR DESCRIPTION
Addresses #282 by implementing a MatrixGate base class for gates that are defined via their matrix (similar to how, e.g., RotationGate captures gates defined via an angle).

Specifically this PR does:

* Simplify `__eq__()` in `BasicGate` to only do class/type comparison
* Disallow the usage of `.matrix` in `BasisGate` altogether (this allows to no longer worry about `==` between `MatrixGates` and `BasicGates` as they are now always not equal.
* Implement `__eq__()` in `MatrixGate` that does matrix comparison (slow but this is the thing to do for gates that are really defined via their matrix)
* Adds unit tests to check various comparisons between `MatrixGate` and other gates.
* Unlocks the performance gain discussed in #282 

Please have a look and tell me what do do/don't like. Please pay especially close attention to the changes unit tests. I am not 100% sure I modified `_simulator_test.py` in the correct way.