### PR TITLE
Open v0.3 API + debiasing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fixed some typos (thanks to @eltociear, @Darkdragon84)
 
+### Changed
+
+-   Update ProjectQ to handle IonQ API v0.3
+
 ### Repository
 
 -   Update GitHub workflows to work with merge queues

--- a/projectq/backends/_ionq/_ionq.py
+++ b/projectq/backends/_ionq/_ionq.py
@@ -78,6 +78,8 @@ class IonQBackend(BasicEngine):  # pylint: disable=too-many-instance-attributes
         verbose=False,
         token=None,
         device='ionq_simulator',
+        error_mitigation=None,
+        sharpen=None,
         num_retries=3000,
         interval=1,
         retrieve_execution=None,
@@ -102,6 +104,8 @@ class IonQBackend(BasicEngine):  # pylint: disable=too-many-instance-attributes
         """
         super().__init__()
         self.device = device if use_hardware else 'ionq_simulator'
+        self.error_mitigation = error_mitigation
+        self._sharpen = sharpen
         self._num_runs = num_runs
         self._verbose = verbose
         self._token = token
@@ -291,6 +295,9 @@ class IonQBackend(BasicEngine):  # pylint: disable=too-many-instance-attributes
             measured_ids = self._measured_ids[:]
             info = {
                 'circuit': self._circuit,
+                'gateset': 'qis',
+                'format': 'ionq.circuit.v0',
+                'error_mitigation': self.error_mitigation,
                 'nq': len(qubit_mapping.keys()),
                 'shots': self._num_runs,
                 'meas_mapped': [qubit_mapping[qubit_id] for qubit_id in measured_ids],
@@ -311,6 +318,7 @@ class IonQBackend(BasicEngine):  # pylint: disable=too-many-instance-attributes
                 device=self.device,
                 token=self._token,
                 jobid=self._retrieve_execution,
+                sharpen=self._sharpen,
                 num_retries=self._num_retries,
                 interval=self._interval,
                 verbose=self._verbose,

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -137,21 +137,21 @@ class IonQ(Session):
             str: The ID of a newly submitted Job.
         """
         argument = {
-            'target': self.backends[device]['target'],
+            'target': self.backends[device].get('target'),
             'metadata': {
                 'sdk': 'ProjectQ',
-                'meas_qubit_ids': json.dumps(info['meas_qubit_ids']),
+                'meas_qubit_ids': json.dumps(info.get('meas_qubit_ids')),
             },
-            'shots': info['shots'],
-            'registers': {'meas_mapped': info['meas_mapped']},
+            'shots': info.get('shots'),
+            'registers': {'meas_mapped': info.get('meas_mapped')},
             'input': {
-                'format': info['format'],
-                'gateset': info['gateset'],
-                'qubits': info['nq'],
-                'circuit': info['circuit'],
+                'format': info.get('format'),
+                'gateset': info.get('gateset'),
+                'qubits': info.get('nq'),
+                'circuit': info.get('circuit'),
             },
         }
-        if info['error_mitigation'] is not None:
+        if info.get('error_mitigation') is not None:
             argument['error_mitigation'] = info['error_mitigation']
 
         # _API_URL[:-1] strips the trailing slash.
@@ -161,11 +161,11 @@ class IonQ(Session):
 
         # Process the response.
         r_json = req.json()
-        status = r_json['status']
+        status = r_json.get('status')
 
         # Return the job id.
         if status == 'ready':
-            return r_json['id']
+            return r_json.get('id')
 
         # Otherwise, extract any provided failure info and raise an exception.
         failure = r_json.get('failure') or {
@@ -226,7 +226,7 @@ class IonQ(Session):
 
                 # Check if job is completed.
                 if status == 'completed':
-                    r = super().get(urljoin(_JOB_API_URL, req_json['results_url']), params=params)
+                    r = super().get(urljoin(_JOB_API_URL, req_json.get('results_url')), params=params)
                     r_json = r.json()
                     meas_mapped = req_json['registers']['meas_mapped']
                     meas_qubit_ids = json.loads(req_json['metadata']['meas_qubit_ids'])

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -104,7 +104,7 @@ class IonQ(Session):
 
     def user_agent(self):
         """Set a User-Agent header for this session."""
-        self.headers.update({'User-Agent': f'projectq-ionq/0.8.0'})
+        self.headers.update({'User-Agent': 'projectq-ionq/0.8.0'})
 
     def authenticate(self, token=None):
         """Set an Authorization header for this session.
@@ -174,7 +174,13 @@ class IonQ(Session):
         }
         raise JobSubmissionError(f"{failure['code']}: {failure['error']} (status={status})")
 
-    def get_result(self, device, execution_id, sharpen=None, num_retries=3000, interval=1):
+    def get_result(
+        self, 
+        device, 
+        execution_id, 
+        sharpen=None, 
+        num_retries=3000, 
+        interval=1):  # pylint: disable=too-many-arguments,too-many-locals
         """
         Given a backend and ID, fetch the results for this job's execution.
 
@@ -226,8 +232,8 @@ class IonQ(Session):
 
                 # Check if job is completed.
                 if status == 'completed':
-                    r = super().get(urljoin(_JOB_API_URL, req_json.get('results_url')), params=params)
-                    r_json = r.json()
+                    r_get = super().get(urljoin(_JOB_API_URL, req_json.get('results_url')), params=params)
+                    re_json = r_get.json()
                     meas_mapped = req_json['registers']['meas_mapped']
                     meas_qubit_ids = json.loads(req_json['metadata']['meas_qubit_ids'])
                     output_probs = r_json

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -40,6 +40,7 @@ class IonQ(Session):
     def __init__(self, verbose=False):
         """Initialize an session with IonQ's APIs."""
         super().__init__()
+        self.user_agent()
         self.backends = {}
         self.timeout = 5.0
         self.token = None
@@ -100,6 +101,10 @@ class IonQ(Session):
         nb_qubit_max = self.backends[device]['nq']
         nb_qubit_needed = info['nq']
         return nb_qubit_needed <= nb_qubit_max, nb_qubit_max, nb_qubit_needed
+
+    def user_agent(self):
+        """Set a User-Agent header for this session."""
+        self.headers.update({'User-Agent': f'projectq-ionq/0.8.0'})
 
     def authenticate(self, token=None):
         """Set an Authorization header for this session.

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -175,12 +175,8 @@ class IonQ(Session):
         raise JobSubmissionError(f"{failure['code']}: {failure['error']} (status={status})")
 
     def get_result(
-        self, 
-        device, 
-        execution_id, 
-        sharpen=None, 
-        num_retries=3000, 
-        interval=1):  # pylint: disable=too-many-arguments,too-many-locals
+        self, device, execution_id, sharpen=None, num_retries=3000, interval=1
+    ):  # pylint: disable=too-many-arguments,too-many-locals
         """
         Given a backend and ID, fetch the results for this job's execution.
 

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -30,7 +30,7 @@ from .._exceptions import (
     RequestTimeoutError,
 )
 
-_API_URL = 'https://api.ionq.co/v0.2/'
+_API_URL = 'https://api.ionq.co/v0.3/'
 _JOB_API_URL = urljoin(_API_URL, 'jobs/')
 
 
@@ -59,7 +59,7 @@ class IonQ(Session):
             },
             'ionq_qpu': {
                 'nq': 11,
-                'target': 'qpu',
+                'target': 'qpu.harmony',
             },
         }
         for backend in r_json:
@@ -139,12 +139,15 @@ class IonQ(Session):
             },
             'shots': info['shots'],
             'registers': {'meas_mapped': info['meas_mapped']},
-            'lang': 'json',
-            'body': {
+            'input': {
+                'format': info['format'],
+                'gateset': info['gateset'],
                 'qubits': info['nq'],
                 'circuit': info['circuit'],
             },
         }
+        if info['error_mitigation'] is not None:
+            argument['error_mitigation'] = info['error_mitigation']
 
         # _API_URL[:-1] strips the trailing slash.
         # TODO: Add comprehensive error parsing for non-200 responses.
@@ -166,7 +169,7 @@ class IonQ(Session):
         }
         raise JobSubmissionError(f"{failure['code']}: {failure['error']} (status={status})")
 
-    def get_result(self, device, execution_id, num_retries=3000, interval=1):
+    def get_result(self, device, execution_id, sharpen=None, num_retries=3000, interval=1):
         """
         Given a backend and ID, fetch the results for this job's execution.
 
@@ -178,6 +181,8 @@ class IonQ(Session):
         Args:
             device (str): The device used to run this job.
             execution_id (str): An IonQ Job ID.
+            sharpen: A boolean that determines how to aggregate error mitigated.
+                If True, apply majority vote mitigation; if False, apply average mitigation.
             num_retries (int, optional): Number of times to retry the fetch
                 before raising a timeout error. Defaults to 3000.
             interval (int, optional): Number of seconds to wait between retries.
@@ -196,6 +201,10 @@ class IonQ(Session):
         if self._verbose:  # pragma: no cover
             print(f"Waiting for results. [Job ID: {execution_id}]")
 
+        params = {}
+        if sharpen is not None:
+            params["sharpen"] = sharpen
+
         original_sigint_handler = signal.getsignal(signal.SIGINT)
 
         def _handle_sigint_during_get_result(*_):  # pragma: no cover
@@ -205,18 +214,20 @@ class IonQ(Session):
 
         try:
             for retries in range(num_retries):
-                req = super().get(urljoin(_JOB_API_URL, execution_id))
+                req = super().get(urljoin(_JOB_API_URL, execution_id), params=params)
                 req.raise_for_status()
-                r_json = req.json()
-                status = r_json['status']
+                req_json = req.json()
+                status = req_json['status']
 
                 # Check if job is completed.
                 if status == 'completed':
-                    meas_mapped = r_json['registers']['meas_mapped']
-                    meas_qubit_ids = json.loads(r_json['metadata']['meas_qubit_ids'])
-                    output_probs = r_json['data']['registers']['meas_mapped']
+                    r = super().get(urljoin(_JOB_API_URL, req_json['results_url']), params=params)
+                    r_json = r.json()
+                    meas_mapped = req_json['registers']['meas_mapped']
+                    meas_qubit_ids = json.loads(req_json['metadata']['meas_qubit_ids'])
+                    output_probs = r_json
                     return {
-                        'nq': r_json['qubits'],
+                        'nq': req_json['qubits'],
                         'output_probs': output_probs,
                         'meas_mapped': meas_mapped,
                         'meas_qubit_ids': meas_qubit_ids,
@@ -255,6 +266,7 @@ def retrieve(
     device,
     token,
     jobid,
+    sharpen=None,
     num_retries=3000,
     interval=1,
     verbose=False,
@@ -281,6 +293,7 @@ def retrieve(
     res = ionq_session.get_result(
         device,
         jobid,
+        sharpen=sharpen,
         num_retries=num_retries,
         interval=interval,
     )

--- a/projectq/backends/_ionq/_ionq_http_client.py
+++ b/projectq/backends/_ionq/_ionq_http_client.py
@@ -229,7 +229,7 @@ class IonQ(Session):
                 # Check if job is completed.
                 if status == 'completed':
                     r_get = super().get(urljoin(_JOB_API_URL, req_json.get('results_url')), params=params)
-                    re_json = r_get.json()
+                    r_json = r_get.json()
                     meas_mapped = req_json['registers']['meas_mapped']
                     meas_qubit_ids = json.loads(req_json['metadata']['meas_qubit_ids'])
                     output_probs = r_json

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -196,7 +196,6 @@ def test_send_real_device_online_verbose(monkeypatch):
         )
         return mock_response
 
-
     def mock_get(_self, path, *args, **kwargs):
         if path == 'https://api.ionq.co/v0.3/jobs/new-job-id':
             mock_response = mock.MagicMock()

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -546,9 +546,9 @@ def test_retrieve(monkeypatch, token):
                 'results_url': 'old-job-id/results',
             }
         elif path == 'https://api.ionq.co/v0.3/jobs/old-job-id/results':
-            json_response = {
+            json_response = '''{
                 '2': 1,
-            }
+            }'''
         else:
             raise ValueError(f"Unexpected URL: {path}")
 

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -197,29 +197,29 @@ def test_send_real_device_online_verbose(monkeypatch):
         return mock_response
 
 
-def mock_get(_self, path, *args, **kwargs):
-    if path == 'https://api.ionq.co/v0.3/jobs/new-job-id':
-        mock_response = mock.MagicMock()
-        mock_response.json = mock.MagicMock(
-            return_value={
-                'id': 'new-job-id',
-                'status': 'completed',
-                'qubits': 4,
-                'metadata': {'meas_qubit_ids': '[2, 3]'},
-                'registers': {'meas_mapped': [2, 3]},
-                'results_url': 'new-job-id/results',
-            }
-        )
-    elif path == 'https://api.ionq.co/v0.3/jobs/new-job-id/results':
-        mock_response = mock.MagicMock()
-        mock_response.json = mock.MagicMock(
-            return_value={
-                {'2': 1},
-            }
-        )
-    else:
-        raise ValueError(f"Unexpected URL: {path}")
-    return mock_response
+    def mock_get(_self, path, *args, **kwargs):
+        if path == 'https://api.ionq.co/v0.3/jobs/new-job-id':
+            mock_response = mock.MagicMock()
+            mock_response.json = mock.MagicMock(
+                return_value={
+                    'id': 'new-job-id',
+                    'status': 'completed',
+                    'qubits': 4,
+                    'metadata': {'meas_qubit_ids': '[2, 3]'},
+                    'registers': {'meas_mapped': [2, 3]},
+                    'results_url': 'new-job-id/results',
+                }
+            )
+        elif path == 'https://api.ionq.co/v0.3/jobs/new-job-id/results':
+            mock_response = mock.MagicMock()
+            mock_response.json = mock.MagicMock(
+                return_value={
+                    {'2': 1},
+                }
+            )
+        else:
+            raise ValueError(f"Unexpected URL: {path}")
+        return mock_response
 
     monkeypatch.setattr('requests.sessions.Session.post', mock_post)
     monkeypatch.setattr('requests.sessions.Session.get', mock_get)
@@ -534,7 +534,7 @@ def test_retrieve(monkeypatch, token):
         'update_devices_list',
         _dummy_update.__get__(None, _ionq_http_client.IonQ),
     )
-    request_num = [0]
+    # request_num = [0]
 
     def mock_get(_self, path, *args, **kwargs):
         if path == 'https://api.ionq.co/v0.3/jobs/old-job-id':

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -212,9 +212,7 @@ def test_send_real_device_online_verbose(monkeypatch):
         elif path == 'https://api.ionq.co/v0.3/jobs/new-job-id/results':
             mock_response = mock.MagicMock()
             mock_response.json = mock.MagicMock(
-                return_value={
-                    {'2': 1},
-                }
+                return_value={'2': 1},
             )
         else:
             raise ValueError(f"Unexpected URL: {path}")
@@ -546,9 +544,7 @@ def test_retrieve(monkeypatch, token):
                 'results_url': 'old-job-id/results',
             }
         elif path == 'https://api.ionq.co/v0.3/jobs/old-job-id/results':
-            json_response = '''{
-                '2': 1,
-            }'''
+            json_response = {'2': 1}
         else:
             raise ValueError(f"Unexpected URL: {path}")
 

--- a/projectq/backends/_ionq/_ionq_http_client_test.py
+++ b/projectq/backends/_ionq/_ionq_http_client_test.py
@@ -50,7 +50,7 @@ def test_authenticate_prompt_requires_token(monkeypatch):
 
 def test_is_online(monkeypatch):
     def mock_get(_self, path, *args, **kwargs):
-        assert 'https://api.ionq.co/v0.2/backends' == path
+        assert 'https://api.ionq.co/v0.3/backends' == path
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value=[
@@ -86,7 +86,7 @@ def test_is_online(monkeypatch):
 
 def test_show_devices(monkeypatch):
     def mock_get(_self, path, *args, **kwargs):
-        assert 'https://api.ionq.co/v0.2/backends' == path
+        assert 'https://api.ionq.co/v0.3/backends' == path
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value=[
@@ -182,7 +182,7 @@ def test_send_real_device_online_verbose(monkeypatch):
     }
 
     def mock_post(_self, path, *args, **kwargs):
-        assert path == 'https://api.ionq.co/v0.2/jobs'
+        assert path == 'https://api.ionq.co/v0.3/jobs'
         assert 'json' in kwargs
         assert expected_request == kwargs['json']
         mock_response = mock.MagicMock()
@@ -196,7 +196,7 @@ def test_send_real_device_online_verbose(monkeypatch):
         return mock_response
 
     def mock_get(_self, path, *args, **kwargs):
-        assert path == 'https://api.ionq.co/v0.2/jobs/new-job-id'
+        assert path == 'https://api.ionq.co/v0.3/jobs/new-job-id'
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value={
@@ -428,7 +428,7 @@ def test_send_api_errors_are_raised(monkeypatch, expected_err, err_data):
     )
 
     def mock_post(_self, path, **kwargs):
-        assert path == 'https://api.ionq.co/v0.2/jobs'
+        assert path == 'https://api.ionq.co/v0.3/jobs'
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(return_value=err_data)
         return mock_response
@@ -467,7 +467,7 @@ def test_timeout_exception(monkeypatch):
     )
 
     def mock_post(_self, path, *args, **kwargs):
-        assert path == 'https://api.ionq.co/v0.2/jobs'
+        assert path == 'https://api.ionq.co/v0.3/jobs'
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value={
@@ -478,7 +478,7 @@ def test_timeout_exception(monkeypatch):
         return mock_response
 
     def mock_get(_self, path, *args, **kwargs):
-        assert path == 'https://api.ionq.co/v0.2/jobs/new-job-id'
+        assert path == 'https://api.ionq.co/v0.3/jobs/new-job-id'
         mock_response = mock.MagicMock()
         mock_response.json = mock.MagicMock(
             return_value={
@@ -528,7 +528,7 @@ def test_retrieve(monkeypatch, token):
     request_num = [0]
 
     def mock_get(_self, path, *args, **kwargs):
-        assert path == 'https://api.ionq.co/v0.2/jobs/old-job-id'
+        assert path == 'https://api.ionq.co/v0.3/jobs/old-job-id'
         json_response = {
             'id': 'old-job-id',
             'status': 'running',
@@ -586,7 +586,7 @@ def test_retrieve_that_errors_are_caught(monkeypatch):
     request_num = [0]
 
     def mock_get(_self, path, *args, **kwargs):
-        assert path == 'https://api.ionq.co/v0.2/jobs/old-job-id'
+        assert path == 'https://api.ionq.co/v0.3/jobs/old-job-id'
         json_response = {
             'id': 'old-job-id',
             'status': 'running',

--- a/projectq/backends/_ionq/_ionq_test.py
+++ b/projectq/backends/_ionq/_ionq_test.py
@@ -393,12 +393,16 @@ def test_ionq_retrieve_nonetype_response_error(monkeypatch, mapper_factory):
 
 
 def test_ionq_backend_functional_test(monkeypatch, mapper_factory):
-    """Test that the backend can handle a valid circuit with valid results."""
+    """Test that sub-classed or aliased gates are handled correctly."""
+    # using alias gates, for coverage
     expected = {
         'nq': 3,
         'shots': 10,
         'meas_mapped': [1, 2],
         'meas_qubit_ids': [1, 2],
+        'error_mitigation': None,
+        'format': 'ionq.circuit.v0',
+        'gateset': 'qis',
         'circuit': [
             {'gate': 'ry', 'rotation': 0.5, 'targets': [1]},
             {'gate': 'rx', 'rotation': 0.5, 'targets': [1]},
@@ -425,7 +429,7 @@ def test_ionq_backend_functional_test(monkeypatch, mapper_factory):
     backend = _ionq.IonQBackend(verbose=True, num_runs=10)
     eng = MainEngine(
         backend=backend,
-        engine_list=[mapper_factory()],
+        engine_list=[mapper_factory(9)],
         verbose=True,
     )
     unused_qubit = eng.allocate_qubit()  # noqa: F841
@@ -458,6 +462,9 @@ def test_ionq_backend_functional_aliases_test(monkeypatch, mapper_factory):
         'shots': 10,
         'meas_mapped': [2, 3],
         'meas_qubit_ids': [2, 3],
+        'error_mitigation': None,
+        'format': 'ionq.circuit.v0',
+        'gateset': 'qis',
         'circuit': [
             {'gate': 'x', 'targets': [0]},
             {'gate': 'x', 'targets': [1]},


### PR DESCRIPTION
This new version of the API separates job status and metadata from actual results into two different endpoints.

v0.3 also includes support for error_mitigation settings like symmetrization as described in https://arxiv.org/pdf/2301.07233.pdf

This includes:

* add a new error_mitigation parameter on job submission so users can configure it
* add a new aggregation parameter on results that would allow getting results aggregated under the two different methods described in the paper