### PR TITLE
IonQ API: Move to v0.2, and fixup backends path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+-   Fixed IonQ dynamic backends fetch, which relied on an incorrect path.
+
 ## [v0.7.2] - 2022-04-11
 
 ### Changed

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -31,7 +31,8 @@ from .._exceptions import (
     RequestTimeoutError,
 )
 
-_API_URL = 'https://api.ionq.co/v0.1/jobs/'
+_API_URL = 'https://api.ionq.co/v0.2/'
+_JOB_API_URL = urljoin([API_URL, 'jobs')
 
 
 class IonQ(Session):
@@ -148,7 +149,7 @@ class IonQ(Session):
 
         # _API_URL[:-1] strips the trailing slash.
         # TODO: Add comprehensive error parsing for non-200 responses.
-        req = super().post(_API_URL[:-1], json=argument)
+        req = super().post(_JOB_API_URL[:-1], json=argument)
         req.raise_for_status()
 
         # Process the response.
@@ -211,7 +212,7 @@ class IonQ(Session):
 
         try:
             for retries in range(num_retries):
-                req = super().get(urljoin(_API_URL, execution_id))
+                req = super().get(urljoin(_JOB_API_URL, execution_id))
                 req.raise_for_status()
                 r_json = req.json()
                 status = r_json['status']

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -32,7 +32,7 @@ from .._exceptions import (
 )
 
 _API_URL = 'https://api.ionq.co/v0.2/'
-_JOB_API_URL = urljoin([API_URL, 'jobs')
+_JOB_API_URL = urljoin(API_URL, 'jobs')
 
 
 class IonQ(Session):

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -32,7 +32,7 @@ from .._exceptions import (
 )
 
 _API_URL = 'https://api.ionq.co/v0.2/'
-_JOB_API_URL = urljoin(API_URL, 'jobs')
+_JOB_API_URL = urljoin(_API_URL, 'jobs')
 
 
 class IonQ(Session):

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -32,7 +32,7 @@ from .._exceptions import (
 )
 
 _API_URL = 'https://api.ionq.co/v0.2/'
-_JOB_API_URL = urljoin(_API_URL, 'jobs')
+_JOB_API_URL = urljoin(_API_URL, 'jobs/')
 
 
 class IonQ(Session):

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -29,7 +29,6 @@ def no_requests(monkeypatch):
     monkeypatch.delattr('requests.sessions.Session.request')
 
 
-
 def test_authenticate():
     ionq_session = _ionq_http_client.IonQ()
     ionq_session.authenticate('NotNone')

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -18,7 +18,6 @@ from unittest import mock
 
 import pytest
 import requests
-from requests.compat import urljoin
 
 from projectq.backends._exceptions import JobSubmissionError, RequestTimeoutError
 from projectq.backends._ionq import _ionq_http_client
@@ -53,7 +52,7 @@ def test_authenticate_prompt_requires_token(monkeypatch):
 
 def test_is_online(monkeypatch):
     def mock_get(_self, path, *args, **kwargs):
-        assert 'api.ionq.co/backends' == path
+        assert 'https://api.ionq.co/v0.2/backends' == path
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value=[
@@ -89,7 +88,7 @@ def test_is_online(monkeypatch):
 
 def test_show_devices(monkeypatch):
     def mock_get(_self, path, *args, **kwargs):
-        assert 'api.ionq.co/v0.2/backends' == path
+        assert 'https://api.ionq.co/v0.2/backends' == path
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value=[

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -30,8 +30,6 @@ def no_requests(monkeypatch):
     monkeypatch.delattr('requests.sessions.Session.request')
 
 
-_api_url = 'https://api.ionq.co/v0.1/jobs/'
-
 
 def test_authenticate():
     ionq_session = _ionq_http_client.IonQ()
@@ -55,7 +53,7 @@ def test_authenticate_prompt_requires_token(monkeypatch):
 
 def test_is_online(monkeypatch):
     def mock_get(_self, path, *args, **kwargs):
-        assert urljoin(_api_url, 'backends') == path
+        assert 'api.ionq.co/backends' == path
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value=[
@@ -91,7 +89,7 @@ def test_is_online(monkeypatch):
 
 def test_show_devices(monkeypatch):
     def mock_get(_self, path, *args, **kwargs):
-        assert urljoin(_api_url, 'backends') == path
+        assert 'api.ionq.co/v0.2/backends' == path
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value=[
@@ -187,7 +185,7 @@ def test_send_real_device_online_verbose(monkeypatch):
     }
 
     def mock_post(_self, path, *args, **kwargs):
-        assert path == _api_url[:-1]
+        assert path == 'https://api.ionq.co/v0.2/jobs'
         assert 'json' in kwargs
         assert expected_request == kwargs['json']
         mock_response = mock.MagicMock()
@@ -201,7 +199,7 @@ def test_send_real_device_online_verbose(monkeypatch):
         return mock_response
 
     def mock_get(_self, path, *args, **kwargs):
-        assert urljoin(_api_url, 'new-job-id') == path
+        assert path == 'https://api.ionq.co/v0.2/jobs/new-job-id'
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value={
@@ -433,7 +431,7 @@ def test_send_api_errors_are_raised(monkeypatch, expected_err, err_data):
     )
 
     def mock_post(_self, path, **kwargs):
-        assert _api_url[:-1] == path
+        assert path == 'https://api.ionq.co/v0.2/jobs'
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(return_value=err_data)
         return mock_response
@@ -472,7 +470,7 @@ def test_timeout_exception(monkeypatch):
     )
 
     def mock_post(_self, path, *args, **kwargs):
-        assert path == _api_url[:-1]
+        assert path == 'https://api.ionq.co/v0.2/jobs'
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value={
@@ -483,7 +481,7 @@ def test_timeout_exception(monkeypatch):
         return mock_response
 
     def mock_get(_self, path, *args, **kwargs):
-        assert urljoin(_api_url, 'new-job-id') == path
+        assert path == 'https://api.ionq.co/v0.2/jobs/new-job-id'
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value={
@@ -533,7 +531,7 @@ def test_retrieve(monkeypatch, token):
     request_num = [0]
 
     def mock_get(_self, path, *args, **kwargs):
-        assert urljoin(_api_url, 'old-job-id') == path
+        assert path == 'https://api.ionq.co/v0.2/jobs/old-job-id'
         json_response = {
             'id': 'old-job-id',
             'status': 'running',
@@ -591,7 +589,7 @@ def test_retrieve_that_errors_are_caught(monkeypatch):
     request_num = [0]
 
     def mock_get(_self, path, *args, **kwargs):
-        assert urljoin(_api_url, 'old-job-id') == path
+        assert path == 'https://api.ionq.co/v0.2/jobs/old-job-id'
         json_response = {
             'id': 'old-job-id',
             'status': 'running',


### PR DESCRIPTION
The previous path was mistakenly incorrect, could we release this as a patch release of project-Q? The previous path 'v0.1/jobs/backends' was mistformatted on a deprecated API.
Happy to help how I can.