### PR TITLE
Add support for dynamic backends for IonQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Added IonQ dynamic backends fetch.
+
 ## [0.7.1] - 2022-01-10
 
 ### Added

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -250,9 +250,6 @@ class IonQ(Session):
     def show_devices(self):
         """Show the currently available device list for the IonQ provider.
 
-        Args:
-            verbose (bool): If True, additional information is printed
-
         Returns:
             list: list of available devices and their properties.
         """

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -248,7 +248,7 @@ class IonQ(Session):
         raise RequestTimeoutError("Timeout. The ID of your submitted job is {}.".format(execution_id))
 
 
-    def show_devices(self, verbose=False):
+    def show_devices(self):
         """Show the currently available device list for the IonQ provider.
 
         Args:

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -63,7 +63,7 @@ class IonQ(Session):
             },
         }
         for backend in r_json:
-            self.backends[backend["backend"]] = { "nq": backend["qubits"], "target": backend["backend"]}
+            self.backends[backend["backend"]] = {"nq": backend["qubits"], "target": backend["backend"]}
         if self._verbose:  # pragma: no cover
             print('- List of IonQ devices available:')
             print(self.backends)
@@ -246,7 +246,6 @@ class IonQ(Session):
                 signal.signal(signal.SIGINT, original_sigint_handler)
 
         raise RequestTimeoutError("Timeout. The ID of your submitted job is {}.".format(execution_id))
-
 
     def show_devices(self):
         """Show the currently available device list for the IonQ provider.

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -58,11 +58,28 @@ def test_is_online(monkeypatch):
         assert urljoin(_api_url, 'backends') == path
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
-            return_value=[{"backend":"qpu.s11","status":"available","qubits":11,"average_queue_time":3253287,"last_updated":1647863473555,"characterization_url":"/characterizations/48ccd423-2913-45e0-a669-e0f676abeb82"},{"backend":"simulator","status":"available","qubits":19,"average_queue_time":1499,"last_updated":1627065490042}],)
+            return_value=[
+                {
+                    "backend": "qpu.s11",
+                    "status": "available",
+                    "qubits": 11,
+                    "average_queue_time": 3253287,
+                    "last_updated": 1647863473555,
+                    "characterization_url": "/characterizations/48ccd423-2913-45e0-a669-e0f676abeb82",
+                },
+                {
+                    "backend": "simulator",
+                    "status": "available",
+                    "qubits": 19,
+                    "average_queue_time": 1499,
+                    "last_updated": 1627065490042,
+                },
+            ],
+        )
         return mock_response
-    
+
     monkeypatch.setattr('requests.sessions.Session.get', mock_get)
-    
+
     ionq_session = _ionq_http_client.IonQ()
     ionq_session.authenticate('not none')
     ionq_session.update_devices_list()
@@ -77,11 +94,28 @@ def test_show_devices(monkeypatch):
         assert urljoin(_api_url, 'backends') == path
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
-            return_value=[{"backend":"qpu.s11","status":"available","qubits":11,"average_queue_time":3253287,"last_updated":1647863473555,"characterization_url":"/characterizations/48ccd423-2913-45e0-a669-e0f676abeb82"},{"backend":"simulator","status":"available","qubits":19,"average_queue_time":1499,"last_updated":1627065490042}],)
+            return_value=[
+                {
+                    "backend": "qpu.s11",
+                    "status": "available",
+                    "qubits": 11,
+                    "average_queue_time": 3253287,
+                    "last_updated": 1647863473555,
+                    "characterization_url": "/characterizations/48ccd423-2913-45e0-a669-e0f676abeb82",
+                },
+                {
+                    "backend": "simulator",
+                    "status": "available",
+                    "qubits": 19,
+                    "average_queue_time": 1499,
+                    "last_updated": 1627065490042,
+                },
+            ],
+        )
         return mock_response
-    
+
     monkeypatch.setattr('requests.sessions.Session.get', mock_get)
-    
+
     ionq_session = _ionq_http_client.IonQ()
     ionq_session.authenticate('not none')
     device_list = ionq_session.show_devices()

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -53,18 +53,40 @@ def test_authenticate_prompt_requires_token(monkeypatch):
     assert str(excinfo.value) == 'An authentication token is required!'
 
 
-def test_is_online():
+def test_is_online(monkeypatch):
+    def mock_get(_self, path, *args, **kwargs):
+        assert urljoin(_api_url, 'backends') == path
+        mock_response = mock.MagicMock()
+        mock_response.json = mock.MagicMock(
+            return_value=[{"backend":"qpu.s11","status":"available","qubits":11,"average_queue_time":3253287,"last_updated":1647863473555,"characterization_url":"/characterizations/48ccd423-2913-45e0-a669-e0f676abeb82"},{"backend":"simulator","status":"available","qubits":19,"average_queue_time":1499,"last_updated":1627065490042}],)
+        return mock_response
+    
+    monkeypatch.setattr('requests.sessions.Session.get', mock_get)
+    
     ionq_session = _ionq_http_client.IonQ()
     ionq_session.authenticate('not none')
     ionq_session.update_devices_list()
     assert ionq_session.is_online('ionq_simulator')
     assert ionq_session.is_online('ionq_qpu')
+    assert ionq_session.is_online('qpu.s11')
     assert not ionq_session.is_online('ionq_unknown')
 
 
-def test_show_devices():
-    device_list = _ionq_http_client.show_devices()
+def test_show_devices(monkeypatch):
+    def mock_get(_self, path, *args, **kwargs):
+        assert urljoin(_api_url, 'backends') == path
+        mock_response = mock.MagicMock()
+        mock_response.json = mock.MagicMock(
+            return_value=[{"backend":"qpu.s11","status":"available","qubits":11,"average_queue_time":3253287,"last_updated":1647863473555,"characterization_url":"/characterizations/48ccd423-2913-45e0-a669-e0f676abeb82"},{"backend":"simulator","status":"available","qubits":19,"average_queue_time":1499,"last_updated":1627065490042}],)
+        return mock_response
+    
+    monkeypatch.setattr('requests.sessions.Session.get', mock_get)
+    
+    ionq_session = _ionq_http_client.IonQ()
+    ionq_session.authenticate('not none')
+    device_list = ionq_session.show_devices()
     assert isinstance(device_list, dict)
+    assert len(device_list) == 4
     for info in device_list.values():
         assert 'nq' in info
         assert 'target' in info

--- a/projectq/setups/ionq.py
+++ b/projectq/setups/ionq.py
@@ -21,7 +21,7 @@ Defines a setup allowing to compile code for IonQ trapped ion devices:
 ->The 29 qubits simulator
 """
 from projectq.backends._exceptions import DeviceOfflineError
-from projectq.backends._ionq._ionq_http_client import show_devices
+from projectq.backends._ionq._ionq_http_client import IonQ
 from projectq.backends._ionq._ionq_mapper import BoundedQubitMapper
 from projectq.ops import (
     Barrier,
@@ -47,7 +47,8 @@ from projectq.setups import restrictedgateset
 
 def get_engine_list(token=None, device=None):
     """Return the default list of compiler engine for the IonQ platform."""
-    devices = show_devices(token)
+    ionQ = IonQ()
+    devices = ionQ.show_devices(token)
     if not device or device not in devices:
         raise DeviceOfflineError("Error checking engine list: no '{}' devices available".format(device))
 

--- a/projectq/setups/ionq.py
+++ b/projectq/setups/ionq.py
@@ -48,7 +48,9 @@ from projectq.setups import restrictedgateset
 def get_engine_list(token=None, device=None):
     """Return the default list of compiler engine for the IonQ platform."""
     service = IonQ()
-    devices = service.show_devices(token)
+    if token is not None:
+        service.authenticate(token=token)
+    devices = service.show_devices()
     if not device or device not in devices:
         raise DeviceOfflineError("Error checking engine list: no '{}' devices available".format(device))
 

--- a/projectq/setups/ionq.py
+++ b/projectq/setups/ionq.py
@@ -47,8 +47,8 @@ from projectq.setups import restrictedgateset
 
 def get_engine_list(token=None, device=None):
     """Return the default list of compiler engine for the IonQ platform."""
-    ionQ = IonQ()
-    devices = ionQ.show_devices(token)
+    service = IonQ()
+    devices = service.show_devices(token)
     if not device or device not in devices:
         raise DeviceOfflineError("Error checking engine list: no '{}' devices available".format(device))
 

--- a/projectq/setups/ionq_test.py
+++ b/projectq/setups/ionq_test.py
@@ -18,7 +18,7 @@ import pytest
 
 from projectq.backends._exceptions import DeviceOfflineError
 from projectq.backends._ionq._ionq_mapper import BoundedQubitMapper
-
+from projectq.backends._ionq._ionq_http_client import IonQ
 
 def test_basic_ionq_mapper(monkeypatch):
     import projectq.setups.ionq
@@ -26,7 +26,11 @@ def test_basic_ionq_mapper(monkeypatch):
     def mock_show_devices(*args, **kwargs):
         return {'dummy': {'nq': 3, 'target': 'dummy'}}
 
-    monkeypatch.setattr(projectq.setups.ionq, 'show_devices', mock_show_devices)
+    monkeypatch.setattr(
+        IonQ,
+        'show_devices',
+        mock_show_devices,
+    )
     engine_list = projectq.setups.ionq.get_engine_list(device='dummy')
     assert len(engine_list) > 1
     mapper = engine_list[-1]
@@ -40,8 +44,12 @@ def test_ionq_errors(monkeypatch):
 
     def mock_show_devices(*args, **kwargs):
         return {'dummy': {'nq': 3, 'target': 'dummy'}}
-
-    monkeypatch.setattr(projectq.setups.ionq, 'show_devices', mock_show_devices)
+    
+    monkeypatch.setattr(
+        IonQ,
+        'show_devices',
+        mock_show_devices,
+    )
 
     with pytest.raises(DeviceOfflineError):
         projectq.setups.ionq.get_engine_list(device='simulator')

--- a/projectq/setups/ionq_test.py
+++ b/projectq/setups/ionq_test.py
@@ -17,8 +17,9 @@
 import pytest
 
 from projectq.backends._exceptions import DeviceOfflineError
-from projectq.backends._ionq._ionq_mapper import BoundedQubitMapper
 from projectq.backends._ionq._ionq_http_client import IonQ
+from projectq.backends._ionq._ionq_mapper import BoundedQubitMapper
+
 
 def test_basic_ionq_mapper(monkeypatch):
     import projectq.setups.ionq
@@ -44,7 +45,7 @@ def test_ionq_errors(monkeypatch):
 
     def mock_show_devices(*args, **kwargs):
         return {'dummy': {'nq': 3, 'target': 'dummy'}}
-    
+
     monkeypatch.setattr(
         IonQ,
         'show_devices',


### PR DESCRIPTION
Using the backends endpoint, add available backends to the list.