### PR TITLE
Aqt Backend

### DIFF
--- a/projectq/backends/__init__.py
+++ b/projectq/backends/__init__.py
@@ -24,9 +24,11 @@ This includes:
 * a resource counter (counts gates and keeps track of the maximal width of the
   circuit)
 * an interface to the IBM Quantum Experience chip (and simulator).
+* an interface to the AQT trapped ion system (and simulator).
 """
 from ._printer import CommandPrinter
 from ._circuits import CircuitDrawer, CircuitDrawerMatplotlib
 from ._sim import Simulator, ClassicalSimulator
 from ._resource import ResourceCounter
 from ._ibm import IBMBackend
+from ._aqt import AQTBackend

--- a/projectq/backends/_aqt/__init__.py
+++ b/projectq/backends/_aqt/__init__.py
@@ -1,0 +1,15 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from ._aqt import AQTBackend

--- a/projectq/backends/_aqt/__init__.py
+++ b/projectq/backends/_aqt/__init__.py
@@ -1,4 +1,4 @@
-#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#   Copyright 2020 ProjectQ-Framework (www.projectq.ch)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/projectq/backends/_aqt/_aqt.py
+++ b/projectq/backends/_aqt/_aqt.py
@@ -242,11 +242,12 @@ class AQTBackend(BasicEngine):
         # instead of 'GATE' 
         info['circuit']=str(self._circuit).replace("'",'"')
         info['nq']=max_qubit_id + 1
-
         info['shots'] = self._num_runs
         info['backend'] = {'name': self.device}
+
         if self._num_runs>200:
             raise Exception("Number of shots limited to 200")
+
         try:
             if self._retrieve_execution is None:
                 res = send(info, device=self.device,
@@ -266,7 +267,6 @@ class AQTBackend(BasicEngine):
             counts = self._format_counts(res,length)
             # Determine random outcome
             P = random.random()
-            print(P)
             p_sum = 0.
             measured = ""
             for state in counts:

--- a/projectq/backends/_aqt/_aqt.py
+++ b/projectq/backends/_aqt/_aqt.py
@@ -261,8 +261,8 @@ class AQTBackend(BasicEngine):
                                num_retries=self._num_retries,
                                interval=self._interval,
                                verbose=self._verbose)
-            self._num_runs = res['repetitions']
-            counts = self._format_counts(res['samples'],n_qubit)
+            self._num_runs = len(res)
+            counts = self._format_counts(res,n_qubit)
             # Determine random outcome
             P = random.random()
             p_sum = 0.

--- a/projectq/backends/_aqt/_aqt.py
+++ b/projectq/backends/_aqt/_aqt.py
@@ -44,14 +44,14 @@ class AQTBackend(BasicEngine):
         Initialize the Backend object.
 
         Args:
-            use_hardware (bool): If True, the code is run on the IBM quantum
-                chip (instead of using the IBM simulator)
+            use_hardware (bool): If True, the code is run on the AQT quantum
+                chip (instead of using the AQT simulator)
             num_runs (int): Number of runs to collect statistics.
-                (default is 100, max is usually around 250)
+                (default is 100, max is usually around 200)
             verbose (bool): If True, statistics are printed, in addition to
                 the measurement result being registered (at the end of the
                 circuit).
-            token (str): AQT user password. 
+            token (str): AQT user API token. 
             device (str): name of the AQT device to use. simulator By default
             num_retries (int): Number of times to retry to obtain
                 results from the AQT API. (default is 3000)

--- a/projectq/backends/_aqt/_aqt.py
+++ b/projectq/backends/_aqt/_aqt.py
@@ -292,8 +292,8 @@ class AQTBackend(BasicEngine):
                     print(str(state) + " with p = " + str(probability) + star)
 
             class QB():
-                def __init__(self, ID):
-                    self.id = ID
+                def __init__(self, qubit_id):
+                    self.id = qubit_id
 
             # register measurement result
             for qubit_id in self._measured_ids:
@@ -313,7 +313,7 @@ class AQTBackend(BasicEngine):
             command_list: List of commands to execute
         """
         for cmd in command_list:
-            if not cmd.gate == FlushGate():
+            if not isinstance(cmd.gate, FlushGate):
                 self._store(cmd)
             else:
                 self._run()

--- a/projectq/backends/_aqt/_aqt.py
+++ b/projectq/backends/_aqt/_aqt.py
@@ -1,0 +1,310 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+""" Back-end to run quantum program on AQT's API."""
+import math
+import random
+import json
+
+from projectq.cengines import BasicEngine
+from projectq.meta import get_control_count, LogicalQubitIDTag
+from projectq.ops import (Rx,
+                          Ry,
+                          Rxx,
+                          Measure,
+                          Allocate,
+                          Barrier,
+                          Deallocate,
+                          FlushGate)
+
+from ._aqt_http_client import send, retrieve
+
+
+class AQTBackend(BasicEngine):
+    """
+    The AQT Backend class, which stores the circuit, transforms it to the appropriate data format,
+    and sends the circuit through the AQT API.
+    """
+    def __init__(self, use_hardware=False, num_runs=100, verbose=False,
+                 token='', device='simulator',
+                 num_retries=3000, interval=1,
+                 retrieve_execution=None):
+        """
+        Initialize the Backend object.
+
+        Args:
+            use_hardware (bool): If True, the code is run on the IBM quantum
+                chip (instead of using the IBM simulator)
+            num_runs (int): Number of runs to collect statistics.
+                (default is 100, max is usually around 250)
+            verbose (bool): If True, statistics are printed, in addition to
+                the measurement result being registered (at the end of the
+                circuit).
+            token (str): AQT user password. 
+            device (str): name of the AQT device to use. simulator By default
+            num_retries (int): Number of times to retry to obtain
+                results from the AQT API. (default is 3000)
+            interval (float, int): Number of seconds between successive
+                attempts to obtain results from the AQT API.
+                (default is 1)
+            retrieve_execution (int): Job ID to retrieve instead of re-
+                running the circuit (e.g., if previous run timed out).
+        """
+        BasicEngine.__init__(self)
+        self._reset()
+        if use_hardware:
+            self.device = device
+        else:
+            self.device = 'simulator'
+        self._num_runs = num_runs
+        self._verbose = verbose
+        self._token=token
+        self._num_retries = num_retries
+        self._interval = interval
+        self._probabilities = dict()
+        self._circuit=[]
+        self._measured_ids = []
+        self._allocated_qubits = set()
+        self._retrieve_execution = retrieve_execution
+
+    def is_available(self, cmd):
+        """
+        Return true if the command can be executed.
+
+        The AQT ion trap can only do Rx,Ry and Rxx.
+
+        Args:
+            cmd (Command): Command for which to check availability
+        """
+        g = cmd.gate
+        if get_control_count(cmd) == 0:
+            if isinstance(g, (Rx, Ry, Rxx)):
+                return True
+        if g in (Measure, Allocate, Deallocate,Barrier):
+            return True
+        return False
+
+    def _reset(self):
+        """ Reset all temporary variables (after flush gate). """
+        self._clear = True
+        self._measured_ids = []
+
+    def _store(self, cmd):
+        """
+        Temporarily store the command cmd.
+
+        Translates the command and stores it in a local variable (self._cmds).
+
+        Args:
+            cmd: Command to store
+        """
+        if self._clear:
+            self._probabilities = dict()
+            self._clear = False
+            self._circuit=[]
+            self._allocated_qubits = set()
+
+        gate = cmd.gate
+        if gate == Allocate:
+            self._allocated_qubits.add(cmd.qubits[0][0].id)
+            return
+        if gate == Deallocate:
+            return
+        if gate == Measure:
+            assert len(cmd.qubits) == 1 and len(cmd.qubits[0]) == 1
+            qb_id = cmd.qubits[0][0].id
+            logical_id = None
+            for t in cmd.tags:
+                if isinstance(t, LogicalQubitIDTag):
+                    logical_id = t.logical_qubit_id
+                    break
+            assert logical_id is not None
+            self._measured_ids += [logical_id]
+            return
+        if isinstance(gate, (Rx, Ry, Rxx)):
+            qubits=[]
+            qubits.append(cmd.qubits[0][0].id)
+            if len(cmd.qubits) == 2:
+                qubits.append(cmd.qubits[1][0].id)
+            angle=gate.angle/math.pi
+            instruction=[]
+            u_name = {'Rx': "X", 'Ry': "Y",
+                      'Rxx': "MS"}
+            instruction.append(u_name[str(gate)[0:int(len(cmd.qubits)+1)]])
+            instruction.append(round(angle,2))
+            instruction.append(qubits)
+            self._circuit.append(instruction)
+            return
+        if gate == Barrier:
+            return
+        else:
+            raise Exception('Invalid command: '+str(cmd))
+            pass
+
+    def _logical_to_physical(self, qb_id):
+        """
+        Return the physical location of the qubit with the given logical id.
+
+        Args:
+            qb_id (int): ID of the logical qubit whose position should be
+                returned.
+        """
+        assert self.main_engine.mapper is not None
+        mapping = self.main_engine.mapper.current_mapping
+        if qb_id not in mapping:
+            raise RuntimeError("Unknown qubit id {}. Please make sure "
+                               "eng.flush() was called and that the qubit "
+                               "was eliminated during optimization."
+                               .format(qb_id))
+        return mapping[qb_id]
+
+    def get_probabilities(self, qureg):
+        """
+        Return the list of basis states with corresponding probabilities.
+
+        The measured bits are ordered according to the supplied quantum
+        register, i.e., the left-most bit in the state-string corresponds to
+        the first qubit in the supplied quantum register.
+
+        Warning:
+            Only call this function after the circuit has been executed!
+
+        Args:
+            qureg (list<Qubit>): Quantum register determining the order of the
+                qubits.
+
+        Returns:
+            probability_dict (dict): Dictionary mapping n-bit strings to
+            probabilities.
+
+        Raises:
+            RuntimeError: If no data is available (i.e., if the circuit has
+                not been executed). Or if a qubit was supplied which was not
+                present in the circuit (might have gotten optimized away).
+        """
+        if len(self._probabilities) == 0:
+            raise RuntimeError("Please, run the circuit first!")
+
+        probability_dict = dict()
+
+        for state in self._probabilities:
+            mapped_state = ['0'] * len(qureg)
+            for i in range(len(qureg)):
+                mapped_state[i] = state[self._logical_to_physical(qureg[i].id)]
+            probability = self._probabilities[state]
+            probability_dict["".join(mapped_state)] = probability
+
+        return probability_dict
+
+    #_rearrange_result & _format_counts imported and modified from qiskit
+    def _rearrange_result(self, input,length):
+        bin_input = list(bin(input)[2:].rjust(length, '0'))
+        return ''.join(bin_input)
+
+    def _format_counts(self, samples,length):
+        counts = {}
+        for result in samples:
+            h_result = self._rearrange_result(result,length)
+            if h_result not in counts:
+                counts[h_result] = 1
+            else:
+                counts[h_result] += 1
+        counts={k: v for k, v in sorted(counts.items(), key=lambda item: item[0])}
+        return counts
+        
+    def _run(self):
+        """
+        Run the circuit.
+
+        Send the circuit via the AQT API using the provided user
+        token / ask for the user token.
+        """
+        # finally: measurements 
+        # NOTE AQT DOESN'T SEEM TO HAVE MEASUREMENT INSTRUCTIONS (no intermediate measurements are allowed, so implicit at the end)
+        # return if no operations.
+        if self._circuit == []:
+            return
+
+        max_qubit_id = max(self._allocated_qubits)
+        info = {}
+        # Hack: AQT instructions specifically need "GATE" string representation
+        # instead of 'GATE' 
+        info['circuit']=str(self._circuit).replace("'",'"')
+        info['nq']=max_qubit_id + 1
+
+        info['shots'] = self._num_runs
+        info['backend'] = {'name': self.device}
+        if self._num_runs>200:
+            raise Exception("Number of shots limited to 200")
+        try:
+            if self._retrieve_execution is None:
+                res = send(info, device=self.device,
+                           token=self._token,
+                           shots=self._num_runs,
+                           num_retries=self._num_retries,
+                           interval=self._interval,
+                           verbose=self._verbose)
+            else:
+                res = retrieve(device=self.device, 
+                               token=self._token,
+                               jobid=self._retrieve_execution,
+                               num_retries=self._num_retries,
+                               interval=self._interval,
+                               verbose=self._verbose)
+            length=len(self._measured_ids)
+            counts = self._format_counts(res,length)
+            # Determine random outcome
+            P = random.random()
+            print(P)
+            p_sum = 0.
+            measured = ""
+            for state in counts:
+                probability = counts[state] * 1. / self._num_runs
+                p_sum += probability
+                star = ""
+                if p_sum >= P and measured == "":
+                    measured = state
+                    star = "*"
+                self._probabilities[state] = probability
+                if self._verbose and probability > 0:
+                    print(str(state) + " with p = " + str(probability) +
+                          star)
+
+            class QB():
+                def __init__(self, ID):
+                    self.id = ID
+
+            # register measurement result
+            for ID in self._measured_ids:
+                location = self._logical_to_physical(ID)
+                result = int(measured[location])
+                self.main_engine.set_measurement_result(QB(ID), result)
+            self._reset()
+        except TypeError:
+            raise Exception("Failed to run the circuit. Aborting.")
+
+    def receive(self, command_list):
+        """
+        Receives a command list and, for each command, stores it until
+        completion.
+
+        Args:
+            command_list: List of commands to execute
+        """
+        for cmd in command_list:
+            if not cmd.gate == FlushGate():
+                self._store(cmd)
+            else:
+                self._run()
+                self._reset()

--- a/projectq/backends/_aqt/_aqt.py
+++ b/projectq/backends/_aqt/_aqt.py
@@ -1,4 +1,4 @@
-#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#   Copyright 2020 ProjectQ-Framework (www.projectq.ch)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/projectq/backends/_aqt/_aqt.py
+++ b/projectq/backends/_aqt/_aqt.py
@@ -228,10 +228,9 @@ class AQTBackend(BasicEngine):
                 mapped_state[i] = state[self._logical_to_physical(qubit.id)]
             probability = self._probabilities[state]
             mapped_state = "".join(mapped_state)
-            if mapped_state not in probability_dict:
-                probability_dict[mapped_state] = probability
-            else:
-                probability_dict[mapped_state] += probability
+
+            probability_dict[mapped_state] = (
+                probability_dict.get(mapped_state, 0) + probability)
         return probability_dict
 
     def _run(self):

--- a/projectq/backends/_aqt/_aqt_http_client.py
+++ b/projectq/backends/_aqt/_aqt_http_client.py
@@ -1,4 +1,4 @@
-#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#   Copyright 2020 ProjectQ-Framework (www.projectq.ch)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -12,28 +12,30 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import requests
+""" Back-end to run quantum program on AQT cloud platform"""
+
 import getpass
-import json
 import signal
-import sys
 import time
+
+import requests
 from requests.compat import urljoin
 from requests import Session
 
-#an AQT token can be requested at:
-#https://gateway-portal.aqt.eu/
+# An AQT token can be requested at:
+# https://gateway-portal.aqt.eu/
 
-_api_url = 'https://gateway.aqt.eu/marmot/'
+_API_URL = 'https://gateway.aqt.eu/marmot/'
+
 
 class AQT(Session):
     def __init__(self):
-        super(AQT,self).__init__()
-        self.backends=dict()
-        self.timeout=5.0
-        self.token=None
+        super(AQT, self).__init__()
+        self.backends = dict()
+        self.timeout = 5.0
+        self.token = None
 
-    def get_list_devices(self,verbose=False):
+    def get_list_devices(self, verbose=False):
         """
         Returns:
             (list): list of available devices
@@ -41,118 +43,155 @@ class AQT(Session):
         Up to my knowledge there is no proper API call for online devices,
         so we just assume that the list from AQT portal always up to date
         """
-        self.backends=dict()
-        self.backends['aqt_simulator']={'nq': 11,'version':'0.0.1','url':'sim/'}
-        self.backends['aqt_simulator_noise']={'nq': 11,'version':'0.0.1','url':'sim/noise-model-1'}
-        self.backends['aqt_device']={'nq': 4,'version':'0.0.1','url':'lint/'}
-        if verbose==True:
+        self.backends = dict()
+        self.backends['aqt_simulator'] = {
+            'nq': 11,
+            'version': '0.0.1',
+            'url': 'sim/'
+        }
+        self.backends['aqt_simulator_noise'] = {
+            'nq': 11,
+            'version': '0.0.1',
+            'url': 'sim/noise-model-1'
+        }
+        self.backends['aqt_device'] = {
+            'nq': 4,
+            'version': '0.0.1',
+            'url': 'lint/'
+        }
+        if verbose:
             print('- List of AQT devices available:')
             print(self.backends)
         return self.backends
 
-    def is_online(self,device):#useless at the moment, may change if API is evolving
+    def is_online(self, device):
+        # useless at the moment, may change if API evolves
         return device in self.backends
 
-    def can_run_experiment(self,info,device):
+    def can_run_experiment(self, info, device):
         """
         check if the device is big enough to run the code
 
         Args:
-            info (dict): dictionary sent by the backend containing the code to run
+            info (dict): dictionary sent by the backend containing the code to
+                run
             device (str): name of the aqt device to use
         Returns:
             (bool): True if device is big enough, False otherwise
         """
-        nb_qubit_max=self.backends[device]['nq']
-        nb_qubit_needed=info['nq']
-        return nb_qubit_needed<=nb_qubit_max,nb_qubit_max,nb_qubit_needed
+        nb_qubit_max = self.backends[device]['nq']
+        nb_qubit_needed = info['nq']
+        return nb_qubit_needed <= nb_qubit_max, nb_qubit_max, nb_qubit_needed
 
-    def _authenticate(self,token=None):
+    def _authenticate(self, token=None):
         """
         Args:
             token (str): AQT user API token.
         """
         if token is None:
             token = getpass.getpass(prompt='AQT token > ')
-        self.headers.update({'Ocp-Apim-Subscription-Key': token, 'SDK': 'ProjectQ'})
-        self.token=token
-        return 
+        self.headers.update({
+            'Ocp-Apim-Subscription-Key': token,
+            'SDK': 'ProjectQ'
+        })
+        self.token = token
 
-    def _run(self,info, device):
-        shots=info['shots']
-        nq=info['nq']
-        instructions=info['circuit']
-        argument={'data': instructions, 'access_token':self.token,'repetitions':shots,'no_qubits':nq}
-        r = super(AQT,self).put(urljoin(_api_url, self.backends[device]['url']), data=argument)
-        r.raise_for_status()
-        r_json=r.json()
+    def _run(self, info, device):
+        argument = {
+            'data': info['circuit'],
+            'access_token': self.token,
+            'repetitions': info['shots'],
+            'no_qubits': info['nq']
+        }
+        req = super(AQT, self).put(urljoin(_API_URL,
+                                           self.backends[device]['url']),
+                                   data=argument)
+        req.raise_for_status()
+        r_json = req.json()
         if r_json['status'] != 'queued':
             raise Exception('Error in sending the code online')
         execution_id = r_json["id"]
         return execution_id
 
-    def _get_result(self,device, execution_id, num_retries=3000,
-                    interval=1, verbose=False):
+    def _get_result(self,
+                    device,
+                    execution_id,
+                    num_retries=3000,
+                    interval=1,
+                    verbose=False):
 
         if verbose:
             print("Waiting for results. [Job ID: {}]".format(execution_id))
 
         original_sigint_handler = signal.getsignal(signal.SIGINT)
 
-        def _handle_sigint_during_get_result(*_):
-            raise Exception("Interrupted. The ID of your submitted job is {}."
-                            .format(execution_id))
+        def _handle_sigint_during_get_result(*_):  # pragma: no cover
+            raise Exception(
+                "Interrupted. The ID of your submitted job is {}.".format(
+                    execution_id))
 
         try:
             signal.signal(signal.SIGINT, _handle_sigint_during_get_result)
 
             for retries in range(num_retries):
-                
-                argument={'id': execution_id, 'access_token': self.token}
-                r = super(AQT,self).put(urljoin(_api_url, self.backends[device]['url']), data=argument)
-                r.raise_for_status()
-                r_json = r.json()
-                if r_json['status']=='finished' or 'samples' in r_json:
+
+                argument = {'id': execution_id, 'access_token': self.token}
+                req = super(AQT,
+                            self).put(urljoin(_API_URL,
+                                              self.backends[device]['url']),
+                                      data=argument)
+                req.raise_for_status()
+                r_json = req.json()
+                if r_json['status'] == 'finished' or 'samples' in r_json:
                     return r_json['samples']
-                elif r_json['status']!='running':
-                    raise Exception("Error while running the code: {}."
-                        .format(r_json['status']))
+                if r_json['status'] != 'running':
+                    raise Exception("Error while running the code: {}.".format(
+                        r_json['status']))
                 time.sleep(interval)
                 if self.is_online(device) and retries % 60 == 0:
                     self.get_list_devices()
                     if not self.is_online(device):
-                        raise DeviceOfflineError("Device went offline. The ID of "
-                                                "your submitted job is {}."
-                                                .format(execution_id))
+                        raise DeviceOfflineError(
+                            "Device went offline. The ID of "
+                            "your submitted job is {}.".format(execution_id))
 
         finally:
             if original_sigint_handler is not None:
                 signal.signal(signal.SIGINT, original_sigint_handler)
 
-        raise Exception("Timeout. The ID of your submitted job is {}."
-                        .format(execution_id))
+        raise Exception("Timeout. The ID of your submitted job is {}.".format(
+            execution_id))
+
 
 class DeviceTooSmall(Exception):
     pass
 
+
 class DeviceOfflineError(Exception):
     pass
 
-def show_devices(verbose=False):    
+
+def show_devices(verbose=False):
     """
-    Access the list of available devices and their properties (ex: for setup configuration)
+    Access the list of available devices and their properties (ex: for setup
+    configuration)
 
     Args:
         verbose (bool): If True, additional information is printed
 
-    ReturnS:
+    Returns:
         (list) list of available devices and their properties
     """
-    aqt_session=AQT()
+    aqt_session = AQT()
     return aqt_session.get_list_devices(verbose=verbose)
 
-def retrieve(device, token, jobid, num_retries=3000,
-             interval=1, verbose=False):
+
+def retrieve(device,
+             token,
+             jobid,
+             num_retries=3000,
+             interval=1,
+             verbose=False):
     """
     Retrieves a previously run job by its ID.
 
@@ -160,20 +199,28 @@ def retrieve(device, token, jobid, num_retries=3000,
         device (str): Device on which the code was run / is running.
         token (str): AQT user API token.
         jobid (str): Id of the job to retrieve
-    
+
     Returns:
         (list) samples form the AQT server
     """
-    aqt_session=AQT()
+    aqt_session = AQT()
     aqt_session._authenticate(token)
     aqt_session.get_list_devices(verbose)
-    res = aqt_session._get_result(device, jobid, num_retries=num_retries,
-                      interval=interval, verbose=verbose)
+    res = aqt_session._get_result(device,
+                                  jobid,
+                                  num_retries=num_retries,
+                                  interval=interval,
+                                  verbose=verbose)
     return res
 
 
-def send(info, device='aqt_simulator',token=None,
-         shots=100, num_retries=100, interval=1, verbose=False):
+def send(info,
+         device='aqt_simulator',
+         token=None,
+         shots=100,
+         num_retries=100,
+         interval=1,
+         verbose=False):
     """
     Sends cicruit through the AQT API and runs the quantum circuit.
 
@@ -181,7 +228,8 @@ def send(info, device='aqt_simulator',token=None,
         info(dict): Contains representation of the circuit to run.
         device (str): name of the aqt device. Simulator chosen by default
         token (str): AQT user API token.
-        shots (int): Number of runs of the same circuit to collect statistics. max for AQT is 200.
+        shots (int): Number of runs of the same circuit to collect
+            statistics. max for AQT is 200.
         verbose (bool): If True, additional information is printed, such as
             measurement statistics. Otherwise, the backend simply registers
             one measurement result (same behavior as the projectq Simulator).
@@ -191,34 +239,41 @@ def send(info, device='aqt_simulator',token=None,
 
     """
     try:
-        aqt_session=AQT()
+        aqt_session = AQT()
 
         if verbose:
             print("- Authenticating...")
         if token is not None:
-            print('user API token: '+token)
+            print('user API token: ' + token)
         aqt_session._authenticate(token)
 
         # check if the device is online
         aqt_session.get_list_devices(verbose)
         online = aqt_session.is_online(device)
-        if not online: #useless for the moment
+        if not online:  # useless for the moment
             print("The device is offline (for maintenance?). Use the "
                   "simulator instead or try again later.")
             raise DeviceOfflineError("Device is offline.")
-            
+
         # check if the device has enough qubit to run the code
-        runnable,qmax,qneeded = aqt_session.can_run_experiment(info,device)
+        runnable, qmax, qneeded = aqt_session.can_run_experiment(info, device)
         if not runnable:
-            print("The device is too small ({} qubits available) for the code requested({} qubits needed"
-                    "Try to look for another device with more qubits".format(qmax,qneeded))
+            print(
+                "The device is too small ({} qubits available) for the code "
+                "requested({} qubits needed). Try to look for another device "
+                "with more qubits".format(
+                    qmax, qneeded))
             raise DeviceTooSmall("Device is too small.")
         if verbose:
             print("- Running code: {}".format(info))
         execution_id = aqt_session._run(info, device)
         if verbose:
             print("- Waiting for results...")
-        res = aqt_session._get_result(device, execution_id,num_retries=num_retries,interval=interval, verbose=verbose)
+        res = aqt_session._get_result(device,
+                                      execution_id,
+                                      num_retries=num_retries,
+                                      interval=interval,
+                                      verbose=verbose)
         if verbose:
             print("- Done.")
         return res

--- a/projectq/backends/_aqt/_aqt_http_client.py
+++ b/projectq/backends/_aqt/_aqt_http_client.py
@@ -1,0 +1,230 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import requests
+import getpass
+import json
+import signal
+import sys
+import time
+from requests.compat import urljoin
+from requests import Session
+
+#an AQT token can be requested at:
+#https://gateway-portal.aqt.eu/
+
+_api_url = 'https://gateway.aqt.eu/marmot/'
+
+class AQT(Session):
+    def __init__(self):
+        super().__init__()
+        self.backends=dict()
+        self.timeout=5.0
+        self.token=None
+
+    def get_list_devices(self,verbose=False):
+        """
+        return list of available devices
+
+        Up to my knowledge there is no proper API call for online devices,
+        so we just assume that the list from AQT portal always up to date
+        """
+        self.backends=dict()
+        self.backends['aqt_simulator']={'nq': 11,'version':'0.0.1','url':'sim/'}
+        self.backends['aqt_simulator_noise']={'nq': 11,'version':'0.0.1','url':'sim/noise-model-1'}
+        self.backends['aqt_device']={'nq': 4,'version':'0.0.1','url':'lint/'}
+        if verbose==True:
+            print('- List of AQT devices available:')
+            print(self.backends)
+        return self.backends
+
+    def is_online(self,device):#useless at the moment, may change if API is evolving
+        return device in self.backends
+
+    def can_run_experiment(self,info,device):
+        """
+        check if the device is big enough to run the code
+
+        Args:
+            info (dict): dictionary sent by the backend containing the code to run
+            device (str): name of the aqt device to use
+        :return:
+            (bool): True if device is big enough, False otherwise
+        """
+        nb_qubit_max=self.backends[device]['nq']
+        nb_qubit_needed=info['nq']
+        return nb_qubit_needed<=nb_qubit_max,nb_qubit_max,nb_qubit_needed
+
+    def _authenticate(self,token=None):
+        """
+        :param token:
+        :return:
+        """
+        if token is None:
+            token = getpass.getpass(prompt='AQT Q token > ')
+        self.headers.update({'Ocp-Apim-Subscription-Key': token, 'SDK': 'ProjectQ'})
+        self.token=token
+        return 
+
+    def _run(self,info, device):
+        shots=info['shots']
+        nq=info['nq']
+        instructions=info['circuit']
+        argument={'data': instructions, 'access_token':self.token,'repetitions':shots,'no_qubits':nq}
+        r = super().put(urljoin(_api_url, self.backends[device]['url']), data=argument)
+        r.raise_for_status()
+        r_json=r.json()
+        if r_json['status'] != 'queued':
+            raise Exception('Error in sending the code online')
+        execution_id = r_json["id"]
+        return execution_id
+
+    def _get_result(self,device, execution_id, num_retries=3000,
+                    interval=1, verbose=False):
+
+        if verbose:
+            print("Waiting for results. [Job ID: {}]".format(execution_id))
+
+        original_sigint_handler = signal.getsignal(signal.SIGINT)
+
+        def _handle_sigint_during_get_result(*_):
+            raise Exception("Interrupted. The ID of your submitted job is {}."
+                            .format(execution_id))
+
+        try:
+            signal.signal(signal.SIGINT, _handle_sigint_during_get_result)
+
+            for retries in range(num_retries):
+                
+                argument={'id': execution_id, 'access_token': self.token}
+                r = super().put(urljoin(_api_url, self.backends[device]['url']), data=argument)
+                r.raise_for_status()
+                r_json = r.json()
+                if r_json['status']=='finished':
+                    return r_json['samples']
+                elif r_json['status']!='running':
+                    raise Exception("Error while running the code: {}."
+                        .format(r_json['status']))
+                time.sleep(interval)
+                if self.is_online(device) and retries % 60 == 0:
+                    self.get_list_devices()
+                    if not self.is_online(device):
+                        raise DeviceOfflineError("Device went offline. The ID of "
+                                                "your submitted job is {}."
+                                                .format(execution_id))
+
+        finally:
+            if original_sigint_handler is not None:
+                signal.signal(signal.SIGINT, original_sigint_handler)
+
+        raise Exception("Timeout. The ID of your submitted job is {}."
+                        .format(execution_id))
+
+class DeviceTooSmall(Exception):
+    pass
+
+class DeviceOfflineError(Exception):
+    pass
+
+def show_devices(verbose=False):    
+    """
+    Access the list of available devices and their properties (ex: for setup configuration)
+
+    Args:
+        verbose (bool): If True, additional information is printed
+
+    Return:
+        (list) list of available devices and their properties
+    """
+    aqt_session=AQT()
+    return aqt_session.get_list_devices(verbose=verbose)
+
+def retrieve(device, token, jobid, num_retries=3000,
+             interval=1, verbose=False):
+    """
+    Retrieves a previously run job by its ID.
+
+    Args:
+        device (str): Device on which the code was run / is running.
+        token (str): AQT quantum experience user token.
+        jobid (str): Id of the job to retrieve
+    
+    Return:
+        (list) samples form the AQT server
+    """
+    aqt_session=AQT()
+    aqt_session._authenticate(token)
+    res = aqt_session._get_result(device, jobid, num_retries=num_retries,
+                      interval=interval, verbose=verbose)
+    return res
+
+
+def send(info, device='aqt_simulator',token=None,
+         shots=100, num_retries=100, interval=1, verbose=False):
+    """
+    Sends cicruit through the AQT API and runs the quantum circuit.
+
+    Args:
+        info(dict): Contains representation of the circuit to run.
+        device (str): name of the aqt device. Simulator chosen by default
+        token (str): AQT quantum experience user token.
+        shots (int): Number of runs of the same circuit to collect statistics. max for AQT is 200.
+        verbose (bool): If True, additional information is printed, such as
+            measurement statistics. Otherwise, the backend simply registers
+            one measurement result (same behavior as the projectq Simulator).
+
+    Return:
+        (list) samples form the AQT server
+
+    """
+    try:
+        aqt_session=AQT()
+
+        if verbose:
+            print("- Authenticating...")
+            print('TOKEN: '+token)
+        aqt_session._authenticate(token)
+
+        # check if the device is online
+        aqt_session.get_list_devices(verbose)
+        online = aqt_session.is_online(device)
+        if not online: #useless for the moment
+            print("The device is offline (for maintenance?). Use the "
+                  "simulator instead or try again later.")
+            raise DeviceOfflineError("Device is offline.")
+            
+        # check if the device has enough qubit to run the code
+        runnable,qmax,qneeded = aqt_session.can_run_experiment(info,device)
+        if not runnable:
+            print("The device is too small ({} qubits available) for the code requested({} qubits needed"
+                    "Try to look for another device with more qubits".format(qmax,qneeded))
+            raise DeviceTooSmall("Device is too small.")
+        if verbose:
+            print("- Running code: {}".format(info))
+        execution_id = aqt_session._run(info, device)
+        if verbose:
+            print("- Waiting for results...")
+        res = aqt_session._get_result(device, execution_id,num_retries=num_retries,interval=interval, verbose=verbose)
+        if verbose:
+            print("- Done.")
+        return res
+    except requests.exceptions.HTTPError as err:
+        print("- There was an error running your code:")
+        print(err)
+    except requests.exceptions.RequestException as err:
+        print("- Looks like something is wrong with server:")
+        print(err)
+    except KeyError as err:
+        print("- Failed to parse response:")
+        print(err)

--- a/projectq/backends/_aqt/_aqt_http_client.py
+++ b/projectq/backends/_aqt/_aqt_http_client.py
@@ -111,7 +111,7 @@ class AQT(Session):
                 r = super(AQT,self).put(urljoin(_api_url, self.backends[device]['url']), data=argument)
                 r.raise_for_status()
                 r_json = r.json()
-                if r_json['status']=='finished':
+                if r_json['status']=='finished' or 'samples' in r_json:
                     return r_json['samples']
                 elif r_json['status']!='running':
                     raise Exception("Error while running the code: {}."

--- a/projectq/backends/_aqt/_aqt_http_client.py
+++ b/projectq/backends/_aqt/_aqt_http_client.py
@@ -28,7 +28,7 @@ _api_url = 'https://gateway.aqt.eu/marmot/'
 
 class AQT(Session):
     def __init__(self):
-        super().__init__()
+        super(AQT,self).__init__()
         self.backends=dict()
         self.timeout=5.0
         self.token=None
@@ -72,7 +72,7 @@ class AQT(Session):
         :return:
         """
         if token is None:
-            token = getpass.getpass(prompt='AQT Q token > ')
+            token = getpass.getpass(prompt='AQT token > ')
         self.headers.update({'Ocp-Apim-Subscription-Key': token, 'SDK': 'ProjectQ'})
         self.token=token
         return 
@@ -82,7 +82,7 @@ class AQT(Session):
         nq=info['nq']
         instructions=info['circuit']
         argument={'data': instructions, 'access_token':self.token,'repetitions':shots,'no_qubits':nq}
-        r = super().put(urljoin(_api_url, self.backends[device]['url']), data=argument)
+        r = super(AQT,self).put(urljoin(_api_url, self.backends[device]['url']), data=argument)
         r.raise_for_status()
         r_json=r.json()
         if r_json['status'] != 'queued':
@@ -108,7 +108,7 @@ class AQT(Session):
             for retries in range(num_retries):
                 
                 argument={'id': execution_id, 'access_token': self.token}
-                r = super().put(urljoin(_api_url, self.backends[device]['url']), data=argument)
+                r = super(AQT,self).put(urljoin(_api_url, self.backends[device]['url']), data=argument)
                 r.raise_for_status()
                 r_json = r.json()
                 if r_json['status']=='finished':
@@ -165,6 +165,7 @@ def retrieve(device, token, jobid, num_retries=3000,
     """
     aqt_session=AQT()
     aqt_session._authenticate(token)
+    aqt_session.get_list_devices(verbose)
     res = aqt_session._get_result(device, jobid, num_retries=num_retries,
                       interval=interval, verbose=verbose)
     return res
@@ -193,7 +194,8 @@ def send(info, device='aqt_simulator',token=None,
 
         if verbose:
             print("- Authenticating...")
-            print('TOKEN: '+token)
+        if token is not None:
+            print('user API token: '+token)
         aqt_session._authenticate(token)
 
         # check if the device is online

--- a/projectq/backends/_aqt/_aqt_http_client.py
+++ b/projectq/backends/_aqt/_aqt_http_client.py
@@ -35,7 +35,8 @@ class AQT(Session):
 
     def get_list_devices(self,verbose=False):
         """
-        return list of available devices
+        Returns:
+            (list): list of available devices
 
         Up to my knowledge there is no proper API call for online devices,
         so we just assume that the list from AQT portal always up to date
@@ -59,7 +60,7 @@ class AQT(Session):
         Args:
             info (dict): dictionary sent by the backend containing the code to run
             device (str): name of the aqt device to use
-        :return:
+        Returns:
             (bool): True if device is big enough, False otherwise
         """
         nb_qubit_max=self.backends[device]['nq']
@@ -68,8 +69,8 @@ class AQT(Session):
 
     def _authenticate(self,token=None):
         """
-        :param token:
-        :return:
+        Args:
+            token (str): AQT user API token.
         """
         if token is None:
             token = getpass.getpass(prompt='AQT token > ')
@@ -144,7 +145,7 @@ def show_devices(verbose=False):
     Args:
         verbose (bool): If True, additional information is printed
 
-    Return:
+    ReturnS:
         (list) list of available devices and their properties
     """
     aqt_session=AQT()
@@ -157,10 +158,10 @@ def retrieve(device, token, jobid, num_retries=3000,
 
     Args:
         device (str): Device on which the code was run / is running.
-        token (str): AQT quantum experience user token.
+        token (str): AQT user API token.
         jobid (str): Id of the job to retrieve
     
-    Return:
+    Returns:
         (list) samples form the AQT server
     """
     aqt_session=AQT()
@@ -179,13 +180,13 @@ def send(info, device='aqt_simulator',token=None,
     Args:
         info(dict): Contains representation of the circuit to run.
         device (str): name of the aqt device. Simulator chosen by default
-        token (str): AQT quantum experience user token.
+        token (str): AQT user API token.
         shots (int): Number of runs of the same circuit to collect statistics. max for AQT is 200.
         verbose (bool): If True, additional information is printed, such as
             measurement statistics. Otherwise, the backend simply registers
             one measurement result (same behavior as the projectq Simulator).
 
-    Return:
+    Returns:
         (list) samples form the AQT server
 
     """

--- a/projectq/backends/_aqt/_aqt_http_client.py
+++ b/projectq/backends/_aqt/_aqt_http_client.py
@@ -43,6 +43,7 @@ class AQT(Session):
         Up to my knowledge there is no proper API call for online devices,
         so we just assume that the list from AQT portal always up to date
         """
+        # TODO: update once the API gets created
         self.backends = dict()
         self.backends['aqt_simulator'] = {
             'nq': 11,
@@ -250,7 +251,8 @@ def send(info,
         # check if the device is online
         aqt_session.get_list_devices(verbose)
         online = aqt_session.is_online(device)
-        if not online:  # useless for the moment
+        # useless for the moment
+        if not online:  # pragma: no cover
             print("The device is offline (for maintenance?). Use the "
                   "simulator instead or try again later.")
             raise DeviceOfflineError("Device is offline.")

--- a/projectq/backends/_aqt/_aqt_http_client_test.py
+++ b/projectq/backends/_aqt/_aqt_http_client_test.py
@@ -1,0 +1,466 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Tests for projectq.backends._aqt._aqt_http_client.py."""
+
+import json
+import pytest
+import requests
+from requests.compat import urljoin
+
+from projectq.backends._aqt import _aqt_http_client
+
+
+# Insure that no HTTP request can be made in all tests in this module
+@pytest.fixture(autouse=True)
+def no_requests(monkeypatch):
+    monkeypatch.delattr("requests.sessions.Session.request")
+
+
+_api_url = 'https://gateway.aqt.eu/marmot/'
+
+def test_send_real_device_online_verbose(monkeypatch):
+    qasms = {'qasms': [{'qasm': 'my qasm'}]}
+    json_qasm = json.dumps(qasms)
+    name = 'projectq_test'
+    access_token = "access"
+    user_id = 2016
+    code_id = 11
+    name_item = '"name":"{name}", "jsonQASM":'.format(name=name)
+    json_body = ''.join([name_item, json_qasm])
+    json_data = ''.join(['{', json_body, '}'])
+    shots = 1
+    device = "aqt_simulator"
+    json_data_run = ''.join(['{"qasm":', json_qasm, '}'])
+    execution_id = 3
+    result_ready = [False]
+    result = "my_result"
+    request_num = [0]  # To assert correct order of calls
+
+    # Mock of AQT server:
+    def mocked_requests_get(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, url=""):
+                self.url = url
+
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+                self.request = MockRequest()
+                self.text = ""
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Accessing status of device. Return online.
+        status_url = 'Network/ibm-q/Groups/open/Projects/main/devices/v/1'
+        if (args[0] == urljoin(_api_url_status, status_url) and
+                (request_num[0] == 0 or request_num[0] == 3)):
+            request_num[0] += 1
+            return MockResponse([{'backend_name': 'ibmqx4', 'coupling_map': None, 'backend_version': '0.1.547', 'n_qubits': 32}], 200)
+        # Getting result
+        elif (args[0] == urljoin(_api_url,
+              "Network/ibm-q/Groups/open/Projects/main/Jobs/{execution_id}".format(execution_id=execution_id)) and
+              kwargs["params"]["access_token"] == access_token and not
+              result_ready[0] and request_num[0] == 3):
+            result_ready[0] = True
+            request_num[0] += 1
+            return MockResponse({"status": {"id": "RUNNING"}}, 200)
+        elif (args[0] == urljoin(_api_url,
+              "Network/ibm-q/Groups/open/Projects/main/Jobs/{execution_id}".format(execution_id=execution_id)) and
+              kwargs["params"]["access_token"] == access_token and
+              result_ready[0] and request_num[0] == 4):
+            print("state ok")
+            return MockResponse({"qasms": [{"result": result}]}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, body="", url=""):
+                self.body = body
+                self.url = url
+
+        class MockPostResponse:
+            def __init__(self, json_data, text=" "):
+                self.json_data = json_data
+                self.text = text
+                self.request = MockRequest()
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Authentication
+        if (args[0] == urljoin(_api_url, "users/loginWithToken") and
+                kwargs["json"]["apiToken"] == token
+                request_num[0] == 1):
+            request_num[0] += 1
+            return MockPostResponse({"userId": user_id, "id": access_token})
+        # Run code
+        elif (args[0] == urljoin(_api_url, "Jobs") and
+                kwargs["data"] == json_qasm and
+                kwargs["params"]["access_token"] == access_token and
+                kwargs["params"]["deviceRunType"] == device and
+                kwargs["params"]["fromCache"] == "false" and
+                kwargs["params"]["shots"] == shots and
+                kwargs["headers"]["Content-Type"] == "application/json" and
+                request_num[0] == 2):
+            request_num[0] += 1
+            return MockPostResponse({"id": execution_id})
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    token = 12345
+
+    def user_password_input(prompt):
+        if prompt == "AQT QE token > ":
+            return token
+
+    monkeypatch.setattr("getpass.getpass", user_password_input)
+
+    # Code to test:
+    res = _aqt_http_client.send(json_qasm,
+                                device="aqt_simulator",
+                                token=None,
+                                shots=shots, verbose=True)
+    print(res)
+    assert res == result
+
+
+def test_send_real_device_offline(monkeypatch):
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+        # Accessing status of device. Return online.
+        status_url = 'Network/ibm-q/Groups/open/Projects/main/devices/v/1'
+        if args[0] == urljoin(_api_url, status_url):
+            return MockResponse({"state": False}, 200)
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    shots = 1
+    json_qasm = "my_json_qasm"
+    name = 'projectq_test'
+    with pytest.raises(_ibm_http_client.DeviceOfflineError):
+        _aqt_http_client.send(json_qasm,
+                              device="aqt_simulator",
+                              token=None,
+                              shots=shots, verbose=True)
+
+
+def test_send_that_errors_are_caught(monkeypatch):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+    def mocked_requests_get(*args, **kwargs):
+        # Accessing status of device. Return online.
+        status_url = 'Network/ibm-q/Groups/open/Projects/main/devices/v/1'
+        if args[0] == urljoin(_api_url_status, status_url):
+            return MockResponse([{'backend_name': 'aqt_simulator', 'coupling_map': None, 'backend_version': '0.1.547', 'n_qubits': 32}], 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        # Test that this error gets caught
+        raise requests.exceptions.HTTPError
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    token = 12345
+
+    def user_password_input(prompt):
+        if prompt == "AQT QE token > ":
+            return token
+
+    monkeypatch.setattr("getpass.getpass", user_password_input)
+    shots = 1
+    json_qasm = "my_json_qasm"
+    name = 'projectq_test'
+    _ibm_http_client.send(json_qasm,
+                          device="ibmqx4",
+                          token=None,
+                          shots=shots, verbose=True)
+
+
+
+
+def test_send_that_errors_are_caught2(monkeypatch):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+    def mocked_requests_get(*args, **kwargs):
+        # Accessing status of device. Return online.
+        status_url = 'Network/ibm-q/Groups/open/Projects/main/devices/v/1'
+        if args[0] == urljoin(_api_url_status, status_url):
+            return MockResponse([{'backend_name': 'ibmqx4', 'coupling_map': None, 'backend_version': '0.1.547', 'n_qubits': 32}], 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        # Test that this error gets caught
+        raise requests.exceptions.RequestException
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    token = 12345
+
+    def user_password_input(prompt):
+        if prompt == "AQT QE token > ":
+            return token
+
+    monkeypatch.setattr("getpass.getpass", user_password_input)
+    shots = 1
+    json_qasm = "my_json_qasm"
+    name = 'projectq_test'
+    _aqt_http_client.send(json_qasm,
+                          device="ibmqx4",
+                          token=None,
+                          shots=shots, verbose=True)
+
+
+
+def test_send_that_errors_are_caught3(monkeypatch):
+    class MockResponse:
+        def __init__(self, json_data, status_code):
+            self.json_data = json_data
+            self.status_code = status_code
+
+        def json(self):
+            return self.json_data
+
+    def mocked_requests_get(*args, **kwargs):
+        # Accessing status of device. Return online.
+        status_url = 'Network/ibm-q/Groups/open/Projects/main/devices/v/1'
+        if args[0] == urljoin(_api_url_status, status_url):
+            return MockResponse([{'backend_name': 'ibmqx4', 'coupling_map': None, 'backend_version': '0.1.547', 'n_qubits': 32}], 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        # Test that this error gets caught
+        raise KeyError
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    # Patch login data
+    token = 12345
+
+    def user_password_input(prompt):
+        if prompt == "AQT QE token > ":
+            return token
+
+    monkeypatch.setattr("getpass.getpass", user_password_input)
+    shots = 1
+    json_qasm = "my_json_qasm"
+    name = 'projectq_test'
+    _aqt_http_client.send(json_qasm,
+                          device="ibmqx4",
+                          token=None,
+                          shots=shots, verbose=True)
+
+
+
+
+def test_timeout_exception(monkeypatch):
+    qasms = {'qasms': [{'qasm': 'my qasm'}]}
+    json_qasm = json.dumps(qasms)
+    tries = [0]
+
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Accessing status of device. Return device info.
+        status_url = 'Network/ibm-q/Groups/open/Projects/main/devices/v/1'
+        if args[0] == urljoin(_api_url_status, status_url):
+            return MockResponse([{'backend_name': 'ibmqx4', 'coupling_map': None, 'backend_version': '0.1.547', 'n_qubits': 32}], 200)
+        job_url = "Network/ibm-q/Groups/open/Projects/main/Jobs/{}".format("123e")
+        if args[0] == urljoin(_api_url, job_url):
+            tries[0] += 1
+            return MockResponse({"status": {"id": "RUNNING"}}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, url=""):
+                self.url = url
+
+        class MockPostResponse:
+            def __init__(self, json_data, text=" "):
+                self.json_data = json_data
+                self.text = text
+                self.request = MockRequest()
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        login_url = 'users/loginWithToken'
+        if args[0] == urljoin(_api_url, login_url):
+            return MockPostResponse({"userId": "1", "id": "12"})
+        if args[0] == urljoin(_api_url, 'Jobs'):
+            return MockPostResponse({"id": "123e"})
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    _ibm_http_client.time.sleep = lambda x: x
+    with pytest.raises(Exception) as excinfo:
+        _ibm_http_client.send(json_qasm,
+                              device="ibmqx4",
+                              token="test",
+                              shots=1,num_retries=10 verbose=False)
+    assert "123e" in str(excinfo.value)  # check that job id is in exception
+    assert tries[0] > 0
+
+
+def test_retrieve_and_device_offline_exception(monkeypatch):
+    qasms = {'qasms': [{'qasm': 'my qasm'}]}
+    json_qasm = json.dumps(qasms)
+    request_num = [0]
+
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Accessing status of device. Return online.
+        status_url = 'Network/ibm-q/Groups/open/Projects/main/devices/v/1'
+        if args[0] == urljoin(_api_url, status_url) and request_num[0] < 2:
+            return MockResponse([{'backend_name': 'ibmqx4', 'coupling_map': None, 'backend_version': '0.1.547', 'n_qubits': 32}], 200)
+        elif args[0] == urljoin(_api_url, status_url):#ibmqx4 gets disconnected, replaced by ibmqx5
+            return MockResponse([{'backend_name': 'ibmqx5', 'coupling_map': None, 'backend_version': '0.1.547', 'n_qubits': 32}], 200)
+        job_url = 'Jobs/{}'.format("123e")
+        if args[0] == urljoin(_api_url, job_url):
+            request_num[0] += 1
+            return MockResponse({"noqasms": "not done"}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, url=""):
+                self.url = url
+
+        class MockPostResponse:
+            def __init__(self, json_data, text=" "):
+                self.json_data = json_data
+                self.text = text
+                self.request = MockRequest()
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        login_url = 'users/loginWithToken'
+        if args[0] == urljoin(_api_url, login_url):
+            return MockPostResponse({"userId": "1", "id": "12"})
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    _ibm_http_client.time.sleep = lambda x: x
+    with pytest.raises(_ibm_http_client.DeviceOfflineError):
+        _ibm_http_client.retrieve(device="ibmqx4",
+                                  user="test", password="test",
+                                  jobid="123e")
+
+
+def test_retrieve(monkeypatch):
+    qasms = {'qasms': [{'qasm': 'my qasm'}]}
+    json_qasm = json.dumps(qasms)
+    request_num = [0]
+
+    def mocked_requests_get(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, json_data, status_code):
+                self.json_data = json_data
+                self.status_code = status_code
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        # Accessing status of device. Return online.
+        status_url = 'Network/ibm-q/Groups/open/Projects/main/devices/v/1'
+        if args[0] == urljoin(_api_url, status_url):
+            return MockResponse([{'backend_name': 'ibmqx4', 'coupling_map': None, 'backend_version': '0.1.547', 'n_qubits': 32}], 200)
+        job_url = 'Network/ibm-q/Groups/open/Projects/main/Jobs/{}'.format("123e")
+        if args[0] == urljoin(_api_url, job_url) and request_num[0] < 1:
+            request_num[0] += 1
+            return MockResponse({"status": {"id": "RUNNING"}}, 200)
+        elif args[0] == urljoin(_api_url, job_url):
+            return MockResponse({"qObjectResult": [{'qasm': 'qasm',
+                                            'result': 'correct'}],"status": {"id": "COMPLETED"}}, 200)
+
+    def mocked_requests_post(*args, **kwargs):
+        class MockRequest:
+            def __init__(self, url=""):
+                self.url = url
+
+        class MockPostResponse:
+            def __init__(self, json_data, text=" "):
+                self.json_data = json_data
+                self.text = text
+                self.request = MockRequest()
+
+            def json(self):
+                return self.json_data
+
+            def raise_for_status(self):
+                pass
+
+        login_url = 'users/loginWithToken'
+        if args[0] == urljoin(_api_url, login_url):
+            return MockPostResponse({"userId": "1", "id": "12"})
+
+    monkeypatch.setattr("requests.get", mocked_requests_get)
+    monkeypatch.setattr("requests.post", mocked_requests_post)
+    _ibm_http_client.time.sleep = lambda x: x
+    res = _ibm_http_client.retrieve(device="ibmqx4",
+                                    token="test",
+                                    jobid="123e")
+    assert res == 'correct'

--- a/projectq/backends/_aqt/_aqt_http_client_test.py
+++ b/projectq/backends/_aqt/_aqt_http_client_test.py
@@ -180,14 +180,6 @@ def test_send_real_device_online_verbose(monkeypatch):
 
 
 def test_send_that_errors_are_caught(monkeypatch):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-
-        def json(self):
-            return self.json_data
-
     def mocked_requests_put(*args, **kwargs):
         # Test that this error gets caught
         raise requests.exceptions.HTTPError
@@ -223,14 +215,6 @@ def test_send_that_errors_are_caught(monkeypatch):
 
 
 def test_send_that_errors_are_caught2(monkeypatch):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-
-        def json(self):
-            return self.json_data
-
     def mocked_requests_put(*args, **kwargs):
         # Test that this error gets caught
         raise requests.exceptions.RequestException
@@ -266,14 +250,6 @@ def test_send_that_errors_are_caught2(monkeypatch):
 
 
 def test_send_that_errors_are_caught3(monkeypatch):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-
-        def json(self):
-            return self.json_data
-
     def mocked_requests_put(*args, **kwargs):
         # Test that this error gets caught
         raise KeyError

--- a/projectq/backends/_aqt/_aqt_http_client_test.py
+++ b/projectq/backends/_aqt/_aqt_http_client_test.py
@@ -305,7 +305,7 @@ def test_retrieve(monkeypatch):
               kwargs["data"]["access_token"] == token and
               kwargs["data"]["id"] == execution_id and
               result_ready[0] and request_num[0] == 1):
-            return MockPutResponse({"samples": result,"status": 'finished'}, 200)z
+            return MockPutResponse({"samples": result,"status": 'finished'}, 200)
 
     monkeypatch.setattr("requests.sessions.Session.put", mocked_requests_put)
 

--- a/projectq/backends/_aqt/_aqt_http_client_test.py
+++ b/projectq/backends/_aqt/_aqt_http_client_test.py
@@ -34,7 +34,7 @@ def test_is_online():
 
     aqt_session = _aqt_http_client.AQT()
     aqt_session._authenticate(token)
-    aqt_session.get_list_devices()
+    aqt_session.update_devices_list()
     assert aqt_session.is_online('aqt_simulator')
     assert aqt_session.is_online('aqt_simulator_noise')
     assert aqt_session.is_online('aqt_device')
@@ -43,7 +43,7 @@ def test_is_online():
 
 def test_show_devices():
     device_list = _aqt_http_client.show_devices(verbose=True)
-    # TODO: update once the API gets created
+    # TODO: update once the API for getting online devices is available
     assert len(device_list) == 3
 
 

--- a/projectq/backends/_aqt/_aqt_http_client_test.py
+++ b/projectq/backends/_aqt/_aqt_http_client_test.py
@@ -305,9 +305,7 @@ def test_retrieve(monkeypatch):
               kwargs["data"]["access_token"] == token and
               kwargs["data"]["id"] == execution_id and
               result_ready[0] and request_num[0] == 1):
-            return MockPutResponse({"samples": result,"status": 'finished'}, 200)
-        else:
-            return MockPutResponse({'url':args[1],'data':kwargs},200)
+            return MockPutResponse({"samples": result,"status": 'finished'}, 200)z
 
     monkeypatch.setattr("requests.sessions.Session.put", mocked_requests_put)
 

--- a/projectq/backends/_aqt/_aqt_http_client_test.py
+++ b/projectq/backends/_aqt/_aqt_http_client_test.py
@@ -1,4 +1,4 @@
-#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#   Copyright 2020 ProjectQ-Framework (www.projectq.ch)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 #   limitations under the License.
 """Tests for projectq.backends._aqt._aqt_http_client.py."""
 
-import json
 import pytest
 import requests
 from requests.compat import urljoin
@@ -49,18 +48,6 @@ def test_show_devices():
 
 
 def test_send_too_many_qubits(monkeypatch):
-    json_aqt = {
-        'data':
-        '[["Y", 0.5, [1]], ["X", 0.5, [1]], ["X", 0.5, [1]], '
-        '["Y", 0.5, [1]], ["MS", 0.5, [1, 2]], ["X", 3.5, [1]], '
-        '["Y", 3.5, [1]], ["X", 3.5, [2]]]',
-        'access_token':
-        'access',
-        'repetitions':
-        1,
-        'no_qubits':
-        3
-    }
     info = {
         'circuit':
         '[["Y", 0.5, [1]], ["X", 0.5, [1]], ["X", 0.5, [1]], '
@@ -303,8 +290,6 @@ def test_send_that_errors_are_caught4(monkeypatch):
     shots = 1
     device = "aqt_simulator"
     execution_id = '123e'
-    result_ready = [False]
-    tries = [0]
 
     def mocked_requests_put(*args, **kwargs):
         class MockRequest:
@@ -375,7 +360,6 @@ def test_timeout_exception(monkeypatch):
     shots = 1
     device = "aqt_simulator"
     execution_id = '123e'
-    result_ready = [False]
     tries = [0]
 
     def mocked_requests_put(*args, **kwargs):
@@ -403,7 +387,7 @@ def test_timeout_exception(monkeypatch):
                 "id": execution_id,
                 "status": "queued"
             }, 200)
-        elif (args[1] == urljoin(_api_url, "sim/")
+        if (args[1] == urljoin(_api_url, "sim/")
               and kwargs["data"]["access_token"] == token
               and kwargs["data"]["id"] == execution_id):
             tries[0] += 1
@@ -465,7 +449,7 @@ def test_retrieve(monkeypatch):
             result_ready[0] = True
             request_num[0] += 1
             return MockPutResponse({"status": 'running'}, 200)
-        elif (args[1] == urljoin(_api_url, "sim/")
+        if (args[1] == urljoin(_api_url, "sim/")
               and kwargs["data"]["access_token"] == token
               and kwargs["data"]["id"] == execution_id and result_ready[0]
               and request_num[0] == 1):
@@ -496,7 +480,6 @@ def test_retrieve_that_errors_are_caught(monkeypatch):
     device = "aqt_simulator"
     execution_id = '123e'
     result_ready = [False]
-    result = "my_result"
     request_num = [0]  # To assert correct order of calls
 
     def mocked_requests_put(*args, **kwargs):
@@ -525,7 +508,7 @@ def test_retrieve_that_errors_are_caught(monkeypatch):
             result_ready[0] = True
             request_num[0] += 1
             return MockPutResponse({"status": 'running'}, 200)
-        elif (args[1] == urljoin(_api_url, "sim/")
+        if (args[1] == urljoin(_api_url, "sim/")
               and kwargs["data"]["access_token"] == token
               and kwargs["data"]["id"] == execution_id and result_ready[0]
               and request_num[0] == 1):

--- a/projectq/backends/_aqt/_aqt_test.py
+++ b/projectq/backends/_aqt/_aqt_test.py
@@ -50,7 +50,7 @@ def test_aqt_backend_is_available(single_qubit_gate, is_available):
 
 @pytest.mark.parametrize("num_ctrl_qubits, is_available", [
     (0, True), (1, False), (2, False), (3, False)])
-def test_ibm_backend_is_available_control_not(num_ctrl_qubits, is_available):
+def test_aqt_backend_is_available_control_not(num_ctrl_qubits, is_available):
     eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
     qubit1 = eng.allocate_qubit()
     qureg = eng.allocate_qureg(num_ctrl_qubits)

--- a/projectq/backends/_aqt/_aqt_test.py
+++ b/projectq/backends/_aqt/_aqt_test.py
@@ -1,4 +1,4 @@
-#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#   Copyright 2020 ProjectQ-Framework (www.projectq.ch)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -14,19 +14,15 @@
 """Tests for projectq.backends._aqt._aqt.py."""
 
 import pytest
-import json
 import math
 
 from projectq import MainEngine
 from projectq.backends._aqt import _aqt
 from projectq.types import WeakQubitRef, Qubit
-from projectq.cengines import (TagRemover, LocalOptimizer, DummyEngine,
-                               BasicMapperEngine)
+from projectq.cengines import DummyEngine, BasicMapperEngine
 from projectq.ops import (All, Allocate, Barrier, Command, Deallocate,
                           Entangle, Measure, NOT, Rx, Ry, Rz, Rxx, S, Sdag, T,
                           Tdag, X, Y, Z)
-
-from projectq.setups import restrictedgateset
 
 
 # Insure that no HTTP request can be made in all tests in this module

--- a/projectq/backends/_aqt/_aqt_test.py
+++ b/projectq/backends/_aqt/_aqt_test.py
@@ -22,8 +22,8 @@ from projectq import MainEngine
 from projectq.backends._aqt import _aqt
 from projectq.cengines import (TagRemover,
                                LocalOptimizer,
-                               DummyEngine,
-                               BasicMapperEngine)
+                               DummyEngine)#,
+                               #BasicMapperEngine)
 from projectq.ops import (All, Allocate, Barrier, Command, Deallocate,
                           Entangle, Measure, NOT, Rx, Ry, Rz, Rxx, S, Sdag, T, Tdag,
                           X, Y, Z)
@@ -93,23 +93,12 @@ def test_aqt_sent_error(monkeypatch):
 def test_aqt_retrieve(monkeypatch):
     # patch send
     def mock_retrieve(*args, **kwargs):
-        return {'id': 'a3877d18-314f-46c9-86e7-316bc4dbe968',
-                'no_qubits': 3,
-                'received': [['Y', 0.5, [1]], ['X', 0.5, [1]], ['X', 0.5, [1]],
-                            ['Y', 0.5, [1]], ['MS', 0.5, [1, 2]], ['X', -0.5, [1]],
-                            ['Y', -0.5, [1]], ['X', -0.5, [2]]],
-                'repetitions': 10,
-                'samples': [0, 6, 0, 6, 0, 0, 0, 6, 0, 6],
-                'status': 'finished'}
+        return [0, 6, 0, 6, 0, 0, 0, 6, 0, 6]
     monkeypatch.setattr(_aqt, "retrieve", mock_retrieve)
     backend = _aqt.AQTBackend(retrieve_execution="a3877d18-314f-46c9-86e7-316bc4dbe968",verbose=True)
-    mapper = BasicMapperEngine()
-    res=dict()
-    for i in range(4):
-        res[i]=i
-    mapper.current_mapping = res
+
     eng = MainEngine(backend=backend,
-                     engine_list=[mapper])
+                     engine_list=[])
     unused_qubit = eng.allocate_qubit()
     qureg = eng.allocate_qureg(2)
     # entangle the qureg
@@ -139,14 +128,7 @@ def test_aqt_backend_functional_test(monkeypatch):
 
     def mock_send(*args, **kwargs):
         assert args[0] == correct_info
-        return {'id': 'a3877d18-314f-46c9-86e7-316bc4dbe968',
-                'no_qubits': 3,
-                'received': [['Y', 0.5, [1]], ['X', 0.5, [1]], ['X', 0.5, [1]],
-                            ['Y', 0.5, [1]], ['MS', 0.5, [1, 2]], ['X', -0.5, [1]],
-                            ['Y', -0.5, [1]], ['X', -0.5, [2]]],
-                'repetitions': 10,
-                'samples': [0, 6, 0, 6, 0, 0, 0, 6, 0, 6],
-                'status': 'finished'}
+        return [0, 6, 0, 6, 0, 0, 0, 6, 0, 6]
 
     monkeypatch.setattr(_aqt, "send", mock_send)
 
@@ -155,13 +137,8 @@ def test_aqt_backend_functional_test(monkeypatch):
     with pytest.raises(RuntimeError):
         backend.get_probabilities([])
 
-    mapper = BasicMapperEngine()
-    res=dict()
-    for i in range(4):
-        res[i]=i
-    mapper.current_mapping = res
     eng = MainEngine(backend=backend,
-                     engine_list=[mapper])
+                     engine_list=[])
 
     unused_qubit = eng.allocate_qubit()
     qureg = eng.allocate_qureg(2)

--- a/projectq/backends/_aqt/_aqt_test.py
+++ b/projectq/backends/_aqt/_aqt_test.py
@@ -11,7 +11,6 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
 """Tests for projectq.backends._aqt._aqt.py."""
 
 import pytest
@@ -20,13 +19,12 @@ import math
 
 from projectq import MainEngine
 from projectq.backends._aqt import _aqt
-from projectq.cengines import (TagRemover,
-                               LocalOptimizer,
-                               DummyEngine)#,
-                               #BasicMapperEngine)
+from projectq.types import WeakQubitRef, Qubit
+from projectq.cengines import (TagRemover, LocalOptimizer, DummyEngine,
+                               BasicMapperEngine)
 from projectq.ops import (All, Allocate, Barrier, Command, Deallocate,
-                          Entangle, Measure, NOT, Rx, Ry, Rz, Rxx, S, Sdag, T, Tdag,
-                          X, Y, Z)
+                          Entangle, Measure, NOT, Rx, Ry, Rz, Rxx, S, Sdag, T,
+                          Tdag, X, Y, Z)
 
 from projectq.setups import restrictedgateset
 
@@ -36,29 +34,36 @@ from projectq.setups import restrictedgateset
 def no_requests(monkeypatch):
     monkeypatch.delattr("requests.sessions.Session.request")
 
-@pytest.mark.parametrize("single_qubit_gate, is_available", [
-    (X, False), (Y, False), (Z, False), (T, False), (Tdag, False), (S, False),
-    (Sdag, False), (Allocate, True), (Deallocate, True), (Measure, True),
-    (NOT, False), (Rx(0.5), True), (Ry(0.5), True), (Rz(0.5), False),
-    (Rxx(0.5), True),(Barrier, True), (Entangle, False)])
+
+@pytest.mark.parametrize("single_qubit_gate, is_available",
+                         [(X, False), (Y, False), (Z, False), (T, False),
+                          (Tdag, False), (S, False), (Sdag, False),
+                          (Allocate, True), (Deallocate, True),
+                          (Measure, True), (NOT, False), (Rx(0.5), True),
+                          (Ry(0.5), True), (Rz(0.5), False), (Rxx(0.5), True),
+                          (Barrier, True), (Entangle, False)])
 def test_aqt_backend_is_available(single_qubit_gate, is_available):
     eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
     qubit1 = eng.allocate_qubit()
     aqt_backend = _aqt.AQTBackend()
-    cmd = Command(eng, single_qubit_gate, (qubit1,))
+    cmd = Command(eng, single_qubit_gate, (qubit1, ))
     assert aqt_backend.is_available(cmd) == is_available
 
-@pytest.mark.parametrize("num_ctrl_qubits, is_available", [
-    (0, True), (1, False), (2, False), (3, False)])
+
+@pytest.mark.parametrize("num_ctrl_qubits, is_available", [(0, True),
+                                                           (1, False),
+                                                           (2, False),
+                                                           (3, False)])
 def test_aqt_backend_is_available_control_not(num_ctrl_qubits, is_available):
     eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
     qubit1 = eng.allocate_qubit()
     qureg = eng.allocate_qureg(num_ctrl_qubits)
     aqt_backend = _aqt.AQTBackend()
-    cmd = Command(eng, Rx(0.5), (qubit1,), controls=qureg)
+    cmd = Command(eng, Rx(0.5), (qubit1, ), controls=qureg)
     assert aqt_backend.is_available(cmd) == is_available
-    cmd = Command(eng, Rxx(0.5), (qubit1,), controls=qureg)
+    cmd = Command(eng, Rxx(0.5), (qubit1, ), controls=qureg)
     assert aqt_backend.is_available(cmd) == is_available
+
 
 def test_aqt_backend_init():
     backend = _aqt.AQTBackend(verbose=True, use_hardware=True)
@@ -71,10 +76,20 @@ def test_aqt_empty_circuit():
     eng.flush()
 
 
+def test_aqt_invalid_command():
+    backend = _aqt.AQTBackend(verbose=True)
+
+    qb = WeakQubitRef(None, 1)
+    cmd = Command(None, gate=S, qubits=[(qb, )])
+    with pytest.raises(Exception):
+        backend.receive([cmd])
+
+
 def test_aqt_sent_error(monkeypatch):
     # patch send
     def mock_send(*args, **kwargs):
         raise TypeError
+
     monkeypatch.setattr(_aqt, "send", mock_send)
 
     backend = _aqt.AQTBackend(verbose=True)
@@ -90,67 +105,37 @@ def test_aqt_sent_error(monkeypatch):
     eng.next_engine = dummy
 
 
+def test_aqt_too_many_runs():
+    backend = _aqt.AQTBackend(num_runs=300, verbose=True)
+    eng = MainEngine(backend=backend, engine_list=[])
+    with pytest.raises(Exception):
+        qubit = eng.allocate_qubit()
+        Rx(math.pi / 2) | qubit
+        eng.flush()
+
+
 def test_aqt_retrieve(monkeypatch):
     # patch send
     def mock_retrieve(*args, **kwargs):
         return [0, 6, 0, 6, 0, 0, 0, 6, 0, 6]
+
     monkeypatch.setattr(_aqt, "retrieve", mock_retrieve)
-    backend = _aqt.AQTBackend(retrieve_execution="a3877d18-314f-46c9-86e7-316bc4dbe968",verbose=True)
+    backend = _aqt.AQTBackend(
+        retrieve_execution="a3877d18-314f-46c9-86e7-316bc4dbe968",
+        verbose=True)
 
-    eng = MainEngine(backend=backend,
-                     engine_list=[])
+    eng = MainEngine(backend=backend, engine_list=[])
     unused_qubit = eng.allocate_qubit()
     qureg = eng.allocate_qureg(2)
     # entangle the qureg
-    Ry(math.pi/2) | qureg[0]
-    Rx(math.pi/2) | qureg[0]
-    Rx(math.pi/2) | qureg[0]
-    Ry(math.pi/2) | qureg[0]
-    Rxx(math.pi/2) | (qureg[0],qureg[1])
-    Rx(7*math.pi/2) | qureg[0]
-    Ry(7*math.pi/2) | qureg[0]
-    Rx(7*math.pi/2) | qureg[1]
-    del unused_qubit
-    # measure; should be all-0 or all-1
-    All(Measure) | qureg
-    # run the circuit
-    eng.flush()
-    prob_dict = eng.backend.get_probabilities([qureg[0],qureg[1]])
-    assert prob_dict['11'] == pytest.approx(0.4)
-    assert prob_dict['00'] == pytest.approx(0.6)
-
-
-def test_aqt_backend_functional_test(monkeypatch):
-    correct_info = {'circuit': '[["Y", 0.5, [1]], ["X", 0.5, [1]], ["X", 0.5, [1]], '
-                                '["Y", 0.5, [1]], ["MS", 0.5, [1, 2]], ["X", 3.5, [1]], '
-                                '["Y", 3.5, [1]], ["X", 3.5, [2]]]',
-                     'nq': 3, 'shots': 10, 'backend': {'name': 'simulator'}}
-
-    def mock_send(*args, **kwargs):
-        assert args[0] == correct_info
-        return [0, 6, 0, 6, 0, 0, 0, 6, 0, 6]
-
-    monkeypatch.setattr(_aqt, "send", mock_send)
-
-    backend = _aqt.AQTBackend(verbose=True,num_runs=10)
-    # no circuit has been executed -> raises exception
-    with pytest.raises(RuntimeError):
-        backend.get_probabilities([])
-
-    eng = MainEngine(backend=backend,
-                     engine_list=[])
-
-    unused_qubit = eng.allocate_qubit()
-    qureg = eng.allocate_qureg(2)
-    # entangle the qureg
-    Ry(math.pi/2) | qureg[0]
-    Rx(math.pi/2) | qureg[0]
-    Rx(math.pi/2) | qureg[0]
-    Ry(math.pi/2) | qureg[0]
-    Rxx(math.pi/2) | (qureg[0],qureg[1])
-    Rx(7*math.pi/2) | qureg[0]
-    Ry(7*math.pi/2) | qureg[0]
-    Rx(7*math.pi/2) | qureg[1]
+    Ry(math.pi / 2) | qureg[0]
+    Rx(math.pi / 2) | qureg[0]
+    Rx(math.pi / 2) | qureg[0]
+    Ry(math.pi / 2) | qureg[0]
+    Rxx(math.pi / 2) | (qureg[0], qureg[1])
+    Rx(7 * math.pi / 2) | qureg[0]
+    Ry(7 * math.pi / 2) | qureg[0]
+    Rx(7 * math.pi / 2) | qureg[1]
     del unused_qubit
     # measure; should be all-0 or all-1
     All(Measure) | qureg
@@ -159,6 +144,72 @@ def test_aqt_backend_functional_test(monkeypatch):
     prob_dict = eng.backend.get_probabilities([qureg[0], qureg[1]])
     assert prob_dict['11'] == pytest.approx(0.4)
     assert prob_dict['00'] == pytest.approx(0.6)
+
+    # Unknown qubit and no mapper
+    invalid_qubit = [Qubit(eng, 10)]
+    with pytest.raises(RuntimeError):
+        eng.backend.get_probabilities(invalid_qubit)
+
+
+def test_aqt_backend_functional_test(monkeypatch):
+    correct_info = {
+        'circuit':
+        '[["Y", 0.5, [1]], ["X", 0.5, [1]], ["X", 0.5, [1]], '
+        '["Y", 0.5, [1]], ["MS", 0.5, [1, 2]], ["X", 3.5, [1]], '
+        '["Y", 3.5, [1]], ["X", 3.5, [2]]]',
+        'nq':
+        3,
+        'shots':
+        10,
+        'backend': {
+            'name': 'simulator'
+        }
+    }
+
+    def mock_send(*args, **kwargs):
+        assert args[0] == correct_info
+        return [0, 6, 0, 6, 0, 0, 0, 6, 0, 6]
+
+    monkeypatch.setattr(_aqt, "send", mock_send)
+
+    backend = _aqt.AQTBackend(verbose=True, num_runs=10)
+    # no circuit has been executed -> raises exception
+    with pytest.raises(RuntimeError):
+        backend.get_probabilities([])
+
+    mapper = BasicMapperEngine()
+    res = dict()
+    for i in range(4):
+        res[i] = i
+    mapper.current_mapping = res
+
+    eng = MainEngine(backend=backend, engine_list=[mapper])
+
+    unused_qubit = eng.allocate_qubit()
+    qureg = eng.allocate_qureg(2)
+    # entangle the qureg
+    Ry(math.pi / 2) | qureg[0]
+    Rx(math.pi / 2) | qureg[0]
+    Rx(math.pi / 2) | qureg[0]
+    Ry(math.pi / 2) | qureg[0]
+    Rxx(math.pi / 2) | (qureg[0], qureg[1])
+    Rx(7 * math.pi / 2) | qureg[0]
+    Ry(7 * math.pi / 2) | qureg[0]
+    Rx(7 * math.pi / 2) | qureg[1]
+    All(Barrier) | qureg
+    del unused_qubit
+    # measure; should be all-0 or all-1
+    All(Measure) | qureg
+    # run the circuit
+    eng.flush()
+    prob_dict = eng.backend.get_probabilities([qureg[0], qureg[1]])
+    assert prob_dict['11'] == pytest.approx(0.4)
+    assert prob_dict['00'] == pytest.approx(0.6)
+
+    # Unknown qubit and no mapper
+    invalid_qubit = [Qubit(eng, 10)]
+    with pytest.raises(RuntimeError):
+        eng.backend.get_probabilities(invalid_qubit)
 
     with pytest.raises(RuntimeError):
         eng.backend.get_probabilities(eng.allocate_qubit())

--- a/projectq/backends/_aqt/_aqt_test.py
+++ b/projectq/backends/_aqt/_aqt_test.py
@@ -1,0 +1,165 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Tests for projectq.backends._aqt._aqt.py."""
+
+import pytest
+import json
+import math
+
+from projectq import MainEngine
+from projectq.backends._aqt import _aqt
+from projectq.cengines import (TagRemover,
+                               LocalOptimizer,
+                               DummyEngine)
+from projectq.ops import (All, Allocate, Barrier, Command, Deallocate,
+                          Entangle, Measure, NOT, Rx, Ry, Rz, Rxx, S, Sdag, T, Tdag,
+                          X, Y, Z)
+
+from projectq.setups import restrictedgateset
+
+
+# Insure that no HTTP request can be made in all tests in this module
+@pytest.fixture(autouse=True)
+def no_requests(monkeypatch):
+    monkeypatch.delattr("requests.sessions.Session.request")
+
+@pytest.mark.parametrize("single_qubit_gate, is_available", [
+    (X, False), (Y, False), (Z, False), (T, False), (Tdag, False), (S, False),
+    (Sdag, False), (Allocate, True), (Deallocate, True), (Measure, True),
+    (NOT, False), (Rx(0.5), True), (Ry(0.5), True), (Rz(0.5), True),
+    (Rxx(0.5), True),(Barrier, True), (Entangle, False)])
+
+
+@pytest.mark.parametrize("num_ctrl_qubits, is_available", [
+    (0, True), (1, False), (2, False), (3, False)])
+def test_ibm_backend_is_available_control_not(num_ctrl_qubits, is_available):
+    eng = MainEngine(backend=DummyEngine(), engine_list=[DummyEngine()])
+    qubit1 = eng.allocate_qubit()
+    qureg = eng.allocate_qureg(num_ctrl_qubits)
+    aqt_backend = _aqt.IBMBackend()
+    cmd = Command(eng, Rx(0.5), (qubit1,), controls=qureg)
+    assert aqt_backend.is_available(cmd) == is_available
+
+def test_aqt_backend_init():
+    backend = _aqt.IBMBackend(verbose=True, use_hardware=True)
+    assert len(backend.circuit) == 0
+
+
+def test_aqt_empty_circuit():
+    backend = _ibm.IBMBackend(verbose=True)
+    eng = MainEngine(backend=backend)
+    eng.flush()
+
+
+def test_aqt_sent_error(monkeypatch):
+    # patch send
+    def mock_send(*args, **kwargs):
+        raise TypeError
+    monkeypatch.setattr(_aqt, "send", mock_send)
+
+    backend = _aqt.AQTBackend(verbose=True)
+    eng = MainEngine(backend=backend)
+    qubit = eng.allocate_qubit()
+    Rx(0.5) | qubit
+    with pytest.raises(Exception):
+        qubit[0].__del__()
+        eng.flush()
+    # atexit sends another FlushGate, therefore we remove the backend:
+    dummy = DummyEngine()
+    dummy.is_last_engine = True
+    eng.next_engine = dummy
+
+
+def test_aqt_retrieve(monkeypatch):
+    # patch send
+    def mock_retrieve(*args, **kwargs):
+        return {'id': 'a3877d18-314f-46c9-86e7-316bc4dbe968',
+                'no_qubits': 2,
+                'received': [['Y', 0.5, [0]], ['X', 0.5, [0]], ['X', 0.5, [0]],
+                            ['Y', 0.5, [0]], ['MS', 0.5, [0, 1]], ['X', -0.5, [0]],
+                            ['Y', -0.5, [0]], ['X', -0.5, [1]]],
+                'repetitions': 10,
+                'samples': [0, 3, 0, 3, 0, 0, 0, 3, 0, 3],
+                'status': 'finished'}
+    monkeypatch.setattr(_aqt, "retrieve", mock_retrieve)
+    backend = _aqt.AQTBackend(retrieve_execution="a3877d18-314f-46c9-86e7-316bc4dbe968")
+    engine_list = [TagRemover(),
+                   LocalOptimizer(10)]
+    eng = MainEngine(backend=backend, engine_list=engine_list)
+    unused_qubit = eng.allocate_qubit()
+    qureg = eng.allocate_qureg(2)
+    # entangle the qureg
+    Ry(math.pi/2) | qureg[0]
+    Rx(math.pi/2) | qureg[0]
+    Rx(math.pi/2) | qureg[0]
+    Ry(math.pi/2) | qureg[0]
+    Rxx(math.pi/2) | (qureg[0],qureg[1])
+    Rx(7*math.pi/2) | qureg[0]
+    Ry(7*math.pi/2) | qureg[0]
+    Rx(7*math.pi/2) | qureg[1]
+    del unused_qubit
+    # measure; should be all-0 or all-1
+    All(Measure) | qureg
+    # run the circuit
+    eng.flush()
+    prob_dict = eng.backend.get_probabilities([qureg[0],qureg[1]])
+    assert prob_dict['11'] == pytest.approx(0.4)
+    assert prob_dict['00'] == pytest.approx(0.6)
+
+
+def test_aqt_backend_functional_test(monkeypatch):
+    correct_info = """{'data': '[["Y", 0.5, [0]], ["X", 0.5, [0]], ["X", 0.5, [0]],
+                            '["Y", 0.5, [0]], ["MS", 0.5, [0, 1]], ["X", -0.5, [0]],'
+                            '["Y", -0.5, [0]], ["X", -0.5, [1]]]',
+                    'access_token': 'TOKEN',
+                    'repetitions': 100,
+                    'no_qubits': 2}"""
+
+    def mock_send(*args, **kwargs):
+        assert json.loads(args[0]) == json.loads(correct_info)
+        return {'id': 'a3877d18-314f-46c9-86e7-316bc4dbe968', 'status': 'queued'}
+
+    monkeypatch.setattr(_aqt, "send", mock_send)
+
+    backend = _aqt.AQTBackend(verbose=True)
+    # no circuit has been executed -> raises exception
+    with pytest.raises(RuntimeError):
+        backend.get_probabilities([])
+
+    engine_list = [TagRemover(),
+                   LocalOptimizer(10)]
+    eng = MainEngine(backend=backend, engine_list=engine_list)
+    unused_qubit = eng.allocate_qubit()
+    qureg = eng.allocate_qureg(2)
+    # entangle the qureg
+    Ry(math.pi/2) | qureg[0]
+    Rx(math.pi/2) | qureg[0]
+    Rx(math.pi/2) | qureg[0]
+    Ry(math.pi/2) | qureg[0]
+    Rxx(math.pi/2) | (qureg[0],qureg[1])
+    Rx(7*math.pi/2) | qureg[0]
+    Ry(7*math.pi/2) | qureg[0]
+    Rx(7*math.pi/2) | qureg[1]
+    del unused_qubit
+    # measure; should be all-0 or all-1
+    All(Measure) | qureg
+    # run the circuit
+    eng.flush()
+    prob_dict = eng.backend.get_probabilities([qureg[0], qureg[1]])
+    assert prob_dict['11'] == pytest.approx(0.4)
+    assert prob_dict['00'] == pytest.approx(0.6)
+
+    with pytest.raises(RuntimeError):
+        eng.backend.get_probabilities(eng.allocate_qubit())

--- a/projectq/setups/aqt.py
+++ b/projectq/setups/aqt.py
@@ -12,14 +12,14 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """
-Defines a setup allowing to compile code for the IBM quantum chips:
-->Any 5 qubit devices
-->the ibmq online simulator
-->the melbourne 15 qubit device
+Defines a setup allowing to compile code for the AQT trapped ion devices:
+->The 4 qubits device
+->The 11 qubits simulator
+->The 11 qubits noisy simulator
 
 It provides the `engine_list` for the `MainEngine' based on the requested
-device.  Decompose the circuit into a Rx/Ry/Rz/H/CNOT gate set that will be
-translated in the backend in the U1/U2/U3/CX gate set.
+device.  Decompose the circuit into a Rx/Ry/Rxx gate set that will be
+translated in the backend in the Rx/Ry/MS gate set.
 """
 
 import projectq
@@ -42,7 +42,7 @@ def get_engine_list(token=None, device=None):
         raise DeviceOfflineError('Error when configuring engine list: device '
                                  'requested for Backend not connected')
     if device == 'aqt_simulator':
-        # The 32 qubit online simulator doesn't need a specific mapping for
+        # The 11 qubit online simulator doesn't need a specific mapping for
         # gates. Can also run wider gateset but this setup keep the
         # restrictedgateset setup for coherence
         mapper = BasicMapperEngine()
@@ -60,12 +60,10 @@ def get_engine_list(token=None, device=None):
         # appropriate mapper and the 'coupling_map' parameter
         raise DeviceNotHandledError('Device not yet fully handled by ProjectQ')
 
-    # Most IBM devices accept U1,U2,U3,CX gates.
     # Most gates need to be decomposed into a subset that is manually converted
     # in the backend (until the implementation of the U1,U2,U3)
-    # available gates decomposable now for U1,U2,U3: Rx,Ry,Rz and H
-    setup = restrictedgateset.get_engine_list(one_qubit_gates=(Rx, Ry, Rxx),
-                                              two_qubit_gates=tuple(),
+    setup = restrictedgateset.get_engine_list(one_qubit_gates=(Rx, Ry),
+                                              two_qubit_gates=(Rxx,),
                                               other_gates=(Barrier, ))
     setup.extend(aqt_setup)
     return setup

--- a/projectq/setups/aqt.py
+++ b/projectq/setups/aqt.py
@@ -29,7 +29,7 @@ from projectq.ops import (Rx, Ry, Rxx, Barrier)
 from projectq.cengines import (LocalOptimizer, IBM5QubitMapper,
                                SwapAndCNOTFlipper, BasicMapperEngine,
                                GridMapper)
-from projectq.backends._aqt._ibm_http_client import show_devices
+from projectq.backends._aqt._aqt_http_client import show_devices
 
 
 def get_engine_list(token=None, device=None):
@@ -41,7 +41,7 @@ def get_engine_list(token=None, device=None):
     if device not in devices:
         raise DeviceOfflineError('Error when configuring engine list: device '
                                  'requested for Backend not connected')
-    if device == 'simulator':
+    if device == 'aqt_simulator':
         # The 32 qubit online simulator doesn't need a specific mapping for
         # gates. Can also run wider gateset but this setup keep the
         # restrictedgateset setup for coherence

--- a/projectq/setups/aqt.py
+++ b/projectq/setups/aqt.py
@@ -1,0 +1,81 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+Defines a setup allowing to compile code for the IBM quantum chips:
+->Any 5 qubit devices
+->the ibmq online simulator
+->the melbourne 15 qubit device
+
+It provides the `engine_list` for the `MainEngine' based on the requested
+device.  Decompose the circuit into a Rx/Ry/Rz/H/CNOT gate set that will be
+translated in the backend in the U1/U2/U3/CX gate set.
+"""
+
+import projectq
+import projectq.setups.decompositions
+from projectq.setups import restrictedgateset
+from projectq.ops import (Rx, Ry, Rxx, Barrier)
+from projectq.cengines import (LocalOptimizer, IBM5QubitMapper,
+                               SwapAndCNOTFlipper, BasicMapperEngine,
+                               GridMapper)
+from projectq.backends._aqt._ibm_http_client import show_devices
+
+
+def get_engine_list(token=None, device=None):
+    # Access to the hardware properties via show_devices
+    # Can also be extended to take into account gate fidelities, new available
+    # gate, etc..
+    devices = show_devices(token)
+    aqt_setup = []
+    if device not in devices:
+        raise DeviceOfflineError('Error when configuring engine list: device '
+                                 'requested for Backend not connected')
+    if device == 'simulator':
+        # The 32 qubit online simulator doesn't need a specific mapping for
+        # gates. Can also run wider gateset but this setup keep the
+        # restrictedgateset setup for coherence
+        mapper = BasicMapperEngine()
+        # Note: Manual Mapper doesn't work, because its map is updated only if
+        # gates are applied if gates in the register are not used, then it
+        # will lead to state errors
+        res = dict()
+        for i in range(devices[device]['nq']):
+            res[i] = i
+        mapper.current_mapping = res
+        aqt_setup = [mapper]
+    .else:
+        # If there is an online device not handled into ProjectQ it's not too
+        # bad, the engine_list can be constructed manually with the
+        # appropriate mapper and the 'coupling_map' parameter
+        raise DeviceNotHandledError('Device not yet fully handled by ProjectQ')
+
+    # Most IBM devices accept U1,U2,U3,CX gates.
+    # Most gates need to be decomposed into a subset that is manually converted
+    # in the backend (until the implementation of the U1,U2,U3)
+    # available gates decomposable now for U1,U2,U3: Rx,Ry,Rz and H
+    setup = restrictedgateset.get_engine_list(one_qubit_gates=(Rx, Ry, Rxx),
+                                              two_qubit_gates=tuple(),
+                                              other_gates=(Barrier, ))
+    setup.extend(aqt_setup)
+    return setup
+
+
+class DeviceOfflineError(Exception):
+    pass
+
+
+class DeviceNotHandledError(Exception):
+    pass
+
+

--- a/projectq/setups/aqt.py
+++ b/projectq/setups/aqt.py
@@ -54,7 +54,7 @@ def get_engine_list(token=None, device=None):
             res[i] = i
         mapper.current_mapping = res
         aqt_setup = [mapper]
-    .else:
+    else:
         # If there is an online device not handled into ProjectQ it's not too
         # bad, the engine_list can be constructed manually with the
         # appropriate mapper and the 'coupling_map' parameter

--- a/projectq/setups/aqt.py
+++ b/projectq/setups/aqt.py
@@ -1,4 +1,4 @@
-#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#   Copyright 2020 ProjectQ-Framework (www.projectq.ch)
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/projectq/setups/aqt_test.py
+++ b/projectq/setups/aqt_test.py
@@ -33,7 +33,7 @@ def test_aqt_mapper_in_cengines(monkeypatch):
     monkeypatch.setattr(projectq.setups.aqt, "show_devices", mock_show_devices)
     engines_simulator = projectq.setups.aqt.get_engine_list(
         device='aqt_simulator')
-    assert len(engines_simulator) == 1
+    assert len(engines_simulator) == 13
 
 
 def test_aqt_errors(monkeypatch):

--- a/projectq/setups/aqt_test.py
+++ b/projectq/setups/aqt_test.py
@@ -11,12 +11,12 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-"""Tests for projectq.setup.ibm."""
+"""Tests for projectq.setup.aqt."""
 
 import pytest
 
 
-def test_aqt_cnot_mapper_in_cengines(monkeypatch):
+def test_aqt_mapper_in_cengines(monkeypatch):
     import projectq.setups.aqt
 
     def mock_show_devices(*args, **kwargs):
@@ -33,7 +33,7 @@ def test_aqt_cnot_mapper_in_cengines(monkeypatch):
     monkeypatch.setattr(projectq.setups.aqt, "show_devices", mock_show_devices)
     engines_simulator = projectq.setups.aqt.get_engine_list(
         device='aqt_simulator')
-    assert len(engines_simulator) == 13
+    assert len(engines_simulator) == 1
 
 
 def test_aqt_errors(monkeypatch):

--- a/projectq/setups/aqt_test.py
+++ b/projectq/setups/aqt_test.py
@@ -1,0 +1,57 @@
+#   Copyright 2020 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for projectq.setup.ibm."""
+
+import pytest
+
+
+def test_aqt_cnot_mapper_in_cengines(monkeypatch):
+    import projectq.setups.aqt
+
+    def mock_show_devices(*args, **kwargs):
+        connections = set([(0, 1), (1, 0), (1, 2), (1, 3), (1, 4), (2, 1),
+                           (2, 3), (2, 4), (3, 1), (3, 4), (4, 3)])
+        return {
+            'aqt_simulator': {
+                'coupling_map': connections,
+                'version': '0.0.0',
+                'nq': 32
+            }
+        }
+
+    monkeypatch.setattr(projectq.setups.aqt, "show_devices", mock_show_devices)
+    engines_simulator = projectq.setups.aqt.get_engine_list(
+        device='aqt_simulator')
+    assert len(engines_simulator) == 13
+
+
+def test_aqt_errors(monkeypatch):
+    import projectq.setups.aqt
+
+    def mock_show_devices(*args, **kwargs):
+        connections = set([(0, 1), (1, 0), (1, 2), (1, 3), (1, 4), (2, 1),
+                           (2, 3), (2, 4), (3, 1), (3, 4), (4, 3)])
+        return {
+            'aqt_imaginary': {
+                'coupling_map': connections,
+                'version': '0.0.0',
+                'nq': 6
+            }
+        }
+
+    monkeypatch.setattr(projectq.setups.aqt, "show_devices", mock_show_devices)
+    with pytest.raises(projectq.setups.aqt.DeviceOfflineError):
+        projectq.setups.aqt.get_engine_list(device='simulator')
+    with pytest.raises(projectq.setups.aqt.DeviceNotHandledError):
+        projectq.setups.aqt.get_engine_list(device='aqt_imaginary')


### PR DESCRIPTION
New Backend to connect to the Alpine Quantum Technologies (AQT) devices.

-> A documentation was released mid-February:
https://www.aqt.eu/aqt-json-tutorial/#json-syntax
-> Access keys can be requested by creating an account at: https://gateway-portal.aqt.eu

->Only tested on the online simulator but the code should be the same for the hardware
->This backend is a trapped ion quantum computer so only accepts Rx,Ry and MS gates