### PR TITLE
Handle case in _configure_openmp() for MacOS system without Homebrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Fixed some typos (thanks to @eltociear, @Darkdragon84)
 -   Fixed support for Python 3.12
+-   Fixed check for OpenMP so it works on MacOS systems without Homebrew
 
 ### Removed
 

--- a/setup.py
+++ b/setup.py
@@ -505,7 +505,7 @@ class BuildExt(build_ext):
                         self.opts.append(flag)
                         self.link_opts.extend((l_arg, flag))
                         return
-            except subprocess.CalledProcessError:
+            except (subprocess.CalledProcessError, OSError):
                 pass
 
             try:


### PR DESCRIPTION
On a MacOS system that's not using Homebrew, running `brew --prefix llvm` with `subprocess.check_output` doesn't produce a CalledProcessError; instead, when the shell produces a FileNotFoundError it passes it back and `check_output` raises that instead.

If we check for OSError (the parent of FileNotFoundError, which should handle other OS-related errors that could get passed back) as well, then this should correctly handle this case.

The MacPorts check doesn't have the same issue, because the `which` command is built in and so `which port` will raise a CalledProcessError if MacPorts isn't installed.