### PR TITLE
Context Manager: with flushing(MainEngine()) as eng:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [vNext] - 2022-mm-dd
+## [Unreleased]
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [vNext] - 2022-mm-dd
+
+### Added
+
+-   Python context manager `with flusing(MainEngine()) as eng:`
+
 ## [v0.8.0] - 2022-10-18
 
 ### Added

--- a/projectq/cengines/__init__.py
+++ b/projectq/cengines/__init__.py
@@ -14,6 +14,8 @@
 
 """ProjectQ module containing all compiler engines."""
 
+from contextlib import contextmanager
+
 from ._basics import BasicEngine, ForwarderEngine, LastEngineException  # isort:skip
 from ._cmdmodifier import CommandModifier  # isort:skip
 from ._basicmapper import BasicMapperEngine  # isort:skip
@@ -33,3 +35,11 @@ from ._swapandcnotflipper import SwapAndCNOTFlipper
 from ._tagremover import TagRemover
 from ._testengine import CompareEngine, DummyEngine
 from ._twodmapper import GridMapper
+
+
+@contextmanager
+def flushing(thing):
+    try:
+        yield thing
+    finally:
+        thing.flush()

--- a/projectq/cengines/__init__.py
+++ b/projectq/cengines/__init__.py
@@ -38,8 +38,19 @@ from ._twodmapper import GridMapper
 
 
 @contextmanager
-def flushing(thing):
+def flushing(engine):
+    """
+    Context manager to flush the given engine at the end of the 'with' context block.
+
+    Example:
+        with flushing(MainEngine()) as eng:
+            qubit = eng.allocate_qubit()
+            ...
+    
+    Calling 'eng.flush()' is no longer needed because the engine will be flushed at the
+    end of the 'with' block even if an exception has been raised within that block.
+    """
     try:
-        yield thing
+        yield engine
     finally:
-        thing.flush()
+        engine.flush()

--- a/projectq/cengines/__init__.py
+++ b/projectq/cengines/__init__.py
@@ -16,6 +16,12 @@
 
 from contextlib import contextmanager
 
+from ._basicmapper import BasicMapperEngine
+from ._basics import BasicEngine, ForwarderEngine, LastEngineException
+from ._cmdmodifier import CommandModifier
+
+# isort: split
+
 from ._ibm5qubitmapper import IBM5QubitMapper
 from ._linearmapper import LinearMapper, return_swap_depth
 from ._main import MainEngine, NotYetMeasuredError, UnsupportedEngineError
@@ -31,10 +37,6 @@ from ._swapandcnotflipper import SwapAndCNOTFlipper
 from ._tagremover import TagRemover
 from ._testengine import CompareEngine, DummyEngine
 from ._twodmapper import GridMapper
-
-from ._basics import BasicEngine, ForwarderEngine, LastEngineException  # isort:skip
-from ._cmdmodifier import CommandModifier  # isort:skip
-from ._basicmapper import BasicMapperEngine  # isort:skip
 
 
 @contextmanager

--- a/projectq/cengines/__init__.py
+++ b/projectq/cengines/__init__.py
@@ -16,10 +16,6 @@
 
 from contextlib import contextmanager
 
-from ._basics import BasicEngine, ForwarderEngine, LastEngineException  # isort:skip
-from ._cmdmodifier import CommandModifier  # isort:skip
-from ._basicmapper import BasicMapperEngine  # isort:skip
-
 from ._ibm5qubitmapper import IBM5QubitMapper
 from ._linearmapper import LinearMapper, return_swap_depth
 from ._main import MainEngine, NotYetMeasuredError, UnsupportedEngineError
@@ -36,6 +32,10 @@ from ._tagremover import TagRemover
 from ._testengine import CompareEngine, DummyEngine
 from ._twodmapper import GridMapper
 
+from ._basics import BasicEngine, ForwarderEngine, LastEngineException  # isort:skip
+from ._cmdmodifier import CommandModifier  # isort:skip
+from ._basicmapper import BasicMapperEngine  # isort:skip
+
 
 @contextmanager
 def flushing(engine):
@@ -46,7 +46,7 @@ def flushing(engine):
         with flushing(MainEngine()) as eng:
             qubit = eng.allocate_qubit()
             ...
-    
+
     Calling 'eng.flush()' is no longer needed because the engine will be flushed at the
     end of the 'with' block even if an exception has been raised within that block.
     """

--- a/projectq/cengines/__init__.py
+++ b/projectq/cengines/__init__.py
@@ -16,9 +16,9 @@
 
 from contextlib import contextmanager
 
-from ._basicmapper import BasicMapperEngine
-from ._basics import BasicEngine, ForwarderEngine, LastEngineException
-from ._cmdmodifier import CommandModifier
+from ._basics import BasicEngine, ForwarderEngine, LastEngineException  # isort:skip
+from ._cmdmodifier import CommandModifier  # isort:skip
+from ._basicmapper import BasicMapperEngine  # isort:skip
 
 # isort: split
 

--- a/projectq/cengines/_withflushing_test.py
+++ b/projectq/cengines/_withflushing_test.py
@@ -1,0 +1,38 @@
+#   Copyright 2017 ProjectQ-Framework (www.projectq.ch)
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for projectq.cengines.__init__.py."""
+
+from unittest.mock import MagicMock
+
+from projectq.cengines import DummyEngine, flushing
+
+
+def test_with_flushing():
+    """Test with flushing() as eng:"""
+    with flushing(DummyEngine()) as engine:
+        engine.flush = MagicMock()
+        assert engine.flush.call_count == 0
+    assert engine.flush.call_count == 1
+
+
+def test_with_flushing_with_exception():
+    """Test with flushing() as eng: with an exception raised in the 'with' block."""
+    try:
+        with flushing(DummyEngine()) as engine:
+            engine.flush = MagicMock()
+            assert engine.flush.call_count == 0
+            raise ValueError("An exception is raised in the 'with' block")
+    except ValueError:
+        pass
+    assert engine.flush.call_count == 1


### PR DESCRIPTION
Simplify the creation, use, and flushing of any Engine using a Python context manager.

When exiting the `with` block, the engine is _automatically_ flushed.

Just like auto-closing of files:
```
with open("my_file.txt") as in_file:
    print(in_file.read())
 ```
Modeled after https://docs.python.org/3/library/contextlib.html#contextlib.closing
```python
from projectq import MainEngine, flushing  # import the main compiler engine
from projectq.ops import (
    H,
    Measure,
)  # import the operations we want to perform (Hadamard and measurement)

with flushing(MainEngine()) as eng:  # create a default compiler (the back-end is a simulator)
    qubit = eng.allocate_qubit()  # allocate a quantum register with 1 qubit

    H | qubit  # apply a Hadamard gate
    Measure | qubit  # measure the qubit

    # This line is no longer required... eng.flush()

print(f"Measured {int(qubit)}")  # converting a qubit to int or bool gives access to the measurement result