### PR TITLE
Fix bugs with matplotlib drawer

### DIFF
--- a/projectq/backends/_circuits/_drawer_matplotlib.py
+++ b/projectq/backends/_circuits/_drawer_matplotlib.py
@@ -181,7 +181,7 @@ class CircuitDrawerMatplotlib(BasicEngine):
             if not self.is_last_engine:
                 self.send([cmd])
 
-    def draw(self, qubit_labels=None, drawing_order=None):
+    def draw(self, qubit_labels=None, drawing_order=None, **kwargs):
         """
         Generates and returns the plot of the quantum circuit stored so far
 
@@ -228,4 +228,5 @@ class CircuitDrawerMatplotlib(BasicEngine):
 
         return to_draw(self._qubit_lines,
                        qubit_labels=qubit_labels,
-                       drawing_order=drawing_order)
+                       drawing_order=drawing_order,
+                       **kwargs)

--- a/projectq/backends/_circuits/_plot.py
+++ b/projectq/backends/_circuits/_plot.py
@@ -222,12 +222,14 @@ def calculate_gate_grid(axes, qubit_lines, plot_params):
     ]
 
     gate_grid = np.array([0] * (depth + 1), dtype=float)
-
-    gate_grid[0] = plot_params['labels_margin'] + (width_list[0]) * 0.5
-    for idx in range(1, depth):
-        gate_grid[idx] = gate_grid[idx - 1] + column_spacing + (
-            width_list[idx] + width_list[idx - 1]) * 0.5
-    gate_grid[-1] = gate_grid[-2] + column_spacing + width_list[-1] * 0.5
+    
+    gate_grid[0] = plot_params['labels_margin']
+    if depth > 0:
+        gate_grid[0] += width_list[0] * 0.5
+        for idx in range(1, depth):
+            gate_grid[idx] = gate_grid[idx - 1] + column_spacing + (
+                width_list[idx] + width_list[idx - 1]) * 0.5
+        gate_grid[-1] = gate_grid[-2] + column_spacing + width_list[-1] * 0.5
     return gate_grid
 
 


### PR DESCRIPTION
- Add missing **kwargs in `draw()` method of `CircuitDrawerMatplotlib`
- Fix bug while drawing if no gate present in the circuit