### PR TITLE
Fix install on macOS Big Sur

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -370,10 +370,9 @@ class BuildExt(build_ext):
             cxx_standards = [year for year in cxx_standards if year < 17]
 
         if sys.platform == 'darwin':
-            _, minor_version, _ = [
-                int(i) for i in platform.mac_ver()[0].split('.')
-            ]
-            if minor_version < 14:
+            major_version = int(platform.mac_ver()[0].split('.')[0])
+            minor_version = int(platform.mac_ver()[0].split('.')[1])
+            if major_version <= 10 and minor_version < 14:
                 cxx_standards = [year for year in cxx_standards if year < 17]
 
         for year in cxx_standards:


### PR DESCRIPTION
Fixes #382 and future proofs in case `platform.mac_ver()[0]` returns `11.x`.